### PR TITLE
docs: update CHANGELOG, ROADMAP, FEATURE_PARITY for v0.7.0–v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ SynapseKit uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.0.0] — 2026-03-18
+
+### Added
+
+- **Multimodal support** — `ImageContent` (from_file, from_url, from_base64), `AudioContent`, `MultimodalMessage` with OpenAI/Anthropic format conversion
+- **Image loader** — `ImageLoader` with sync/async loading and optional vision LLM description
+- **API stability markers** — `@public_api`, `@experimental` (FutureWarning), `@deprecated(reason, alternative)` (DeprecationWarning)
+- 42 new tests (1011 total)
+
+---
+
+## [0.9.0] — 2026-03-18
+
+### Added
+
+- **A2A protocol** — `A2AClient`, `A2AServer`, `AgentCard` for Google Agent-to-Agent protocol; `A2ATask`, `A2AMessage`, `TaskState` types
+- **Agent guardrails** — `ContentFilter` (blocked patterns/words/max length), `PIIDetector` (email, phone, SSN, credit card, IP), `TopicRestrictor`, `Guardrails` (composite checker)
+- **Distributed tracing** — `DistributedTracer` and `TraceSpan` with parent-child relationships, events, and timing
+- 64 new tests (1008 total)
+
+---
+
+## [0.8.0] — 2026-03-18
+
+### Added
+
+- **Evaluation metrics** — `FaithfulnessMetric` (claim verification), `RelevancyMetric` (document relevance), `GroundednessMetric` (answer grounding score 0-1)
+- **Evaluation pipeline** — `EvaluationPipeline` runs multiple metrics, `EvaluationResult` with mean_score aggregation
+- **OpenTelemetry tracing** — `OTelExporter` with optional OTLP export, `Span` spans, `TracingMiddleware` auto-traces LLM calls
+- **Tracing UI** — `TracingUI` renders traces as HTML dashboard, saves to file, or serves via local HTTP server
+- 50 new tests (944 total)
+
+---
+
+## [0.7.0] — 2026-03-18
+
+### Added
+
+- **MCP client** — `MCPClient` connects to MCP servers via stdio or SSE transport; `MCPToolAdapter` wraps MCP tools as `BaseTool` instances
+- **MCP server** — `MCPServer` exposes SynapseKit tools as MCP-compatible tools via stdio or SSE
+- **Supervisor agent** — `SupervisorAgent` delegates tasks to `WorkerAgent` instances via DELEGATE/FINAL protocol
+- **Handoff chain** — `HandoffChain` with condition-based `Handoff` transfers between agents, returns `HandoffResult`
+- **Crew** — `Crew` for role-based multi-agent teams with `CrewAgent`, `Task`, sequential and parallel execution
+- 60 new tests (844 total)
+
+---
+
 ## [0.6.9] — 2026-03-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/synapsekit?color=0a7bbd&label=pypi&logo=pypi&logoColor=white)](https://pypi.org/project/synapsekit/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue?logo=python&logoColor=white)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-22c55e)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-795%20passing-22c55e?logo=pytest&logoColor=white)]()
+[![Tests](https://img.shields.io/badge/tests-1011%20passing-22c55e?logo=pytest&logoColor=white)]()
 [![Downloads](https://img.shields.io/pypi/dm/synapsekit?color=0a7bbd&logo=pypi&logoColor=white)](https://pypistats.org/packages/synapsekit)
 [![Docs](https://img.shields.io/badge/docs-online-0a7bbd?logo=readthedocs&logoColor=white)](https://synapsekit.github.io/synapsekit-docs/)
 

--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -1,6 +1,6 @@
 # SynapseKit vs LangChain — Feature Parity Report
 
-> Updated for v0.6.9 (2026-03-18)
+> Updated for v1.0.0 (2026-03-18)
 
 ## Phase 1: RAG Pipelines
 
@@ -29,9 +29,9 @@
 | Rate limiting | Built-in | Token-bucket (`requests_per_minute`) | At parity |
 | Retries | Built-in | Exponential backoff (`max_retries`) | At parity |
 | Structured output | Pydantic output parsers | `generate_structured()` with retry | At parity |
-| Callbacks / observability | LangSmith integration | TokenTracer + `ExecutionTrace` (graph event tracing with timing) | Basic vs enterprise |
+| Callbacks / observability | LangSmith integration | TokenTracer + `ExecutionTrace` + `OTelExporter` + `TracingMiddleware` + `TracingUI` + `DistributedTracer` | At parity |
 
-**Verdict:** Excellent coverage. 15 providers cover 99%+ of real usage. Caching (memory + SQLite + filesystem + Redis), retries, rate limiting, and structured output all done. Only remaining gap: deep observability.
+**Verdict:** Excellent coverage. 15 providers cover 99%+ of real usage. Caching (memory + SQLite + filesystem + Redis), retries, rate limiting, structured output, and full observability stack (OTel, tracing UI, distributed tracing) all done.
 
 ---
 
@@ -45,10 +45,10 @@
 | Custom tools | @tool decorator + StructuredTool | @tool decorator + BaseTool subclass | At parity |
 | Streaming agent steps | Yes | Yes | At parity |
 | Human input tool | Yes | Yes (`HumanInputTool`) | At parity |
-| Multi-agent orchestration | Yes (via LangGraph) | No | Missing |
+| Multi-agent orchestration | Yes (via LangGraph) | Yes (Supervisor, Handoff, Crew) | At parity |
 | Tool sandboxing/timeout | Partial | ShellTool has timeout + allowed-commands | Partial parity |
 
-**Verdict:** Strong for single-agent workflows. `@tool` decorator, function calling on 4 providers, 32 built-in tools including DuckDuckGo, PDF reader, GraphQL, shell, SQL schema, arXiv, Tavily, GitHub API, PubMed, Email, VectorSearch, YouTube, Slack, Jira, and Brave Search. Missing multi-agent orchestration.
+**Verdict:** Excellent. `@tool` decorator, function calling on 4 providers, 32 built-in tools, MCP client/server, 3 multi-agent patterns (Supervisor, Handoff, Crew), guardrails (content filter, PII detector, topic restrictor), and A2A protocol support. At parity with LangChain/LangGraph.
 
 ---
 
@@ -77,24 +77,35 @@
 
 | | LangChain | SynapseKit | Notes |
 |---|---|---|---|
-| Breadth | Massive (200+ loaders, 38+ providers, 50+ tools) | Focused (14 loaders, 15 providers, 32 tools) | SynapseKit covers the 80/20 |
+| Breadth | Massive (200+ loaders, 38+ providers, 50+ tools) | Focused (15 loaders, 15 providers, 32 tools) | SynapseKit covers the 80/20 |
 | API simplicity | Complex, lots of boilerplate | Clean, 3-line happy path | SynapseKit advantage |
 | Async/streaming | Retrofitted | Native from day 1 | SynapseKit advantage |
 | Dependencies | Heavy (langchain-core + per-provider) | 2 hard deps | SynapseKit advantage |
-| Production features | Caching, retries, rate limiting, observability | Caching (memory+SQLite+filesystem+Redis), retries, rate limiting, structured output | Close — missing deep observability |
+| Production features | Caching, retries, rate limiting, observability | Caching, retries, rate limiting, structured output, OTel tracing, tracing UI, guardrails | At parity |
 | Graph workflows | Mature (HITL, checkpoints, cycles, subgraphs, typed state) | HITL, checkpoints, cycles, subgraphs, typed state, fan-out, SSE, WebSocket, event callbacks, execution tracing | At parity |
+| Multi-agent | LangGraph supervisor, handoff | Supervisor, Handoff, Crew + MCP client/server | At parity |
+| Evaluation | RAGAS integration | Built-in faithfulness, relevancy, groundedness metrics | At parity |
 | Retrieval | 10+ strategies | 18 strategies | Exceeds LangChain |
 | Memory | 4+ types | 8 types (window, hybrid, SQLite, summary buffer, token buffer, buffer, entity) | Exceeds LangChain |
+| Multimodal | Image, audio inputs | ImageContent, AudioContent, MultimodalMessage, ImageLoader | At parity |
+| Interoperability | Hub integrations | MCP protocol + A2A protocol | Modern standards |
 
-### Where SynapseKit already wins
+### Where SynapseKit wins
 
 - Simpler API, less boilerplate
 - Truly async-native and streaming-first
 - Minimal dependencies (2 hard deps)
 - Auto-detection of providers from model name
-- 15 LLM providers, 14 loaders, 32 tools — covers real-world needs
-- 18 retrieval strategies including CRAG, ensemble, compression, HyDE, FLARE, Step-Back, Self-RAG, Adaptive RAG, and Multi-Step
-- Graph workflows at feature parity with LangGraph
+- 15 LLM providers, 15 loaders, 32 tools — covers real-world needs
+- 18 retrieval strategies exceeding LangChain
+- Graph workflows at parity with LangGraph
+- MCP + A2A protocol for modern interoperability
+- Multi-agent orchestration (Supervisor, Handoff, Crew)
+- Built-in evaluation metrics (faithfulness, relevancy, groundedness)
+- Full observability stack (OTel, tracing UI, distributed tracing)
+- Agent guardrails (content filter, PII, topic restriction)
+- Multimodal support (image, audio) with provider format conversion
+- API stability markers (@public_api, @experimental, @deprecated)
 
 ### Closed since v0.5.0
 
@@ -162,9 +173,27 @@
 61. `approval_node()` — gate graph on human approval via GraphInterrupt (v0.6.9)
 62. `dynamic_route_node()` — runtime subgraph routing (v0.6.9)
 
+63. `MCPClient` + `MCPToolAdapter` — MCP client with stdio/SSE transport (v0.7.0)
+64. `MCPServer` — expose SynapseKit tools via MCP protocol (v0.7.0)
+65. `SupervisorAgent` + `WorkerAgent` — supervisor multi-agent pattern (v0.7.0)
+66. `HandoffChain` + `Handoff` — condition-based agent handoff (v0.7.0)
+67. `Crew` + `CrewAgent` + `Task` — role-based multi-agent teams (v0.7.0)
+68. `FaithfulnessMetric` — claim verification against sources (v0.8.0)
+69. `RelevancyMetric` — document relevance scoring (v0.8.0)
+70. `GroundednessMetric` — answer grounding score (v0.8.0)
+71. `EvaluationPipeline` — multi-metric evaluation runner (v0.8.0)
+72. `OTelExporter` + `Span` + `TracingMiddleware` — OpenTelemetry tracing (v0.8.0)
+73. `TracingUI` — HTML trace visualization dashboard (v0.8.0)
+74. `A2AClient` + `A2AServer` + `AgentCard` — Google A2A protocol (v0.9.0)
+75. `ContentFilter` + `PIIDetector` + `TopicRestrictor` + `Guardrails` — agent guardrails (v0.9.0)
+76. `DistributedTracer` + `TraceSpan` — distributed tracing with parent-child spans (v0.9.0)
+77. `ImageContent` + `AudioContent` + `MultimodalMessage` — multimodal support (v1.0.0)
+78. `ImageLoader` — image loading with optional vision LLM description (v1.0.0)
+79. `@public_api`, `@experimental`, `@deprecated` — API stability markers (v1.0.0)
+
 ### Remaining priority gaps
 
-1. Multi-agent orchestration
-2. Multi-modal support (image inputs)
-3. Evaluation framework (RAGAS-style metrics)
-4. Deep observability (LangSmith equivalent)
+1. Postgres/Redis checkpoint backends
+2. Video/audio loaders
+3. `synapsekit serve` CLI
+4. Prompt hub

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -146,17 +146,55 @@
 - [x] `dynamic_route_node()` — route to subgraphs at runtime based on routing function
 - [x] 15 providers, 32 tools, 14 loaders, 18 retrieval strategies, 4 cache backends, 8 memory backends, 795 tests passing
 
-## v0.7.0 (planned)
+## v0.7.0 — MCP + Multi-Agent Orchestration
 
-- [ ] Multi-modal support (image inputs for vision models)
-- [ ] `Evaluator` — faithfulness, relevancy, groundedness
-- [ ] RAGAS-style metrics
-- [ ] Conversation branching and tree-of-thought
+- [x] `MCPClient` — connect to MCP servers via stdio or SSE transport
+- [x] `MCPToolAdapter` — wrap MCP tools as SynapseKit `BaseTool` instances
+- [x] `MCPServer` — expose SynapseKit tools as MCP-compatible tools
+- [x] `SupervisorAgent` + `WorkerAgent` — delegate tasks via DELEGATE/FINAL protocol
+- [x] `HandoffChain` + `Handoff` — condition-based agent transfers
+- [x] `Crew` + `CrewAgent` + `Task` — role-based multi-agent teams (sequential & parallel)
+- [x] 15 providers, 32 tools, 14 loaders, 18 retrieval strategies, MCP client/server, 3 multi-agent patterns, 844 tests passing
 
-## v0.8.0 (planned)
+## v0.8.0 — Evaluation Metrics + Observability
 
-- [ ] Local observability UI (LangSmith-style, open source)
-- [ ] Streaming UI helpers — SSE + WebSocket for FastAPI
+- [x] `FaithfulnessMetric` — verify answer claims against source contexts via LLM judge
+- [x] `RelevancyMetric` — check document relevance to query
+- [x] `GroundednessMetric` — score answer grounding in source documents (0-1)
+- [x] `EvaluationPipeline` + `EvaluationResult` — run multiple metrics with mean_score
+- [x] `OTelExporter` — lightweight tracing with optional OTLP export
+- [x] `Span` — individual trace spans
+- [x] `TracingMiddleware` — auto-trace LLM calls
+- [x] `TracingUI` — render traces as HTML dashboard, file, or local HTTP server
+- [x] 944 tests passing
+
+## v0.9.0 — A2A Protocol, Guardrails, Distributed Tracing
+
+- [x] `A2AClient` + `A2AServer` — Google Agent-to-Agent protocol support
+- [x] `AgentCard` — agent capability discovery for A2A
+- [x] `A2ATask`, `A2AMessage`, `TaskState` — A2A protocol types
+- [x] `ContentFilter` — blocked patterns, words, max length
+- [x] `PIIDetector` — email, phone, SSN, credit card, IP detection
+- [x] `TopicRestrictor` — blocked topic enforcement
+- [x] `Guardrails` — composite checker combining multiple guardrail types
+- [x] `DistributedTracer` + `TraceSpan` — parent-child span relationships with events and timing
+- [x] 1008 tests passing
+
+## v1.0.0 — Multimodal, Image Loader, API Stability
+
+- [x] `ImageContent` — from_file, from_url, from_base64 with OpenAI/Anthropic format conversion
+- [x] `AudioContent` — from_file, from_base64
+- [x] `MultimodalMessage` — combines text + images, converts to provider-specific formats
+- [x] `ImageLoader` — sync/async image loading with optional vision LLM description
+- [x] `@public_api` — mark stable public API surface
+- [x] `@experimental` — FutureWarning on first use
+- [x] `@deprecated(reason, alternative)` — DeprecationWarning with migration guidance
+- [x] 1011 tests passing
+
+## v1.1.0 (planned)
+
 - [ ] `synapsekit serve` — deploy any app as FastAPI in one command
 - [ ] Prompt hub — versioned prompt registry
 - [ ] Plugin system for community extensions
+- [ ] Postgres/Redis checkpoint backends
+- [ ] Video/audio loaders


### PR DESCRIPTION
## Summary
- Updated CHANGELOG with entries for v0.7.0, v0.8.0, v0.9.0, v1.0.0
- Updated ROADMAP with completed v0.7.0–v1.0.0 sections and v1.1.0 planned
- Updated FEATURE_PARITY with 17 new closed items (#63-#79), updated verdicts
- Updated README test badge to 1011 passing