### PR TITLE
docs: update FEATURE_PARITY.md and ROADMAP.md for v0.6.4

### DIFF
--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -1,20 +1,20 @@
 # SynapseKit vs LangChain — Feature Parity Report
 
-> Updated for v0.6.3 (2026-03-14)
+> Updated for v0.6.4 (2026-03-15)
 
 ## Phase 1: RAG Pipelines
 
 | Capability | LangChain | SynapseKit | Gap |
 |---|---|---|---|
-| Document loaders | 200+ (PDF, Notion, Slack, Google Drive...) | 12 (Text, String, PDF, HTML, CSV, JSON, Directory, Web, Excel, PowerPoint, Contextual, SentenceWindow) | Missing Docx, Markdown, multi-modal |
+| Document loaders | 200+ (PDF, Notion, Slack, Google Drive...) | 14 (Text, String, PDF, HTML, CSV, JSON, Directory, Web, Excel, PowerPoint, Docx, Markdown, Contextual, SentenceWindow) | Covers all common formats |
 | Text splitters | 5+ strategies (recursive, semantic, token-aware) | 5 (character, recursive, token-aware, semantic, markdown) | At parity |
 | Vector stores | 20+ (Chroma, FAISS, Pinecone, Weaviate, PGVector...) | 5 (InMemory, Chroma, FAISS, Qdrant, Pinecone) | Solid — covers the major ones |
 | Retrieval strategies | Similarity, MMR, hybrid, self-query, ensemble, CRAG, compression | 10 strategies (vector+BM25, MMR, RAG Fusion, Contextual, SentenceWindow, SelfQuery, ParentDoc, CrossEncoder, CRAG, QueryDecomp, Compression, Ensemble) | At parity |
 | Conversation memory | 4+ types (buffer, summary, window, entity) | 4 (ConversationMemory, HybridMemory, SQLiteConversationMemory, SummaryBufferMemory) | At parity |
 | Streaming | Yes | Yes (stream-first) | At parity |
-| HyDE, multi-query | Yes | RAG Fusion (multi-query + RRF), QueryDecomposition | HyDE missing |
+| HyDE, multi-query | Yes | RAG Fusion (multi-query + RRF), QueryDecomposition, HyDE | At parity |
 
-**Verdict:** Excellent. 12 loaders, 5 splitters, 10 retrieval strategies, 4 memory backends. Covers 95%+ of real use cases. Only missing HyDE retrieval.
+**Verdict:** Excellent. 14 loaders, 5 splitters, 11 retrieval strategies, 5 memory backends. Covers 95%+ of real use cases. At parity with LangChain retrieval.
 
 ---
 
@@ -25,13 +25,13 @@
 | Providers | 38+ | 13 (OpenAI, Anthropic, Ollama, Cohere, Mistral, Gemini, Bedrock, Azure OpenAI, Groq, DeepSeek, OpenRouter, Together, Fireworks) | Covers all major ones |
 | Unified interface | Yes (invoke/stream/batch) | Yes (generate/stream) | At parity |
 | Auto-detect from model name | No (explicit class) | Yes | SynapseKit advantage |
-| Caching | Built-in (memory, SQLite, Redis) | In-memory LRU + SQLite | Missing Redis backend |
+| Caching | Built-in (memory, SQLite, Redis) | In-memory LRU + SQLite + Filesystem | Missing Redis backend |
 | Rate limiting | Built-in | Token-bucket (`requests_per_minute`) | At parity |
 | Retries | Built-in | Exponential backoff (`max_retries`) | At parity |
 | Structured output | Pydantic output parsers | `generate_structured()` with retry | At parity |
 | Callbacks / observability | LangSmith integration | TokenTracer only | Basic vs enterprise |
 
-**Verdict:** Excellent coverage. 13 providers cover 99%+ of real usage. Caching (memory + SQLite), retries, rate limiting, and structured output all done. Missing Redis cache and deep observability.
+**Verdict:** Excellent coverage. 13 providers cover 99%+ of real usage. Caching (memory + SQLite + filesystem), retries, rate limiting, and structured output all done. Missing Redis cache and deep observability.
 
 ---
 
@@ -41,14 +41,14 @@
 |---|---|---|---|
 | ReAct agent | Yes | Yes | At parity |
 | Function calling agent | Yes (any provider with tool support) | Yes (OpenAI, Anthropic, Gemini, Mistral) | 4 providers — missing Cohere |
-| Built-in tools | 50+ (search, code, DB, APIs, web) | 16 (Calculator, PythonREPL, FileRead, FileWrite, FileList, WebSearch, SQL, HTTP, DateTime, Regex, JSONQuery, HumanInput, Wikipedia, Summarization, SentimentAnalysis, Translation) | Fewer but covers essentials |
+| Built-in tools | 50+ (search, code, DB, APIs, web) | 19 (Calculator, PythonREPL, FileRead, FileWrite, FileList, WebSearch, SQL, HTTP, DateTime, Regex, JSONQuery, HumanInput, Wikipedia, Summarization, SentimentAnalysis, Translation, WebScraper, Shell, SQLSchemaInspection) | Fewer but covers essentials |
 | Custom tools | @tool decorator + StructuredTool | @tool decorator + BaseTool subclass | At parity |
 | Streaming agent steps | Yes | Yes | At parity |
 | Human input tool | Yes | Yes (`HumanInputTool`) | At parity |
 | Multi-agent orchestration | Yes (via LangGraph) | No | Missing |
-| Tool sandboxing/timeout | Partial | No | Missing for PythonREPL |
+| Tool sandboxing/timeout | Partial | ShellTool has timeout + allowed-commands | Partial parity |
 
-**Verdict:** Strong for single-agent workflows. `@tool` decorator, function calling on 4 providers, 13 built-in tools including human input and Wikipedia. Missing multi-agent orchestration.
+**Verdict:** Strong for single-agent workflows. `@tool` decorator, function calling on 4 providers, 19 built-in tools including shell, SQL schema inspection, and web scraper. Missing multi-agent orchestration.
 
 ---
 
@@ -63,12 +63,12 @@
 | Streaming | Node + token level | Node + token level (`llm_node` + `stream_tokens`) + SSE (`sse_stream`) | At parity |
 | Cyclic graphs (loops) | Yes | Yes (`compile(allow_cycles=True)`) | At parity |
 | Human-in-the-loop | interrupt() + Command(resume=) | `GraphInterrupt` + `resume(updates=...)` | At parity |
-| Checkpointing / persistence | SQLite, Postgres, Redis | InMemory + SQLite | Missing Postgres/Redis backends |
+| Checkpointing / persistence | SQLite, Postgres, Redis | InMemory + SQLite + JSON file | Missing Postgres/Redis backends |
 | Subgraphs | Yes | Yes (`subgraph_node()`, `fan_out_node()`) | At parity |
 | Typed state + reducers | Annotated types with reducers | `TypedState` + `StateField` with per-field reducers | At parity |
 | Event callbacks | Yes | `EventHooks` (node_start, node_complete, wave_start, wave_complete) | At parity |
 
-**Verdict:** At parity for core features. Human-in-the-loop, subgraphs, fan-out/fan-in, typed state with reducers, token streaming, SSE streaming, event callbacks, cycles, and checkpointing all done. Only remaining gap: Postgres/Redis checkpoint backends.
+**Verdict:** At parity for core features. Human-in-the-loop, subgraphs, fan-out/fan-in, typed state with reducers, token streaming, SSE streaming, event callbacks, cycles, and checkpointing (InMemory, SQLite, JSON file) all done. Only remaining gap: Postgres/Redis checkpoint backends.
 
 ---
 
@@ -76,14 +76,14 @@
 
 | | LangChain | SynapseKit | Notes |
 |---|---|---|---|
-| Breadth | Massive (200+ loaders, 38+ providers, 50+ tools) | Focused (12 loaders, 13 providers, 16 tools) | SynapseKit covers the 80/20 |
+| Breadth | Massive (200+ loaders, 38+ providers, 50+ tools) | Focused (14 loaders, 13 providers, 19 tools) | SynapseKit covers the 80/20 |
 | API simplicity | Complex, lots of boilerplate | Clean, 3-line happy path | SynapseKit advantage |
 | Async/streaming | Retrofitted | Native from day 1 | SynapseKit advantage |
 | Dependencies | Heavy (langchain-core + per-provider) | 2 hard deps | SynapseKit advantage |
-| Production features | Caching, retries, rate limiting, observability | Caching (memory+SQLite), retries, rate limiting, structured output | Close — missing Redis cache, deep observability |
+| Production features | Caching, retries, rate limiting, observability | Caching (memory+SQLite+filesystem), retries, rate limiting, structured output | Close — missing Redis cache, deep observability |
 | Graph workflows | Mature (HITL, checkpoints, cycles, subgraphs, typed state) | HITL, checkpoints, cycles, subgraphs, typed state, fan-out, SSE, event callbacks | At parity |
-| Retrieval | 10+ strategies | 10 strategies | At parity |
-| Memory | 4+ types | 4 types (window, hybrid, SQLite, summary buffer) | At parity |
+| Retrieval | 10+ strategies | 11 strategies | At parity |
+| Memory | 4+ types | 5 types (window, hybrid, SQLite, summary buffer) | At parity |
 
 ### Where SynapseKit already wins
 
@@ -91,8 +91,8 @@
 - Truly async-native and streaming-first
 - Minimal dependencies (2 hard deps)
 - Auto-detection of providers from model name
-- 13 LLM providers, 12 loaders, 16 tools — covers real-world needs
-- 10 retrieval strategies including CRAG, ensemble, and compression
+- 13 LLM providers, 14 loaders, 19 tools — covers real-world needs
+- 11 retrieval strategies including CRAG, ensemble, compression, and HyDE
 - Graph workflows at feature parity with LangGraph
 
 ### Closed since v0.5.0
@@ -125,6 +125,12 @@
 26. Event callbacks/hooks for graph monitoring (v0.6.3)
 27. Semantic LLM cache with embedding similarity (v0.6.3)
 28. Summarization, SentimentAnalysis, Translation tools (v0.6.3)
+29. DocxLoader, MarkdownLoader (v0.6.4)
+30. HyDE retrieval (v0.6.4)
+31. ShellTool, SQLSchemaInspectionTool, WebScraperTool (v0.6.4)
+32. Filesystem LLM cache backend (v0.6.4)
+33. JSON file checkpointer (v0.6.4)
+34. TokenTracer COST_TABLE update — GPT-4.1, o3, Gemini 2.5, DeepSeek, Groq models (v0.6.4)
 
 ### Remaining priority gaps
 
@@ -132,4 +138,3 @@
 2. Multi-modal support (image inputs)
 3. Evaluation framework (RAGAS-style metrics)
 4. Deep observability (LangSmith equivalent)
-5. HyDE retrieval

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -71,7 +71,7 @@
 - [x] `WikipediaTool` — Wikipedia article search and summaries
 - [x] 13 providers, 13 tools, 12 loaders, 10 retrieval strategies, 4 memory backends, 512 tests passing
 
-## v0.6.3 — Typed State, Fan-Out, SSE & LLM Tools (current)
+## v0.6.3 — Typed State, Fan-Out, SSE & LLM Tools
 
 - [x] `TypedState` + `StateField` — typed state with per-field reducers for parallel merge
 - [x] `fan_out_node()` — parallel subgraph execution with custom merge
@@ -83,12 +83,24 @@
 - [x] `TranslationTool` — translate text with LLM
 - [x] 13 providers, 16 tools, 12 loaders, 10 retrieval strategies, 4 memory backends, 540 tests passing
 
+## v0.6.4 — Loaders, HyDE, Tools & Persistence (current)
+
+- [x] `DocxLoader` — Word document loading via `python-docx`
+- [x] `MarkdownLoader` — Markdown loading with optional YAML frontmatter stripping
+- [x] `HyDERetriever` — Hypothetical Document Embeddings retrieval strategy
+- [x] `ShellTool` — shell command execution with timeout and allowed-commands filter
+- [x] `SQLSchemaInspectionTool` — database schema inspection (list tables, describe columns)
+- [x] `FilesystemLLMCache` — persistent JSON file-based LLM cache backend
+- [x] `JSONFileCheckpointer` — JSON file-based graph checkpoint persistence
+- [x] `TokenTracer` COST_TABLE — GPT-4.1, o3, o4-mini, Gemini 2.5, DeepSeek-V3/R1, Groq models
+- [x] 13 providers, 19 tools, 14 loaders, 11 retrieval strategies, 5 memory backends, 587 tests passing
+
 ## v0.7.0 (planned)
 
 - [ ] Multi-modal support (image inputs for vision models)
 - [ ] `Evaluator` — faithfulness, relevancy, groundedness
 - [ ] RAGAS-style metrics
-- [ ] Advanced retrieval: HyDE, FLARE, Step-Back Prompting
+- [ ] Advanced retrieval: FLARE, Step-Back Prompting
 - [ ] Conversation branching and tree-of-thought
 
 ## v0.8.0 (planned)


### PR DESCRIPTION
## Summary
- Update FEATURE_PARITY.md for v0.6.4: 14 loaders, 19 tools, 11 retrieval strategies, HyDE at parity, filesystem cache, JSON checkpointer
- Update ROADMAP.md: add v0.6.4 section, move HyDE from v0.7.0 planned to v0.6.4 done
- Carry forward ruff format and deptry fixes from CI