### PR TITLE
feat: add Discord document loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ Homepage = "https://github.com/SynapseKit/SynapseKit"
 Repository = "https://github.com/SynapseKit/SynapseKit"
 
 [project.optional-dependencies]
+discord = ["discord.py>=2.0"]
 openai = ["openai>=1.0"]
 anthropic = ["anthropic>=0.25"]
 semantic = ["sentence-transformers>=2.7"]
@@ -63,6 +64,7 @@ all = [
     "google-generativeai>=0.7",
     "boto3>=1.34",
     "duckduckgo-search>=6.0",
+    "discord.py>=2.0",
 ]
 
 [dependency-groups]

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -4,6 +4,7 @@ from .text import StringLoader, TextLoader
 __all__ = [
     "CSVLoader",
     "DirectoryLoader",
+    "DiscordLoader",
     "Document",
     "HTMLLoader",
     "JSONLoader",
@@ -19,6 +20,7 @@ _LOADERS = {
     "CSVLoader": ".csv",
     "JSONLoader": ".json_loader",
     "DirectoryLoader": ".directory",
+    "DiscordLoader": ".discord",
     "WebLoader": ".web",
 }
 

--- a/src/synapsekit/loaders/discord.py
+++ b/src/synapsekit/loaders/discord.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from .base import Document
+
+class DiscordLoader:
+    """Load messages from a Discord channel.
+    
+    Requires 'discord.py' package.
+    """
+
+    def __init__(self, bot_token: str, channel_id: int | str):
+        self.bot_token = bot_token
+        self.channel_id = str(channel_id)
+
+    def load(self, limit: int = 100) -> list[Document]:
+        """
+        Sync: Load messages from Discord. 
+        """
+        import asyncio
+        # We need a fresh event loop if one isn't running
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            
+        return loop.run_until_complete(self.load_async(limit=limit))
+
+    async def load_async(self, limit: int = 100) -> list[Document]:
+        """Async: Load messages from Discord."""
+        try:
+            import discord
+        except ImportError:
+            raise ImportError(
+                "Discord loader requires 'discord.py' package. "
+                "Install it with: pip install discord.py"
+            )
+
+        intents = discord.Intents.default()
+        # We need message_content intent to read messages
+        intents.message_content = True
+        client = discord.Client(intents=intents)
+        documents = []
+
+        @client.event
+        async def on_ready():
+            try:
+                channel = client.get_channel(int(self.channel_id))
+                if not channel:
+                    try:
+                        channel = await client.fetch_channel(int(self.channel_id))
+                    except Exception:
+                        pass
+                
+                if not channel:
+                    print(f"Error: Could not find channel {self.channel_id}")
+                    return
+
+                # Check if it's a channel we can read
+                if hasattr(channel, 'history'):
+                    async for message in channel.history(limit=limit):
+                        if message.content:
+                            documents.append(Document(
+                                text=message.content,
+                                metadata={
+                                    "author": str(message.author),
+                                    "timestamp": message.created_at.isoformat(),
+                                    "channel_id": self.channel_id,
+                                    "message_id": str(message.id),
+                                    "attachments": [str(a.url) for a in message.attachments]
+                                }
+                            ))
+            finally:
+                await client.close()
+
+        try:
+            await client.start(self.bot_token)
+        except Exception as e:
+            # Ensure client is closed on error
+            if not client.is_closed():
+                await client.close()
+            raise e
+
+        return documents

--- a/tests/loaders/test_discord.py
+++ b/tests/loaders/test_discord.py
@@ -1,0 +1,13 @@
+import pytest
+from synapsekit.loaders.discord import DiscordLoader
+
+def test_discord_loader_init():
+    loader = DiscordLoader("token", "12345")
+    assert loader.bot_token == "token"
+    assert loader.channel_id == "12345"
+
+@pytest.mark.asyncio
+async def test_discord_loader_async_init():
+    loader = DiscordLoader("token", "12345")
+    assert loader.bot_token == "token"
+    assert loader.channel_id == "12345"


### PR DESCRIPTION
This PR adds a `DiscordLoader` to SynapseKit, allowing users to load messages from Discord channels and threads. 

Changes:
- Added `DiscordLoader` in `src/synapsekit/loaders/discord.py`.
- Added `discord.py` as an optional dependency in `pyproject.toml`.
- Exported `DiscordLoader` from `src/synapsekit/loaders/__init__.py`.
- Added basic unit tests.

Fixes #50