### PR TITLE
feat: Added metadata preservation in text_splitters

### DIFF
--- a/src/synapsekit/text_splitters/base.py
+++ b/src/synapsekit/text_splitters/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 
 class BaseSplitter(ABC):
@@ -10,3 +11,30 @@ class BaseSplitter(ABC):
     def split(self, text: str) -> list[str]:
         """Split *text* into a list of chunks."""
         ...
+
+    def split_with_metadata(
+        self, text: str, metadata: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        """
+        Split *text* into chunks, preserving metadata for each chunk.
+
+        Args:
+            text: The text to split.
+            metadata: Optional metadata to attach to each chunk.
+
+        Returns:
+            List of dicts with keys:
+                - "text": The chunk text
+                - "metadata": Merged metadata including parent metadata and chunk_index
+        """
+        chunks = self.split(text)
+        result: list[dict[str, Any]] = []
+
+        base_metadata = metadata.copy() if metadata else {}
+
+        for idx, chunk_text in enumerate(chunks):
+            chunk_metadata = base_metadata.copy()
+            chunk_metadata["chunk_index"] = idx
+            result.append({"text": chunk_text, "metadata": chunk_metadata})
+
+        return result

--- a/tests/text_splitters/test_splitters.py
+++ b/tests/text_splitters/test_splitters.py
@@ -159,6 +159,112 @@ def test_text_splitter_compat_api():
 
 
 # ------------------------------------------------------------------ #
+# Metadata support
+# ------------------------------------------------------------------ #
+
+
+def test_split_with_metadata_basic():
+    """Test basic metadata inheritance."""
+    s = CharacterTextSplitter(separator="\n\n", chunk_size=20, chunk_overlap=0)
+    text = "paragraph one\n\nparagraph two\n\nparagraph three"
+    metadata = {"source": "test.txt", "author": "Alice"}
+
+    result = s.split_with_metadata(text, metadata)
+
+    assert len(result) > 0
+    assert all("text" in chunk for chunk in result)
+    assert all("metadata" in chunk for chunk in result)
+    assert all(chunk["metadata"]["source"] == "test.txt" for chunk in result)
+    assert all(chunk["metadata"]["author"] == "Alice" for chunk in result)
+
+
+def test_split_with_metadata_chunk_index():
+    """Test chunk_index increments correctly."""
+    s = CharacterTextSplitter(separator="\n\n", chunk_size=20, chunk_overlap=0)
+    text = "paragraph one\n\nparagraph two\n\nparagraph three"
+
+    result = s.split_with_metadata(text, {"source": "test.txt"})
+
+    for idx, chunk in enumerate(result):
+        assert chunk["metadata"]["chunk_index"] == idx
+
+
+def test_split_with_metadata_none():
+    """Test handling of None metadata."""
+    s = CharacterTextSplitter(chunk_size=100)
+    text = "Hello world"
+
+    result = s.split_with_metadata(text, None)
+
+    assert len(result) == 1
+    assert result[0]["text"] == "Hello world"
+    assert result[0]["metadata"]["chunk_index"] == 0
+    assert len(result[0]["metadata"]) == 1  # Only chunk_index
+
+
+def test_split_with_metadata_immutability():
+    """Test that original metadata is not mutated."""
+    s = CharacterTextSplitter(separator="\n\n", chunk_size=20, chunk_overlap=0)
+    text = "paragraph one\n\nparagraph two\n\nparagraph three"
+    original_metadata = {"source": "test.txt", "count": 42}
+
+    result = s.split_with_metadata(text, original_metadata)
+
+    # Original should be unchanged
+    assert original_metadata == {"source": "test.txt", "count": 42}
+    assert "chunk_index" not in original_metadata
+
+    # Result chunks should have chunk_index
+    assert all("chunk_index" in chunk["metadata"] for chunk in result)
+
+
+def test_split_with_metadata_recursive_splitter():
+    """Test metadata with RecursiveCharacterTextSplitter."""
+    s = RecursiveCharacterTextSplitter(chunk_size=25, chunk_overlap=0)
+    text = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph."
+
+    result = s.split_with_metadata(text, {"doc_id": "123"})
+
+    assert len(result) >= 2
+    assert all(chunk["metadata"]["doc_id"] == "123" for chunk in result)
+    assert all("chunk_index" in chunk["metadata"] for chunk in result)
+
+
+def test_split_with_metadata_token_splitter():
+    """Test metadata with TokenAwareSplitter."""
+    s = TokenAwareSplitter(max_tokens=10, chunk_overlap=0)
+    text = "word " * 50
+
+    result = s.split_with_metadata(text, {"type": "article"})
+
+    assert len(result) >= 2
+    assert all(chunk["metadata"]["type"] == "article" for chunk in result)
+    for idx, chunk in enumerate(result):
+        assert chunk["metadata"]["chunk_index"] == idx
+
+
+def test_split_with_metadata_empty_text():
+    """Test metadata with empty text."""
+    s = CharacterTextSplitter()
+    result = s.split_with_metadata("", {"source": "empty.txt"})
+
+    assert result == []
+
+
+def test_split_with_metadata_single_chunk():
+    """Test metadata when text fits in single chunk."""
+    s = CharacterTextSplitter(chunk_size=100)
+    text = "Short text"
+
+    result = s.split_with_metadata(text, {"page": 1})
+
+    assert len(result) == 1
+    assert result[0]["text"] == "Short text"
+    assert result[0]["metadata"]["page"] == 1
+    assert result[0]["metadata"]["chunk_index"] == 0
+
+
+# ------------------------------------------------------------------ #
 # Top-level imports
 # ------------------------------------------------------------------ #
 


### PR DESCRIPTION
## Summary

Adds metadata-preserving chunk outputs at the splitter layer via BaseSplitter.split_with_metadata.
Each returned chunk includes the chunk text plus merged parent metadata and a chunk_index, while keeping existing split behavior unchanged.

Closes #24 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / internal improvement
- [ ] Dependency / tooling update

## Changes

- Added metadata-aware splitting in the splitter base contract using split_with_metadata(text, metadata=None).
- Ensured each chunk inherits parent metadata and gets a stable chunk_index.
- Kept split(text) return type unchanged for backward compatibility.

## Testing

- [x] All existing tests pass (`uv run pytest tests/ -q`)
- [x] New tests added for new behaviour
- [x] No API keys or secrets in the code