### PR TITLE
feat: add Discord badge, navbar link, and PyPI URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@
 [![Downloads](https://img.shields.io/pypi/dm/synapsekit?color=22c55e&logo=pypi&logoColor=white)](https://pypistats.org/packages/synapsekit)
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/synapsekit?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/synapsekit)
 [![Docs](https://img.shields.io/badge/docs-online-22c55e?logo=readthedocs&logoColor=white)](https://synapsekit.github.io/synapsekit-docs/)
+[![Discord](https://img.shields.io/discord/1489713020098842794?color=22c55e&label=discord&logo=discord&logoColor=white)](https://discord.gg/unn4cXXH)
 
-**[Documentation](https://synapsekit.github.io/synapsekit-docs/) · [Quickstart](https://synapsekit.github.io/synapsekit-docs/docs/getting-started/quickstart) · [API Reference](https://synapsekit.github.io/synapsekit-docs/docs/api/llm) · [Changelog](CHANGELOG.md) · [Report a Bug](https://github.com/SynapseKit/SynapseKit/issues/new?template=bug_report.yml)**
+**[Documentation](https://synapsekit.github.io/synapsekit-docs/) · [Quickstart](https://synapsekit.github.io/synapsekit-docs/docs/getting-started/quickstart) · [API Reference](https://synapsekit.github.io/synapsekit-docs/docs/api/llm) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/unn4cXXH) · [Report a Bug](https://github.com/SynapseKit/SynapseKit/issues/new?template=bug_report.yml)**
 
 </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/SynapseKit/SynapseKit"
 Repository = "https://github.com/SynapseKit/SynapseKit"
+Documentation = "https://synapsekit.github.io/synapsekit-docs/"
+Discord = "https://discord.gg/unn4cXXH"
 
 [project.scripts]
 synapsekit = "synapsekit.cli.main:main"


### PR DESCRIPTION
- README: Discord badge + link in nav row
- pyproject.toml: Discord URL (shows on PyPI sidebar)
- GitHub repo About: homepage set to Discord invite