### PR TITLE
fix: wiki workflow — handle both cloned and fresh-init remote

### DIFF
--- a/.github/workflows/init-wiki.yml
+++ b/.github/workflows/init-wiki.yml
@@ -55,5 +55,5 @@ jobs:
           git diff --cached --quiet && echo "No changes" && exit 0
 
           git commit -m "Initialize wiki with Discord community guides"
-          git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git"
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git" 2>/dev/null || git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git"
           git push -f origin HEAD:master


### PR DESCRIPTION
Handles both cases: when wiki already exists (clone succeeds, origin set) and when it doesn't (fresh init, no origin). Uses `set-url || add` pattern.