### PR TITLE
fixed: discord badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Downloads](https://img.shields.io/pypi/dm/synapsekit?color=22c55e&logo=pypi&logoColor=white)](https://pypistats.org/packages/synapsekit)
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/synapsekit?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/synapsekit)
 [![Docs](https://img.shields.io/badge/docs-online-22c55e?logo=readthedocs&logoColor=white)](https://synapsekit.github.io/synapsekit-docs/)
-[![Discord](https://img.shields.io/discord/1489713020098842794?color=22c55e&label=discord&logo=discord&logoColor=white)](https://discord.gg/unn4cXXH)
+[![Discord](https://img.shields.io/discord/1488136255597182988?logo=discord&logoColor=white)](https://discord.gg/unn4cXXH)
 
 **[Documentation](https://synapsekit.github.io/synapsekit-docs/) · [Quickstart](https://synapsekit.github.io/synapsekit-docs/docs/getting-started/quickstart) · [API Reference](https://synapsekit.github.io/synapsekit-docs/docs/api/llm) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/unn4cXXH) · [Report a Bug](https://github.com/SynapseKit/SynapseKit/issues/new?template=bug_report.yml)**
 


### PR DESCRIPTION
## Summary

<img width="952" height="322" alt="image" src="https://github.com/user-attachments/assets/e7340d40-aac7-443e-9e4e-77ff707e5930" />

Closes #484 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / internal improvement
- [ ] Dependency / tooling update

## Changes

<!-- List the key changes made. -->

- Made the correct format for the discord badge from `https://shields.io/badges/discord`