### PR TITLE
docs: update FEATURE_PARITY.md and ROADMAP.md for v0.6.6

### DIFF
--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -1,6 +1,6 @@
 # SynapseKit vs LangChain — Feature Parity Report
 
-> Updated for v0.6.5 (2026-03-15)
+> Updated for v0.6.6 (2026-03-16)
 
 ## Phase 1: RAG Pipelines
 
@@ -9,12 +9,12 @@
 | Document loaders | 200+ (PDF, Notion, Slack, Google Drive...) | 14 (Text, String, PDF, HTML, CSV, JSON, Directory, Web, Excel, PowerPoint, Docx, Markdown, Contextual, SentenceWindow) | Covers all common formats |
 | Text splitters | 5+ strategies (recursive, semantic, token-aware) | 5 (character, recursive, token-aware, semantic, markdown) | At parity |
 | Vector stores | 20+ (Chroma, FAISS, Pinecone, Weaviate, PGVector...) | 5 (InMemory, Chroma, FAISS, Qdrant, Pinecone) | Solid — covers the major ones |
-| Retrieval strategies | Similarity, MMR, hybrid, self-query, ensemble, CRAG, compression | 14 strategies (vector+BM25, MMR, RAG Fusion, Contextual, SentenceWindow, SelfQuery, ParentDoc, CrossEncoder, CRAG, QueryDecomp, Compression, Ensemble, CohereRerank, StepBack, FLARE, HyDE) | Exceeds LangChain |
-| Conversation memory | 4+ types (buffer, summary, window, entity) | 6 (ConversationMemory, HybridMemory, SQLiteConversationMemory, SummaryBufferMemory, TokenBufferMemory) | Exceeds LangChain |
+| Retrieval strategies | Similarity, MMR, hybrid, self-query, ensemble, CRAG, compression | 18 strategies (vector+BM25, MMR, RAG Fusion, Contextual, SentenceWindow, SelfQuery, ParentDoc, CrossEncoder, CRAG, QueryDecomp, Compression, Ensemble, CohereRerank, StepBack, FLARE, HyDE, HybridSearch, SelfRAG, AdaptiveRAG, MultiStep) | Exceeds LangChain |
+| Conversation memory | 4+ types (buffer, summary, window, entity) | 8 (ConversationMemory, HybridMemory, SQLiteConversationMemory, SummaryBufferMemory, TokenBufferMemory, BufferMemory, EntityMemory) | Exceeds LangChain |
 | Streaming | Yes | Yes (stream-first) | At parity |
 | HyDE, multi-query | Yes | RAG Fusion (multi-query + RRF), QueryDecomposition, HyDE | At parity |
 
-**Verdict:** Excellent. 14 loaders, 5 splitters, 14 retrieval strategies, 6 memory backends. Exceeds LangChain retrieval coverage with FLARE, Step-Back, and Cohere reranking.
+**Verdict:** Excellent. 14 loaders, 5 splitters, 18 retrieval strategies, 8 memory backends. Exceeds LangChain retrieval coverage with FLARE, Step-Back, Cohere reranking, Self-RAG, Adaptive RAG, and Multi-Step retrieval.
 
 ---
 
@@ -22,7 +22,7 @@
 
 | Capability | LangChain | SynapseKit | Gap |
 |---|---|---|---|
-| Providers | 38+ | 13 (OpenAI, Anthropic, Ollama, Cohere, Mistral, Gemini, Bedrock, Azure OpenAI, Groq, DeepSeek, OpenRouter, Together, Fireworks) | Covers all major ones |
+| Providers | 38+ | 15 (OpenAI, Anthropic, Ollama, Cohere, Mistral, Gemini, Bedrock, Azure OpenAI, Groq, DeepSeek, OpenRouter, Together, Fireworks, Perplexity, Cerebras) | Covers all major ones |
 | Unified interface | Yes (invoke/stream/batch) | Yes (generate/stream) | At parity |
 | Auto-detect from model name | No (explicit class) | Yes | SynapseKit advantage |
 | Caching | Built-in (memory, SQLite, Redis) | In-memory LRU + SQLite + Filesystem + Redis | At parity |
@@ -31,7 +31,7 @@
 | Structured output | Pydantic output parsers | `generate_structured()` with retry | At parity |
 | Callbacks / observability | LangSmith integration | TokenTracer only | Basic vs enterprise |
 
-**Verdict:** Excellent coverage. 13 providers cover 99%+ of real usage. Caching (memory + SQLite + filesystem + Redis), retries, rate limiting, and structured output all done. Only remaining gap: deep observability.
+**Verdict:** Excellent coverage. 15 providers cover 99%+ of real usage. Caching (memory + SQLite + filesystem + Redis), retries, rate limiting, and structured output all done. Only remaining gap: deep observability.
 
 ---
 
@@ -41,14 +41,14 @@
 |---|---|---|---|
 | ReAct agent | Yes | Yes | At parity |
 | Function calling agent | Yes (any provider with tool support) | Yes (OpenAI, Anthropic, Gemini, Mistral) | 4 providers — missing Cohere |
-| Built-in tools | 50+ (search, code, DB, APIs, web) | 22 (Calculator, PythonREPL, FileRead, FileWrite, FileList, WebSearch, DuckDuckGoSearch, SQL, HTTP, GraphQL, DateTime, Regex, JSONQuery, HumanInput, Wikipedia, Summarization, SentimentAnalysis, Translation, WebScraper, Shell, SQLSchemaInspection, PDFReader) | Fewer but covers essentials |
+| Built-in tools | 50+ (search, code, DB, APIs, web) | 24 (Calculator, PythonREPL, FileRead, FileWrite, FileList, WebSearch, DuckDuckGoSearch, SQL, HTTP, GraphQL, DateTime, Regex, JSONQuery, HumanInput, Wikipedia, Summarization, SentimentAnalysis, Translation, WebScraper, Shell, SQLSchemaInspection, PDFReader, ArxivSearch, TavilySearch) | Fewer but covers essentials |
 | Custom tools | @tool decorator + StructuredTool | @tool decorator + BaseTool subclass | At parity |
 | Streaming agent steps | Yes | Yes | At parity |
 | Human input tool | Yes | Yes (`HumanInputTool`) | At parity |
 | Multi-agent orchestration | Yes (via LangGraph) | No | Missing |
 | Tool sandboxing/timeout | Partial | ShellTool has timeout + allowed-commands | Partial parity |
 
-**Verdict:** Strong for single-agent workflows. `@tool` decorator, function calling on 4 providers, 22 built-in tools including DuckDuckGo search, PDF reader, GraphQL, shell, and SQL schema inspection. Missing multi-agent orchestration.
+**Verdict:** Strong for single-agent workflows. `@tool` decorator, function calling on 4 providers, 24 built-in tools including DuckDuckGo search, PDF reader, GraphQL, shell, SQL schema inspection, arXiv search, and Tavily search. Missing multi-agent orchestration.
 
 ---
 
@@ -76,14 +76,14 @@
 
 | | LangChain | SynapseKit | Notes |
 |---|---|---|---|
-| Breadth | Massive (200+ loaders, 38+ providers, 50+ tools) | Focused (14 loaders, 13 providers, 22 tools) | SynapseKit covers the 80/20 |
+| Breadth | Massive (200+ loaders, 38+ providers, 50+ tools) | Focused (14 loaders, 15 providers, 24 tools) | SynapseKit covers the 80/20 |
 | API simplicity | Complex, lots of boilerplate | Clean, 3-line happy path | SynapseKit advantage |
 | Async/streaming | Retrofitted | Native from day 1 | SynapseKit advantage |
 | Dependencies | Heavy (langchain-core + per-provider) | 2 hard deps | SynapseKit advantage |
 | Production features | Caching, retries, rate limiting, observability | Caching (memory+SQLite+filesystem+Redis), retries, rate limiting, structured output | Close — missing deep observability |
 | Graph workflows | Mature (HITL, checkpoints, cycles, subgraphs, typed state) | HITL, checkpoints, cycles, subgraphs, typed state, fan-out, SSE, event callbacks | At parity |
-| Retrieval | 10+ strategies | 14 strategies | Exceeds LangChain |
-| Memory | 4+ types | 6 types (window, hybrid, SQLite, summary buffer, token buffer) | Exceeds LangChain |
+| Retrieval | 10+ strategies | 18 strategies | Exceeds LangChain |
+| Memory | 4+ types | 8 types (window, hybrid, SQLite, summary buffer, token buffer, buffer, entity) | Exceeds LangChain |
 
 ### Where SynapseKit already wins
 
@@ -91,8 +91,8 @@
 - Truly async-native and streaming-first
 - Minimal dependencies (2 hard deps)
 - Auto-detection of providers from model name
-- 13 LLM providers, 14 loaders, 22 tools — covers real-world needs
-- 14 retrieval strategies including CRAG, ensemble, compression, HyDE, FLARE, and Step-Back
+- 15 LLM providers, 14 loaders, 24 tools — covers real-world needs
+- 18 retrieval strategies including CRAG, ensemble, compression, HyDE, FLARE, Step-Back, Self-RAG, Adaptive RAG, and Multi-Step
 - Graph workflows at feature parity with LangGraph
 
 ### Closed since v0.5.0
@@ -137,6 +137,15 @@
 38. DuckDuckGoSearchTool, PDFReaderTool, GraphQLTool — 3 new tools (v0.6.5)
 39. TokenBufferMemory — token-budget-aware memory without LLM (v0.6.5)
 40. RedisLLMCache — distributed Redis cache backend (v0.6.5)
+41. PerplexityLLM — Perplexity AI with Sonar models (v0.6.6)
+42. CerebrasLLM — Cerebras ultra-fast inference (v0.6.6)
+43. HybridSearchRetriever — BM25 + vector RRF fusion (v0.6.6)
+44. SelfRAGRetriever — self-reflective retrieve-grade-generate-check loop (v0.6.6)
+45. AdaptiveRAGRetriever — LLM query classification routing (v0.6.6)
+46. MultiStepRetriever — iterative gap-fill retrieval (v0.6.6)
+47. ArxivSearchTool, TavilySearchTool — 2 new search tools (v0.6.6)
+48. BufferMemory — simple unbounded buffer (v0.6.6)
+49. EntityMemory — LLM-based entity extraction and tracking (v0.6.6)
 
 ### Remaining priority gaps
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -107,6 +107,20 @@
 - [x] `RedisLLMCache` — distributed Redis cache backend (`pip install synapsekit[redis]`)
 - [x] 13 providers, 22 tools, 14 loaders, 14 retrieval strategies, 4 cache backends, 6 memory backends, 642 tests passing
 
+## v0.6.6 — Providers, Retrieval, Tools & Memory
+
+- [x] `PerplexityLLM` — Perplexity AI with Sonar models, OpenAI-compatible
+- [x] `CerebrasLLM` — Cerebras ultra-fast inference, OpenAI-compatible
+- [x] `HybridSearchRetriever` — BM25 + vector similarity via Reciprocal Rank Fusion
+- [x] `SelfRAGRetriever` — self-reflective RAG: retrieve, grade, generate, check support, retry
+- [x] `AdaptiveRAGRetriever` — LLM classifies query complexity and routes to different retrievers
+- [x] `MultiStepRetriever` — iterative retrieval-generation with gap identification
+- [x] `ArxivSearchTool` — search arXiv for academic papers (stdlib only, no deps)
+- [x] `TavilySearchTool` — AI-optimized web search via Tavily API
+- [x] `BufferMemory` — simplest unbounded buffer, keeps all messages until cleared
+- [x] `EntityMemory` — LLM-based entity extraction with running descriptions and eviction
+- [x] 15 providers, 24 tools, 14 loaders, 18 retrieval strategies, 4 cache backends, 8 memory backends, 698 tests passing
+
 ## v0.7.0 (planned)
 
 - [ ] Multi-modal support (image inputs for vision models)


### PR DESCRIPTION
## Summary

- Update FEATURE_PARITY.md: 15 providers, 24 tools, 18 retrieval strategies, 8 memory backends
- Update ROADMAP.md: add v0.6.6 section with all 10 features
- Add items #41-49 to "Closed since v0.5.0" list