### PR TITLE
feat(loader): ConfluenceLoader — space/page loading, pagination, retry, async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ SynapseKit uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **ConfluenceLoader** — load pages from Atlassian Confluence as Documents; supports single page by `page_id` or full space by `space_key`; automatic pagination; converts Confluence storage format to plain text via BeautifulSoup; rich metadata (title, author, version, URL); retry with exponential back-off for rate limits; sync `load()` and async `aload()`; `pip install synapsekit[confluence]`
+
+---
+
 ## [1.4.8] — 2026-04-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ discord = ["discord.py>=2.0"]
 gdrive = ["google-api-python-client>=2.0", "google-auth>=2.0"]
 slack = ["slack-sdk>=3.0"]
 notion = ["httpx>=0.27"]
+confluence = ["atlassian-python-api>=3.0", "beautifulsoup4>=4.12"]
 all = [
     "openai>=1.0",
     "anthropic>=0.25",
@@ -255,6 +256,7 @@ llama-cpp-python = "llama_cpp"
 "discord.py" = "discord"
 slack-sdk = "slack_sdk"
 weaviate-client = "weaviate"
+atlassian-python-api = "atlassian"
 
 [tool.deptry.per_rule_ignores]
 DEP001 = ["sqlalchemy", "pydantic", "aiohttp", "opentelemetry", "whisper", "botocore", "aiomcache", "nest_asyncio", "huggingface_hub", "serpapi", "weaviate"]

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -147,6 +147,7 @@ from .llm.multimodal import AudioContent, ImageContent, MultimodalMessage
 from .llm.structured import generate_structured
 from .loaders.arxiv import ArXivLoader
 from .loaders.base import Document
+from .loaders.confluence import ConfluenceLoader
 from .loaders.csv import CSVLoader
 from .loaders.directory import DirectoryLoader
 from .loaders.email import EmailLoader
@@ -320,6 +321,7 @@ __all__ = [
     "CSVLoader",
     "JSONLoader",
     "DirectoryLoader",
+    "ConfluenceLoader",
     "DocxLoader",
     "EmailLoader",
     "MarkdownLoader",

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "ArXivLoader",
     "AudioLoader",
     "CSVLoader",
+    "ConfluenceLoader",
     "DirectoryLoader",
     "DiscordLoader",
     "DocxLoader",
@@ -48,6 +49,7 @@ _LOADERS = {
     "SlackLoader": ".slack",
     "NotionLoader": ".notion",
     "WikipediaLoader": ".wikipedia",
+    "ConfluenceLoader": ".confluence",
 }
 
 

--- a/src/synapsekit/loaders/confluence.py
+++ b/src/synapsekit/loaders/confluence.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from .base import Document
+
+
+class ConfluenceLoader:
+    """Load pages from Atlassian Confluence."""
+
+    def __init__(
+        self,
+        url: str,
+        username: str,
+        api_token: str,
+        space_key: str | None = None,
+        page_id: str | None = None,
+        limit: int | None = None,
+    ) -> None:
+        if not space_key and not page_id:
+            raise ValueError("Either space_key or page_id must be provided")
+
+        self._url = url.rstrip("/")
+        self._username = username
+        self._api_token = api_token
+        self._space_key = space_key
+        self._page_id = page_id
+        self._limit = limit
+        self._confluence = None
+
+    def _init_client(self) -> Any:
+        if self._confluence is None:
+            try:
+                from atlassian import Confluence
+            except ImportError:
+                raise ImportError(
+                    "atlassian-python-api required: pip install synapsekit[confluence]"
+                ) from None
+            self._confluence = Confluence(
+                url=self._url, username=self._username, password=self._api_token
+            )
+        return self._confluence
+
+    def _convert_storage_to_text(self, storage_html: str) -> str:
+        """Convert Confluence storage format (HTML/XML) to plain text."""
+        try:
+            from bs4 import BeautifulSoup
+        except ImportError:
+            raise ImportError(
+                "beautifulsoup4 required: pip install synapsekit[confluence]"
+            ) from None
+
+        soup = BeautifulSoup(storage_html, "html.parser")
+        return str(soup.get_text(separator="\n", strip=True))
+
+    async def _fetch_page_content_async(self, page_id: str) -> dict[str, Any]:
+        """Fetch a single page with retries (async)."""
+        confluence = self._init_client()
+        max_retries = 3
+        retry_delay = 1
+
+        for attempt in range(max_retries):
+            try:
+                loop = asyncio.get_running_loop()
+                page: dict[str, Any] = await loop.run_in_executor(
+                    None,
+                    lambda: confluence.get_page_by_id(
+                        page_id=page_id,
+                        expand="body.storage,version,space,history.lastUpdated",
+                    ),
+                )
+                return page
+            except Exception as e:
+                error_msg = str(e).lower()
+                error_codes = ["401", "403", "404", "unauthorized", "forbidden"]
+                if any(x in error_msg for x in error_codes):
+                    raise RuntimeError(f"Failed to fetch page {page_id}: {e}") from e
+
+                if attempt < max_retries - 1:
+                    delay = retry_delay * (2**attempt)
+                    if "429" in error_msg or "rate limit" in error_msg:
+                        delay = min(delay, 60)
+                    await asyncio.sleep(delay)
+                else:
+                    raise RuntimeError(f"Failed to fetch page {page_id} after retries: {e}") from e
+        raise RuntimeError(f"Failed to fetch page {page_id}")
+
+    def _fetch_page_content_sync(self, page_id: str) -> dict[str, Any]:
+        """Fetch a single page with retries (sync)."""
+        confluence = self._init_client()
+        max_retries = 3
+        retry_delay = 1
+
+        for attempt in range(max_retries):
+            try:
+                page: dict[str, Any] = confluence.get_page_by_id(
+                    page_id=page_id,
+                    expand="body.storage,version,space,history.lastUpdated",
+                )
+                return page
+            except Exception as e:
+                error_msg = str(e).lower()
+                error_codes = ["401", "403", "404", "unauthorized", "forbidden"]
+                if any(x in error_msg for x in error_codes):
+                    raise RuntimeError(f"Failed to fetch page {page_id}: {e}") from e
+
+                if attempt < max_retries - 1:
+                    delay = retry_delay * (2**attempt)
+                    if "429" in error_msg or "rate limit" in error_msg:
+                        delay = min(delay, 60)
+                    time.sleep(delay)
+                else:
+                    raise RuntimeError(f"Failed to fetch page {page_id} after retries: {e}") from e
+        raise RuntimeError(f"Failed to fetch page {page_id}")
+
+    async def _get_all_pages_in_space_async(self, space_key: str) -> list[dict[str, Any]]:
+        """Get all pages in a space with automatic pagination (async)."""
+        confluence = self._init_client()
+        all_pages = []
+        start = 0
+        limit = 100
+
+        while True:
+            try:
+                loop = asyncio.get_running_loop()
+
+                def _fetch_pages(start_val: int) -> Any:
+                    return confluence.get_all_pages_from_space(
+                        space=space_key,
+                        start=start_val,
+                        limit=limit,
+                        expand="body.storage,version,space,history.lastUpdated",
+                    )
+
+                result = await loop.run_in_executor(None, _fetch_pages, start)
+
+                if not result:
+                    break
+
+                all_pages.extend(result)
+
+                if self._limit and len(all_pages) >= self._limit:
+                    all_pages = all_pages[: self._limit]
+                    break
+
+                if len(result) < limit:
+                    break
+
+                start += limit
+
+            except Exception as e:
+                error_msg = str(e).lower()
+                error_codes = ["401", "403", "404", "unauthorized", "forbidden"]
+                if any(x in error_msg for x in error_codes):
+                    raise RuntimeError(f"Failed to fetch pages from space {space_key}: {e}") from e
+                raise RuntimeError(f"Error fetching pages from space {space_key}: {e}") from e
+
+        return all_pages
+
+    def _get_all_pages_in_space_sync(self, space_key: str) -> list[dict[str, Any]]:
+        """Get all pages in a space with automatic pagination (sync)."""
+        confluence = self._init_client()
+        all_pages = []
+        start = 0
+        limit = 100
+
+        while True:
+            try:
+                result = confluence.get_all_pages_from_space(
+                    space=space_key,
+                    start=start,
+                    limit=limit,
+                    expand="body.storage,version,space,history.lastUpdated",
+                )
+
+                if not result:
+                    break
+
+                all_pages.extend(result)
+
+                if self._limit and len(all_pages) >= self._limit:
+                    all_pages = all_pages[: self._limit]
+                    break
+
+                if len(result) < limit:
+                    break
+
+                start += limit
+
+            except Exception as e:
+                error_msg = str(e).lower()
+                error_codes = ["401", "403", "404", "unauthorized", "forbidden"]
+                if any(x in error_msg for x in error_codes):
+                    raise RuntimeError(f"Failed to fetch pages from space {space_key}: {e}") from e
+                raise RuntimeError(f"Error fetching pages from space {space_key}: {e}") from e
+
+        return all_pages
+
+    def _page_to_document(self, page: dict[str, Any]) -> Document:
+        """Convert a Confluence page to a Document."""
+        # Extract page body
+        body_storage = page.get("body", {}).get("storage", {}).get("value", "")
+        text = self._convert_storage_to_text(body_storage)
+
+        # Extract metadata
+        metadata = {
+            "source": "confluence",
+            "title": page.get("title", ""),
+            "page_id": page.get("id", ""),
+            "space": page.get("space", {}).get("key", ""),
+            "url": f"{self._url}{page.get('_links', {}).get('webui', '')}",
+            "version": page.get("version", {}).get("number", ""),
+        }
+
+        # Add author if available
+        if "history" in page:
+            last_updated = page["history"].get("lastUpdated", {})
+            if last_updated:
+                metadata["author"] = last_updated.get("by", {}).get("displayName", "")
+                metadata["last_modified"] = last_updated.get("when", "")
+
+        return Document(text=text, metadata=metadata)
+
+    async def aload(self) -> list[Document]:
+        """Load pages from Confluence and return as Documents (async)."""
+        if self._page_id:
+            page = await self._fetch_page_content_async(self._page_id)
+            return [self._page_to_document(page)]
+
+        pages = await self._get_all_pages_in_space_async(
+            self._space_key  # type: ignore[arg-type]
+        )
+        return [self._page_to_document(page) for page in pages]
+
+    def load(self) -> list[Document]:
+        """Load pages from Confluence and return as Documents (sync)."""
+        if self._page_id:
+            page = self._fetch_page_content_sync(self._page_id)
+            return [self._page_to_document(page)]
+
+        pages = self._get_all_pages_in_space_sync(
+            self._space_key  # type: ignore[arg-type]
+        )
+        return [self._page_to_document(page) for page in pages]

--- a/tests/loaders/test_confluence_loader.py
+++ b/tests/loaders/test_confluence_loader.py
@@ -1,0 +1,436 @@
+"""Tests for ConfluenceLoader."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapsekit.loaders.confluence import ConfluenceLoader
+
+
+class TestConfluenceLoader:
+    def test_requires_space_key_or_page_id(self):
+        with pytest.raises(ValueError, match="Either space_key or page_id"):
+            ConfluenceLoader(
+                url="https://test.atlassian.net",
+                username="user@example.com",
+                api_token="token",
+            )
+
+    def test_import_error_without_atlassian_api(self):
+        with patch.dict("sys.modules", {"atlassian": None}):
+            loader = ConfluenceLoader(
+                url="https://test.atlassian.net",
+                username="user@example.com",
+                api_token="token",
+                page_id="123",
+            )
+            with pytest.raises(ImportError, match="atlassian-python-api"):
+                loader.load()
+
+    def test_load_single_page(self):
+        mock_confluence_instance = MagicMock()
+        mock_page = {
+            "id": "123",
+            "title": "Test Page",
+            "body": {"storage": {"value": "<p>Test content</p>"}},
+            "space": {"key": "TEST"},
+            "version": {"number": 1},
+            "_links": {"webui": "/spaces/TEST/pages/123"},
+            "history": {
+                "lastUpdated": {
+                    "by": {"displayName": "John Doe"},
+                    "when": "2024-01-01T00:00:00Z",
+                }
+            },
+        }
+        mock_confluence_instance.get_page_by_id.return_value = mock_page
+
+        mock_confluence_class = MagicMock(return_value=mock_confluence_instance)
+        mock_atlassian = MagicMock()
+        mock_atlassian.Confluence = mock_confluence_class
+
+        mock_soup = MagicMock()
+        mock_soup.get_text.return_value = "Test content"
+        mock_bs4 = MagicMock()
+        mock_bs4.BeautifulSoup.return_value = mock_soup
+
+        with patch.dict("sys.modules", {"atlassian": mock_atlassian, "bs4": mock_bs4}):
+            loader = ConfluenceLoader(
+                url="https://test.atlassian.net",
+                username="user@example.com",
+                api_token="token",
+                page_id="123",
+            )
+            docs = loader.load()
+
+        assert len(docs) == 1
+        assert docs[0].text == "Test content"
+        assert docs[0].metadata["title"] == "Test Page"
+        assert docs[0].metadata["page_id"] == "123"
+        assert docs[0].metadata["space"] == "TEST"
+        assert docs[0].metadata["source"] == "confluence"
+        assert docs[0].metadata["version"] == 1
+        assert docs[0].metadata["author"] == "John Doe"
+        assert "test.atlassian.net" in docs[0].metadata["url"]
+
+    @pytest.mark.asyncio
+    async def test_aload_single_page(self):
+        mock_confluence_instance = MagicMock()
+        mock_page = {
+            "id": "123",
+            "title": "Test Page Async",
+            "body": {"storage": {"value": "<p>Async content</p>"}},
+            "space": {"key": "TEST"},
+            "version": {"number": 1},
+            "_links": {"webui": "/spaces/TEST/pages/123"},
+            "history": {"lastUpdated": {}},
+        }
+        mock_confluence_instance.get_page_by_id.return_value = mock_page
+
+        mock_confluence_class = MagicMock(return_value=mock_confluence_instance)
+        mock_atlassian = MagicMock()
+        mock_atlassian.Confluence = mock_confluence_class
+
+        mock_soup = MagicMock()
+        mock_soup.get_text.return_value = "Async content"
+        mock_bs4 = MagicMock()
+        mock_bs4.BeautifulSoup.return_value = mock_soup
+
+        with patch.dict("sys.modules", {"atlassian": mock_atlassian, "bs4": mock_bs4}):
+            loader = ConfluenceLoader(
+                url="https://test.atlassian.net",
+                username="user@example.com",
+                api_token="token",
+                page_id="123",
+            )
+            docs = await loader.aload()
+
+        assert len(docs) == 1
+        assert docs[0].text == "Async content"
+        assert docs[0].metadata["title"] == "Test Page Async"
+
+    def test_load_space_pages(self):
+        mock_confluence_instance = MagicMock()
+        mock_pages = [
+            {
+                "id": "1",
+                "title": "Page 1",
+                "body": {"storage": {"value": "<p>Content 1</p>"}},
+                "space": {"key": "DOCS"},
+                "version": {"number": 1},
+                "_links": {"webui": "/spaces/DOCS/pages/1"},
+                "history": {"lastUpdated": {}},
+            },
+            {
+                "id": "2",
+                "title": "Page 2",
+                "body": {"storage": {"value": "<p>Content 2</p>"}},
+                "space": {"key": "DOCS"},
+                "version": {"number": 2},
+                "_links": {"webui": "/spaces/DOCS/pages/2"},
+                "history": {"lastUpdated": {}},
+            },
+        ]
+        mock_confluence_instance.get_all_pages_from_space.return_value = mock_pages
+
+        mock_confluence_class = MagicMock(return_value=mock_confluence_instance)
+        mock_atlassian = MagicMock()
+        mock_atlassian.Confluence = mock_confluence_class
+
+        mock_soup = MagicMock()
+        mock_soup.get_text.side_effect = ["Content 1", "Content 2"]
+        mock_bs4 = MagicMock()
+        mock_bs4.BeautifulSoup.return_value = mock_soup
+
+        with patch.dict("sys.modules", {"atlassian": mock_atlassian, "bs4": mock_bs4}):
+            loader = ConfluenceLoader(
+                url="https://test.atlassian.net",
+                username="user@example.com",
+                api_token="token",
+                space_key="DOCS",
+            )
+            docs = loader.load()
+
+        assert len(docs) == 2
+        assert docs[0].text == "Content 1"
+        assert docs[1].text == "Content 2"
+        assert docs[0].metadata["title"] == "Page 1"
+        assert docs[1].metadata["title"] == "Page 2"
+
+    @pytest.mark.asyncio
+    async def test_aload_space_pages(self):
+        mock_confluence_instance = MagicMock()
+        mock_pages = [
+            {
+                "id": "1",
+                "title": "Async Page 1",
+                "body": {"storage": {"value": "<p>Async Content 1</p>"}},
+                "space": {"key": "DOCS"},
+                "version": {"number": 1},
+                "_links": {"webui": "/spaces/DOCS/pages/1"},
+                "history": {"lastUpdated": {}},
+            },
+        ]
+        mock_confluence_instance.get_all_pages_from_space.return_value = mock_pages
+
+        mock_confluence_class = MagicMock(return_value=mock_confluence_instance)
+        mock_atlassian = MagicMock()
+        mock_atlassian.Confluence = mock_confluence_class
+
+        mock_soup = MagicMock()
+        mock_soup.get_text.return_value = "Async Content 1"
+        mock_bs4 = MagicMock()
+        mock_bs4.BeautifulSoup.return_value = mock_soup
+
+        with patch.dict("sys.modules", {"atlassian": mock_atlassian, "bs4": mock_bs4}):
+            loader = ConfluenceLoader(
+                url="https://test.atlassian.net",
+                username="user@example.com",
+                api_token="token",
+                space_key="DOCS",
+            )
+            docs = await loader.aload()
+
+        assert len(docs) == 1
+        assert docs[0].text == "Async Content 1"
+
+    def test_pagination(self):
+        mock_confluence_instance = MagicMock()
+
+        first_batch = [
+            {
+                "id": str(i),
+                "title": f"Page {i}",
+                "body": {"storage": {"value": f"<p>Content {i}</p>"}},
+                "space": {"key": "DOCS"},
+                "version": {"number": 1},
+                "_links": {"webui": f"/pages/{i}"},
+                "history": {"lastUpdated": {}},
+            }
+            for i in range(100)
+        ]
+        second_batch = [
+            {
+                "id": "100",
+                "title": "Page 100",
+                "body": {"storage": {"value": "<p>Last page</p>"}},
+                "space": {"key": "DOCS"},
+                "version": {"number": 1},
+                "_links": {"webui": "/pages/100"},
+                "history": {"lastUpdated": {}},
+            }
+        ]
+
+        mock_confluence_instance.get_all_pages_from_space.side_effect = [
+            first_batch,
+            second_batch,
+        ]
+
+        mock_confluence_class = MagicMock(return_value=mock_confluence_instance)
+        mock_atlassian = MagicMock()
+        mock_atlassian.Confluence = mock_confluence_class
+
+        mock_soup = MagicMock()
+        mock_soup.get_text.side_effect = [f"Content {i}" for i in range(101)]
+        mock_bs4 = MagicMock()
+        mock_bs4.BeautifulSoup.return_value = mock_soup
+
+        with patch.dict("sys.modules", {"atlassian": mock_atlassian, "bs4": mock_bs4}):
+            loader = ConfluenceLoader(
+                url="https://test.atlassian.net",
+                username="user@example.com",
+                api_token="token",
+                space_key="DOCS",
+            )
+            docs = loader.load()
+
+        assert len(docs) == 101
+        assert mock_confluence_instance.get_all_pages_from_space.call_count == 2
+
+    def test_empty_space(self):
+        mock_confluence_instance = MagicMock()
+        mock_confluence_instance.get_all_pages_from_space.return_value = []
+
+        mock_confluence_class = MagicMock(return_value=mock_confluence_instance)
+        mock_atlassian = MagicMock()
+        mock_atlassian.Confluence = mock_confluence_class
+
+        mock_bs4 = MagicMock()
+
+        with patch.dict("sys.modules", {"atlassian": mock_atlassian, "bs4": mock_bs4}):
+            loader = ConfluenceLoader(
+                url="https://test.atlassian.net",
+                username="user@example.com",
+                api_token="token",
+                space_key="EMPTY",
+            )
+            docs = loader.load()
+
+        assert docs == []
+
+    def test_limit_parameter(self):
+        mock_confluence_instance = MagicMock()
+        mock_pages = [
+            {
+                "id": str(i),
+                "title": f"Page {i}",
+                "body": {"storage": {"value": f"<p>Content {i}</p>"}},
+                "space": {"key": "DOCS"},
+                "version": {"number": 1},
+                "_links": {"webui": f"/pages/{i}"},
+                "history": {"lastUpdated": {}},
+            }
+            for i in range(150)
+        ]
+        mock_confluence_instance.get_all_pages_from_space.return_value = mock_pages
+
+        mock_confluence_class = MagicMock(return_value=mock_confluence_instance)
+        mock_atlassian = MagicMock()
+        mock_atlassian.Confluence = mock_confluence_class
+
+        mock_soup = MagicMock()
+        mock_soup.get_text.side_effect = [f"Content {i}" for i in range(10)]
+        mock_bs4 = MagicMock()
+        mock_bs4.BeautifulSoup.return_value = mock_soup
+
+        with patch.dict("sys.modules", {"atlassian": mock_atlassian, "bs4": mock_bs4}):
+            loader = ConfluenceLoader(
+                url="https://test.atlassian.net",
+                username="user@example.com",
+                api_token="token",
+                space_key="DOCS",
+                limit=10,
+            )
+            docs = loader.load()
+
+        assert len(docs) == 10
+
+    def test_html_to_text_conversion(self):
+        pytest.importorskip("bs4")
+
+        mock_confluence_instance = MagicMock()
+        mock_page = {
+            "id": "1",
+            "title": "Rich Content",
+            "body": {
+                "storage": {
+                    "value": """
+                    <h1>Heading</h1>
+                    <p>Paragraph with <strong>bold</strong> and <em>italic</em></p>
+                    <ul>
+                        <li>Item 1</li>
+                        <li>Item 2</li>
+                    </ul>
+                    <a href="http://example.com">Link</a>
+                    """
+                }
+            },
+            "space": {"key": "TEST"},
+            "version": {"number": 1},
+            "_links": {"webui": "/pages/1"},
+            "history": {"lastUpdated": {}},
+        }
+        mock_confluence_instance.get_page_by_id.return_value = mock_page
+
+        mock_confluence_class = MagicMock(return_value=mock_confluence_instance)
+        mock_atlassian = MagicMock()
+        mock_atlassian.Confluence = mock_confluence_class
+
+        with patch.dict("sys.modules", {"atlassian": mock_atlassian}):
+            loader = ConfluenceLoader(
+                url="https://test.atlassian.net",
+                username="user@example.com",
+                api_token="token",
+                page_id="1",
+            )
+            docs = loader.load()
+
+        text = docs[0].text
+        assert "Heading" in text
+        assert "Paragraph" in text
+        assert "Item 1" in text
+        assert "Link" in text
+        assert "<h1>" not in text
+        assert "<p>" not in text
+
+    def test_url_trailing_slash_handling(self):
+        mock_confluence_instance = MagicMock()
+        mock_page = {
+            "id": "1",
+            "title": "Test",
+            "body": {"storage": {"value": "<p>Test</p>"}},
+            "space": {"key": "TEST"},
+            "version": {"number": 1},
+            "_links": {"webui": "/pages/1"},
+            "history": {"lastUpdated": {}},
+        }
+        mock_confluence_instance.get_page_by_id.return_value = mock_page
+
+        mock_confluence_class = MagicMock(return_value=mock_confluence_instance)
+        mock_atlassian = MagicMock()
+        mock_atlassian.Confluence = mock_confluence_class
+
+        mock_soup = MagicMock()
+        mock_soup.get_text.return_value = "Test"
+        mock_bs4 = MagicMock()
+        mock_bs4.BeautifulSoup.return_value = mock_soup
+
+        with patch.dict("sys.modules", {"atlassian": mock_atlassian, "bs4": mock_bs4}):
+            loader = ConfluenceLoader(
+                url="https://test.atlassian.net/",
+                username="user@example.com",
+                api_token="token",
+                page_id="1",
+            )
+            docs = loader.load()
+
+        assert "https://test.atlassian.net/pages/1" in docs[0].metadata["url"]
+        assert "//" not in docs[0].metadata["url"].replace("https://", "")
+
+    def test_metadata_extraction(self):
+        mock_confluence_instance = MagicMock()
+        mock_page = {
+            "id": "999",
+            "title": "Metadata Test",
+            "body": {"storage": {"value": "<p>Content</p>"}},
+            "space": {"key": "META"},
+            "version": {"number": 5},
+            "_links": {"webui": "/spaces/META/pages/999/Metadata+Test"},
+            "history": {
+                "lastUpdated": {
+                    "by": {"displayName": "Jane Smith"},
+                    "when": "2024-12-01T10:30:00Z",
+                }
+            },
+        }
+        mock_confluence_instance.get_page_by_id.return_value = mock_page
+
+        mock_confluence_class = MagicMock(return_value=mock_confluence_instance)
+        mock_atlassian = MagicMock()
+        mock_atlassian.Confluence = mock_confluence_class
+
+        mock_soup = MagicMock()
+        mock_soup.get_text.return_value = "Content"
+        mock_bs4 = MagicMock()
+        mock_bs4.BeautifulSoup.return_value = mock_soup
+
+        with patch.dict("sys.modules", {"atlassian": mock_atlassian, "bs4": mock_bs4}):
+            loader = ConfluenceLoader(
+                url="https://company.atlassian.net",
+                username="user@example.com",
+                api_token="token",
+                page_id="999",
+            )
+            docs = loader.load()
+
+        metadata = docs[0].metadata
+        assert metadata["source"] == "confluence"
+        assert metadata["title"] == "Metadata Test"
+        assert metadata["page_id"] == "999"
+        assert metadata["space"] == "META"
+        assert metadata["version"] == 5
+        assert metadata["author"] == "Jane Smith"
+        assert metadata["last_modified"] == "2024-12-01T10:30:00Z"
+        assert "company.atlassian.net" in metadata["url"]


### PR DESCRIPTION
Fixes from the review of #444 by @Abhay-Mmmm:
- Restored CHANGELOG.md (was accidentally deleted)
- `get_event_loop()` → `get_running_loop()` (deprecated in 3.10+)
- Added `@pytest.mark.asyncio` to async test methods

All 11 tests pass.