### PR TITLE
ci: add PyPI publish workflow on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,16 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv build
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that auto-publishes to PyPI when a release is created
- Uses PyPI trusted publishers (OIDC) — no API token needed