### PR TITLE
feat: mirror all GitHub activity to #github-activity

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [opened, closed]
   issues:
-    types: [labeled]
+    types: [labeled, opened]
   release:
     types: [published]
   workflow_run:
@@ -18,78 +18,92 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - name: Post to #contributors-chat
+      - name: Post to Discord
         run: |
           COMMIT_MSG=$(echo "${{ github.event.head_commit.message }}" | head -1)
           AUTHOR="${{ github.event.head_commit.author.name }}"
           URL="https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
-          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_CONTRIBUTORS }}" \
-            -H "Content-Type: application/json" \
-            -d "{\"embeds\":[{\"title\":\"Push to main\",\"description\":\"**${COMMIT_MSG}**\n\n[View commit](${URL})\",\"color\":5793266,\"footer\":{\"text\":\"${AUTHOR}\"}}]}"
+          PAYLOAD="{\"embeds\":[{\"title\":\"Push to main\",\"description\":\"**${COMMIT_MSG}**\n\n[View commit](${URL})\",\"color\":5793266,\"footer\":{\"text\":\"${AUTHOR}\"}}]}"
+          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_CONTRIBUTORS }}" -H "Content-Type: application/json" -d "$PAYLOAD"
+          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_GITHUB_ACTIVITY }}" -H "Content-Type: application/json" -d "$PAYLOAD"
 
   notify-pr-opened:
     if: github.event_name == 'pull_request' && github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
-      - name: Post to #pr-feed
+      - name: Post to Discord
         run: |
           TITLE="${{ github.event.pull_request.title }}"
           AUTHOR="${{ github.event.pull_request.user.login }}"
           URL="${{ github.event.pull_request.html_url }}"
           NUMBER="${{ github.event.pull_request.number }}"
-          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_PR_FEED }}" \
-            -H "Content-Type: application/json" \
-            -d "{\"embeds\":[{\"title\":\"PR #${NUMBER} opened\",\"description\":\"**${TITLE}**\n\n[View PR](${URL})\",\"color\":3447003,\"footer\":{\"text\":\"${AUTHOR}\"}}]}"
+          PAYLOAD="{\"embeds\":[{\"title\":\"PR #${NUMBER} opened\",\"description\":\"**${TITLE}**\n\n[View PR](${URL})\",\"color\":3447003,\"footer\":{\"text\":\"${AUTHOR}\"}}]}"
+          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_PR_FEED }}" -H "Content-Type: application/json" -d "$PAYLOAD"
+          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_GITHUB_ACTIVITY }}" -H "Content-Type: application/json" -d "$PAYLOAD"
 
   notify-pr-merged:
     if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - name: Post to #pr-feed
+      - name: Post to Discord
         run: |
           TITLE="${{ github.event.pull_request.title }}"
           AUTHOR="${{ github.event.pull_request.user.login }}"
           URL="${{ github.event.pull_request.html_url }}"
           NUMBER="${{ github.event.pull_request.number }}"
-          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_PR_FEED }}" \
-            -H "Content-Type: application/json" \
-            -d "{\"embeds\":[{\"title\":\"✅ PR #${NUMBER} merged\",\"description\":\"**${TITLE}**\n\n[View PR](${URL})\",\"color\":5763719,\"footer\":{\"text\":\"${AUTHOR}\"}}]}"
+          PAYLOAD="{\"embeds\":[{\"title\":\"✅ PR #${NUMBER} merged\",\"description\":\"**${TITLE}**\n\n[View PR](${URL})\",\"color\":5763719,\"footer\":{\"text\":\"${AUTHOR}\"}}]}"
+          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_PR_FEED }}" -H "Content-Type: application/json" -d "$PAYLOAD"
+          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_GITHUB_ACTIVITY }}" -H "Content-Type: application/json" -d "$PAYLOAD"
 
-  notify-good-first-issue:
-    if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'good first issue'
+  notify-issue-opened:
+    if: github.event_name == 'issues' && github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
-      - name: Post to #good-first-issues
+      - name: Post to #github-activity
         run: |
           TITLE="${{ github.event.issue.title }}"
           URL="${{ github.event.issue.html_url }}"
           NUMBER="${{ github.event.issue.number }}"
           AUTHOR="${{ github.event.issue.user.login }}"
-          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_GOOD_FIRST_ISSUES }}" \
+          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_GITHUB_ACTIVITY }}" \
             -H "Content-Type: application/json" \
-            -d "{\"embeds\":[{\"title\":\"👋 Good first issue #${NUMBER}\",\"description\":\"**${TITLE}**\n\n[View issue](${URL})\",\"color\":10181046,\"footer\":{\"text\":\"opened by ${AUTHOR}\"}}]}"
+            -d "{\"embeds\":[{\"title\":\"Issue #${NUMBER} opened\",\"description\":\"**${TITLE}**\n\n[View issue](${URL})\",\"color\":16776960,\"footer\":{\"text\":\"${AUTHOR}\"}}]}"
+
+  notify-good-first-issue:
+    if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'good first issue'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord
+        run: |
+          TITLE="${{ github.event.issue.title }}"
+          URL="${{ github.event.issue.html_url }}"
+          NUMBER="${{ github.event.issue.number }}"
+          AUTHOR="${{ github.event.issue.user.login }}"
+          PAYLOAD="{\"embeds\":[{\"title\":\"👋 Good first issue #${NUMBER}\",\"description\":\"**${TITLE}**\n\n[View issue](${URL})\",\"color\":10181046,\"footer\":{\"text\":\"opened by ${AUTHOR}\"}}]}"
+          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_GOOD_FIRST_ISSUES }}" -H "Content-Type: application/json" -d "$PAYLOAD"
+          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_GITHUB_ACTIVITY }}" -H "Content-Type: application/json" -d "$PAYLOAD"
 
   notify-release:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
-      - name: Post to #contributors-chat
+      - name: Post to Discord
         run: |
           TAG="${{ github.event.release.tag_name }}"
           URL="${{ github.event.release.html_url }}"
-          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_CONTRIBUTORS }}" \
-            -H "Content-Type: application/json" \
-            -d "{\"embeds\":[{\"title\":\"🚀 Released ${TAG}\",\"description\":\"[View release](${URL})\",\"color\":15844367}]}"
+          PAYLOAD="{\"embeds\":[{\"title\":\"🚀 Released ${TAG}\",\"description\":\"[View release](${URL})\",\"color\":15844367}]}"
+          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_CONTRIBUTORS }}" -H "Content-Type: application/json" -d "$PAYLOAD"
+          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_GITHUB_ACTIVITY }}" -H "Content-Type: application/json" -d "$PAYLOAD"
 
   notify-ci-failure:
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
     steps:
-      - name: Post to #contributors-chat
+      - name: Post to Discord
         run: |
           BRANCH="${{ github.event.workflow_run.head_branch }}"
           ACTOR="${{ github.event.workflow_run.triggering_actor.login }}"
           URL="${{ github.event.workflow_run.html_url }}"
-          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_CONTRIBUTORS }}" \
-            -H "Content-Type: application/json" \
-            -d "{\"embeds\":[{\"title\":\"❌ CI failed on ${BRANCH}\",\"description\":\"[View run](${URL})\",\"color\":15158332,\"footer\":{\"text\":\"triggered by ${ACTOR}\"}}]}"
+          PAYLOAD="{\"embeds\":[{\"title\":\"❌ CI failed on ${BRANCH}\",\"description\":\"[View run](${URL})\",\"color\":15158332,\"footer\":{\"text\":\"triggered by ${ACTOR}\"}}]}"
+          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_CONTRIBUTORS }}" -H "Content-Type: application/json" -d "$PAYLOAD"
+          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_GITHUB_ACTIVITY }}" -H "Content-Type: application/json" -d "$PAYLOAD"


### PR DESCRIPTION
Every event (PRs, commits, issues, releases, CI failures) now posts to both its dedicated channel and #github-activity as a full log.