### PR TITLE
chore: release v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ SynapseKit uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.4.2] — 2026-03-28
+
+### Added
+
+- **HuggingFaceLLM** — Hugging Face Inference API via `AsyncInferenceClient`; supports serverless API (model ID) and Dedicated Inference Endpoints (URL); streaming and generate
+- **DynamoDBCacheBackend** — serverless LLM response caching on AWS DynamoDB; configurable partition key, TTL via `ttl_seconds`, custom region and endpoint
+- **MemcachedCacheBackend** — high-throughput distributed LLM caching via `aiomcache`; TTL via `exptime`; async-native
+- **GoogleSearchTool** — Google web search via SerpAPI (`google-search-results`); graceful handling of missing keys, empty results, and API errors
+- **Graph versioning and checkpoint migration** — `StateGraph(version="1", migrations={...})`; `CompiledGraph.resume()` now applies migration chains when loading older checkpoint versions; supports direct and chained `(next_version, state_dict)` migrations; missing paths raise `GraphRuntimeError`
+- 11 new tests (1368 total)
+
+### Improved
+
+- **SQLQueryTool** — added `params` dict for parameterized queries (eliminates string interpolation); `max_rows` cap; fixed variable name shadowing
+
+---
+
 ## [1.4.1] — 2026-03-27
 
 ### Added

--- a/docs/COMMERCIALIZATION.md
+++ b/docs/COMMERCIALIZATION.md
@@ -1,11 +1,11 @@
 # SynapseKit — Commercialization Strategy
 
-> Updated for v1.4.1 (2026-03-27)
+> Updated for v1.4.2 (2026-03-28)
 
-## Current State (v1.4.1)
+## Current State (v1.4.2)
 
-- 1,357 tests passing, CI pipeline, linting, type checking
-- 25 LLM providers, 15 loaders, 5 vector stores, 40 tools
+- 1,368 tests passing, CI pipeline, linting, type checking
+- 26 LLM providers, 15 loaders, 5 vector stores, 41 tools, 6 cache backends
 - 20 retrieval strategies (exceeds LangChain), 9 memory backends
 - Agents (ReAct + function calling), graph workflows (cycles, HITL, subgraphs, typed state)
 - Multi-agent (Supervisor, Handoff, Crew) + MCP + A2A protocol
@@ -93,7 +93,7 @@ Drag-and-drop graph editor exporting SynapseKit configs. Non-engineers build and
 
 ## Open-Core Boundary
 
-**Pivot point: v1.4.1** — v1.4.1 and below is fully open source. v1.5.0+ introduces commercial products built on top of the open core.
+**Pivot point: v1.4.2** — v1.4.2 and below is fully open source. v1.5.0+ introduces commercial products built on top of the open core.
 
 | Layer | Open source (free) | Commercial (paid) |
 |---|---|---|
@@ -110,7 +110,7 @@ Drag-and-drop graph editor exporting SynapseKit configs. Non-engineers build and
 
 | Priority | Move | Timeline | Revenue type |
 |---|---|---|---|
-| **Done** | `synapsekit serve` + cost tracking + eval CLI + compliance primitives | v1.2.0–v1.4.1 | Open source (adoption) |
+| **Done** | `synapsekit serve` + cost tracking + eval CLI + compliance primitives | v1.2.0–v1.4.2 | Open source (adoption) |
 | **Now** | EU compliance platform (GDPR toolkit, DataResidency) + EvalCI Action | v1.5.0 (Q2 2026) | Freemium SaaS |
 | **Next** | Fintech vertical + edge runtime | v1.6.0 (Q3 2026) | Enterprise licensing |
 | **Future** | Visual builder + managed cloud | v2.0.0 (2027) | Platform SaaS |

--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -1,6 +1,6 @@
 # SynapseKit vs LangChain — Feature Parity Report
 
-> Updated for v1.4.1 (2026-03-27)
+> Updated for v1.4.2 (2026-03-28)
 
 ## Phase 1: RAG Pipelines
 
@@ -22,7 +22,7 @@
 
 | Capability | LangChain | SynapseKit | Gap |
 |---|---|---|---|
-| Providers | 38+ | 25 (OpenAI, Anthropic, Ollama, Cohere, Mistral, Gemini, Vertex AI, Bedrock, Azure OpenAI, Groq, DeepSeek, OpenRouter, Together, Fireworks, Perplexity, Cerebras, Moonshot, Zhipu, Cloudflare, AI21, Databricks, ERNIE, llama.cpp, Minimax, Aleph Alpha) | Covers all major ones |
+| Providers | 38+ | 26 (OpenAI, Anthropic, Ollama, Cohere, Mistral, Gemini, Vertex AI, Bedrock, Azure OpenAI, Groq, DeepSeek, OpenRouter, Together, Fireworks, Perplexity, Cerebras, Moonshot, Zhipu, Cloudflare, AI21, Databricks, ERNIE, llama.cpp, Minimax, Aleph Alpha, HuggingFace) | Covers all major ones |
 | Unified interface | Yes (invoke/stream/batch) | Yes (generate/stream) | At parity |
 | Auto-detect from model name | No (explicit class) | Yes | SynapseKit advantage |
 | Caching | Built-in (memory, SQLite, Redis) | In-memory LRU + SQLite + Filesystem + Redis | At parity |

--- a/docs/GROWTH_PLAN.md
+++ b/docs/GROWTH_PLAN.md
@@ -1,6 +1,6 @@
 # SynapseKit — Competitive Growth Plan
 
-> Created 2026-03-19 | Updated: 2026-03-27 | Current: v1.4.1
+> Created 2026-03-19 | Updated: 2026-03-28 | Current: v1.4.2
 
 ## The Core Problem
 
@@ -10,21 +10,21 @@ SynapseKit needs **blue-ocean moves** — features that redefine what an LLM fra
 
 ---
 
-## Where We Stand Today (v1.4.1)
+## Where We Stand Today (v1.4.2)
 
 | Metric | Count |
 |---|---|
-| LLM providers | 25 |
+| LLM providers | 26 |
 | Retrieval strategies | 20 (exceeds LangChain) |
-| Built-in tools | 40 |
+| Built-in tools | 41 |
 | Document loaders | 15 |
 | Text splitters | 6 |
 | Memory backends | 9 (exceeds LangChain) |
-| Cache backends | 4 |
+| Cache backends | 6 |
 | Graph checkpointers | 5 |
 | Multi-agent patterns | 3 |
 | Evaluation metrics | 3 |
-| Tests passing | 1357 |
+| Tests passing | 1368 |
 | Hard runtime deps | 2 |
 
 **Parity status:** At or exceeding LangChain on retrieval, memory, graph workflows, evaluation, observability, and cost intelligence. Fewer loaders but covers 80/20 of real usage. Now includes local inference (llama.cpp) with zero API cost.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -254,6 +254,16 @@
 - [x] Fixed missing return type annotations in loader helper functions
 - [x] 25 providers, 40 tools, 15 loaders, 20 retrieval strategies, 9 memory backends, 1357 tests passing
 
+## v1.4.2 — HuggingFace, Cache Backends, Graph Versioning (2026-03-28)
+
+- [x] `HuggingFaceLLM` — Hugging Face Inference API via `AsyncInferenceClient`; serverless and Dedicated Endpoint support
+- [x] `DynamoDBCacheBackend` — serverless LLM response caching on AWS DynamoDB with TTL support
+- [x] `MemcachedCacheBackend` — distributed LLM caching via aiomcache with TTL
+- [x] `GoogleSearchTool` — Google web search via SerpAPI
+- [x] Graph versioning — `StateGraph(version=, migrations={})` + `CompiledGraph.resume()` migration chains
+- [x] `SQLQueryTool` improved — parameterized queries via `params` dict, `max_rows` cap
+- [x] 26 providers, 41 tools, 15 loaders, 20 retrieval strategies, 9 memory backends, 6 cache backends, 1368 tests passing
+
 ## v1.5.0 (planned — Q2 2026)
 
 - [ ] **EU Compliance Platform** — `DataResidency` (enforce data never leaves a region), `ConsentManager`, `RetentionPolicy`, `RightToErasure` (GDPR primitives)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "synapsekit"
-version = "1.4.1"
+version = "1.4.2"
 description = "Async-native Python framework for building production-grade LLM applications. Streaming-first, 2 dependencies, fully transparent."
 authors = [{ name = "Amit", email = "de.amit.nautiyal@gmail.com" }]
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## v1.4.2 Release

Bumps version to 1.4.2 and updates CHANGELOG + internal docs.

### What's included (from merged PRs #349, #351, #352, #353, #354, #355):

- **HuggingFaceLLM** — Hugging Face Inference API (serverless + Dedicated Endpoints)
- **DynamoDBCacheBackend** — serverless LLM caching on AWS DynamoDB with TTL
- **MemcachedCacheBackend** — distributed LLM caching via aiomcache
- **GoogleSearchTool** — Google web search via SerpAPI
- **Graph versioning + checkpoint migration** — `StateGraph(version=, migrations={})`, migration chains on `resume()`
- **SQLQueryTool** — parameterized queries, max_rows cap, security fixes

**Stats:** 26 providers · 41 tools · 15 loaders · 6 cache backends · 1368 tests