### PR TITLE
fix: require Python >=3.10, bump to v0.6.7

### DIFF
--- a/.github/profile/README.md
+++ b/.github/profile/README.md
@@ -11,9 +11,9 @@ Async-native RAG, agents, and graph workflows. 2 dependencies. Zero magic.
 
 [![PyPI version](https://img.shields.io/pypi/v/synapsekit?color=0a7bbd&label=pypi&logo=pypi&logoColor=white)](https://pypi.org/project/synapsekit/)
 [![Downloads](https://img.shields.io/pypi/dm/synapsekit?color=0a7bbd&logo=pypi&logoColor=white)](https://pypi.org/project/synapsekit/)
-[![Python](https://img.shields.io/badge/python-3.14%2B-blue?logo=python&logoColor=white)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue?logo=python&logoColor=white)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-22c55e)](https://github.com/SynapseKit/SynapseKit/blob/main/LICENSE)
-[![Tests](https://img.shields.io/badge/tests-332%20passing-22c55e?logo=pytest&logoColor=white)](https://github.com/SynapseKit/SynapseKit)
+[![Tests](https://img.shields.io/badge/tests-698%20passing-22c55e?logo=pytest&logoColor=white)](https://github.com/SynapseKit/SynapseKit)
 [![GitHub Stars](https://img.shields.io/github/stars/SynapseKit/SynapseKit?style=social)](https://github.com/SynapseKit/SynapseKit)
 
 <br/>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ tests/
 - **Type hints.** All public functions and methods must be fully typed.
 - **No new hard dependencies.** Core functionality must work with `numpy` and `rank-bm25` only. New providers and backends go behind optional extras.
 - **No magic.** No monkey-patching, hidden callbacks, or implicit global state.
-- **Python 3.14+.** Use modern syntax freely.
+- **Python 3.10+.** Use modern syntax freely.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 <div align="center">
 
 [![PyPI version](https://img.shields.io/pypi/v/synapsekit?color=0a7bbd&label=pypi&logo=pypi&logoColor=white)](https://pypi.org/project/synapsekit/)
-[![Python](https://img.shields.io/badge/python-3.14%2B-blue?logo=python&logoColor=white)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue?logo=python&logoColor=white)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-22c55e)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-587%20passing-22c55e?logo=pytest&logoColor=white)]()
+[![Tests](https://img.shields.io/badge/tests-698%20passing-22c55e?logo=pytest&logoColor=white)]()
 [![Downloads](https://img.shields.io/pypi/dm/synapsekit?color=0a7bbd&logo=pypi&logoColor=white)](https://pypistats.org/packages/synapsekit)
 [![Docs](https://img.shields.io/badge/docs-online-0a7bbd?logo=readthedocs&logoColor=white)](https://synapsekit.github.io/synapsekit-docs/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "hatchling.build"
 
 [project]
 name = "synapsekit"
-version = "0.6.6"
+version = "0.6.7"
 description = "Async-native Python framework for building production-grade LLM applications. Streaming-first, 2 dependencies, fully transparent."
 authors = [{ name = "Amit", email = "de.amit.nautiyal@gmail.com" }]
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">=3.14"
+requires-python = ">=3.10"
 keywords = ["rag", "llm", "ai", "async", "streaming", "retrieval"]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -17,6 +17,10 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
@@ -96,7 +100,7 @@ asyncio_mode = "auto"
 testpaths = ["tests"]
 
 [tool.ruff]
-target-version = "py314"
+target-version = "py310"
 line-length = 100
 src = ["src"]
 

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -134,7 +134,7 @@ from .text_splitters import (
     TokenAwareSplitter,
 )
 
-__version__ = "0.6.6"
+__version__ = "0.6.7"
 __all__ = [
     # Facade
     "RAG",

--- a/src/synapsekit/retrieval/self_query.py
+++ b/src/synapsekit/retrieval/self_query.py
@@ -70,7 +70,7 @@ class SelfQueryRetriever:
             # Only keep filters for known fields
             filters = {k: v for k, v in filters.items() if k in self._fields and v}
             return query, filters
-        except json.JSONDecodeError, KeyError:
+        except (json.JSONDecodeError, KeyError):
             # Fallback: use original question with no filters
             return question, {}
 

--- a/tests/test_v060_features.py
+++ b/tests/test_v060_features.py
@@ -509,4 +509,4 @@ def test_tool_schemas():
 def test_version():
     import synapsekit
 
-    assert synapsekit.__version__ == "0.6.6"
+    assert synapsekit.__version__ == "0.6.7"

--- a/tests/test_v065_features.py
+++ b/tests/test_v065_features.py
@@ -15,7 +15,7 @@ import pytest
 def test_version():
     import synapsekit
 
-    assert synapsekit.__version__ == "0.6.6"
+    assert synapsekit.__version__ == "0.6.7"
 
 
 # ------------------------------------------------------------------ #

--- a/tests/test_v066_features.py
+++ b/tests/test_v066_features.py
@@ -14,7 +14,7 @@ import pytest
 def test_version():
     import synapsekit
 
-    assert synapsekit.__version__ == "0.6.6"
+    assert synapsekit.__version__ == "0.6.7"
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary

- Change `requires-python` from `>=3.14` to `>=3.10` — the package was uninstallable on Python 3.10-3.13
- Add Python 3.10-3.13 classifiers to pyproject.toml
- Update badges and docs to say Python 3.10+
- Bump version to 0.6.7