### PR TITLE
chore: update README stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/synapsekit?color=0a7bbd&label=pypi&logo=pypi&logoColor=white)](https://pypi.org/project/synapsekit/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue?logo=python&logoColor=white)](https://www.python.org/)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-22c55e)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-1011%20passing-22c55e?logo=pytest&logoColor=white)]()
+[![Tests](https://img.shields.io/badge/tests-1305%20passing-22c55e?logo=pytest&logoColor=white)]()
 [![Downloads](https://img.shields.io/pypi/dm/synapsekit?color=0a7bbd&logo=pypi&logoColor=white)](https://pypistats.org/packages/synapsekit)
 [![Docs](https://img.shields.io/badge/docs-online-0a7bbd?logo=readthedocs&logoColor=white)](https://synapsekit.github.io/synapsekit-docs/)
 
@@ -41,7 +41,7 @@ Token-level streaming is the default,<br/>not an afterthought.<br/>Works across 
 <tr>
 <td align="center" width="33%">
 <h3>🔌 One interface</h3>
-13 LLM providers and 5 vector stores<br/>behind the same API.<br/>Swap without rewriting.
+19 LLM providers and 5 vector stores<br/>behind the same API.<br/>Swap without rewriting.
 </td>
 <td align="center" width="33%">
 <h3>🧩 Composable</h3>
@@ -84,7 +84,7 @@ Retrieval-augmented generation with streaming, BM25 reranking, conversation memo
 <td width="50%">
 
 **🤖 Agents**<br/>
-ReAct loop (any LLM) and native function calling (OpenAI / Anthropic / Gemini / Mistral). 19 built-in tools including calculator, Python REPL, web search, SQL, HTTP, shell, summarization, sentiment analysis, and translation. Fully extensible.
+ReAct loop (any LLM) and native function calling (OpenAI / Anthropic / Gemini / Mistral). 35 built-in tools including calculator, Python REPL, web search, SQL, HTTP, shell, summarization, sentiment analysis, and translation. Fully extensible.
 
 </td>
 </tr>
@@ -98,7 +98,7 @@ DAG-based async pipelines. Nodes run in waves — parallel nodes execute concurr
 <td width="50%">
 
 **🧠 LLM Providers**<br/>
-OpenAI, Anthropic, Ollama, Gemini, Cohere, Mistral, Bedrock, Azure OpenAI, Groq, DeepSeek, OpenRouter, Together, Fireworks — all behind one interface. Auto-detected from the model name. Swap without rewriting.
+OpenAI, Anthropic, Ollama, Gemini, Cohere, Mistral, Bedrock, Azure OpenAI, Groq, DeepSeek, OpenRouter, Together, Fireworks, Cerebras, Cloudflare, Moonshot, Perplexity, Vertex AI, Zhipu — all behind one interface. Auto-detected from the model name. Swap without rewriting.
 
 </td>
 </tr>


### PR DESCRIPTION
## Summary
- Update test count: 1011 → 1305
- Update built-in tools count: 19 → 35
- Update LLM providers count: 13 → 19 (added Cerebras, Cloudflare, Moonshot, Perplexity, Vertex AI, Zhipu)