### PR TITLE
chore: add all-contributors config

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,20 @@
+{
+  "projectName": "SynapseKit",
+  "projectOwner": "SynapseKit",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": ["README.md"],
+  "imageSize": 100,
+  "commit": true,
+  "commitConvention": "none",
+  "contributors": [
+    {
+      "login": "AmitoVrito",
+      "name": "Nautiverse",
+      "avatar_url": "https://avatars.githubusercontent.com/u/34062684?v=4",
+      "profile": "https://github.com/AmitoVrito",
+      "contributions": ["code", "doc", "maintenance"]
+    }
+  ],
+  "contributorsPerLine": 7
+}


### PR DESCRIPTION
## Summary
- Add `.all-contributorsrc` for the All Contributors bot
- Auto-recognizes PR authors as contributors when the bot is installed