### PR TITLE
feat(loaders): add SupabaseLoader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ gcs = ["google-cloud-storage>=2.0"]
 gdrive = ["google-api-python-client>=2.0", "google-auth>=2.0"]
 sql = ["sqlalchemy>=2.0"]
 slack = ["slack-sdk>=3.0"]
+supabase = ["supabase>=2.0"]
 notion = ["httpx>=0.27"]
 confluence = ["atlassian-python-api>=3.0", "beautifulsoup4>=4.12"]
 all = [

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "SQLLoader",
     "SlackLoader",
     "StringLoader",
+    "SupabaseLoader",
     "TextLoader",
     "VideoLoader",
     "WebLoader",
@@ -56,6 +57,7 @@ _LOADERS = {
     "NotionLoader": ".notion",
     "RSSLoader": ".rss",
     "SQLLoader": ".sql",
+    "SupabaseLoader": ".supabase",
     "WikipediaLoader": ".wikipedia",
     "ConfluenceLoader": ".confluence",
 }

--- a/src/synapsekit/loaders/supabase.py
+++ b/src/synapsekit/loaders/supabase.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from .base import Document
+
+
+class SupabaseLoader:
+    """Load data from a Supabase table."""
+
+    def __init__(
+        self,
+        table: str,
+        supabase_url: str | None = None,
+        supabase_key: str | None = None,
+        text_columns: list[str] | None = None,
+        metadata_columns: list[str] | None = None,
+    ) -> None:
+        self._table = table
+        self._supabase_url = supabase_url or os.environ.get("SUPABASE_URL")
+        self._supabase_key = supabase_key or os.environ.get("SUPABASE_KEY")
+        self._text_columns = text_columns
+        self._metadata_columns = metadata_columns
+
+        if not self._supabase_url or not self._supabase_key:
+            raise ValueError("supabase_url and supabase_key are required (or set via environment)")
+
+    def load(self) -> list[Document]:
+        try:
+            from supabase import Client, create_client
+        except ImportError:
+            raise ImportError("supabase required: pip install synapsekit[supabase]") from None
+
+        client: Client = create_client(self._supabase_url, self._supabase_key)
+
+        columns = "*"
+        if self._text_columns is not None and self._metadata_columns is not None:
+            columns = ",".join(self._text_columns + self._metadata_columns)
+        elif self._text_columns is not None:
+            columns = ",".join(self._text_columns)
+
+        response = client.table(self._table).select(columns).execute()
+        rows = response.data
+
+        docs: list[Document] = []
+        for i, row in enumerate(rows):
+            if self._text_columns:
+                text = "\n".join(f"{col}: {row.get(col, '')}" for col in self._text_columns)
+            else:
+                text = "\n".join(f"{k}: {v}" for k, v in row.items())
+
+            metadata: dict[str, Any] = {"table": self._table, "row": i}
+            if self._metadata_columns:
+                for col in self._metadata_columns:
+                    if col in row:
+                        metadata[col] = row[col]
+            else:
+                # Store all row data as metadata if text columns are specified and metadata columns aren't
+                if self._text_columns:
+                    metadata.update(row)
+
+            docs.append(Document(text=text, metadata=metadata))
+
+        return docs

--- a/tests/loaders/test_supabase_loader.py
+++ b/tests/loaders/test_supabase_loader.py
@@ -1,0 +1,104 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapsekit.loaders.supabase import SupabaseLoader
+
+
+def test_import_error_missing_supabase():
+    with patch.dict("sys.modules", {"supabase": None}):
+        loader = SupabaseLoader("users", supabase_url="http://url", supabase_key="key")
+        with pytest.raises(ImportError, match="supabase required"):
+            loader.load()
+
+
+def test_init_missing_credentials():
+    with patch.dict("os.environ", clear=True):
+        with pytest.raises(ValueError, match="supabase_url and supabase_key are required"):
+            SupabaseLoader("users")
+
+
+def test_init_credentials_from_env():
+    with patch.dict("os.environ", {"SUPABASE_URL": "env_url", "SUPABASE_KEY": "env_key"}):
+        loader = SupabaseLoader("users")
+        assert loader._supabase_url == "env_url"
+        assert loader._supabase_key == "env_key"
+
+
+@patch.dict("sys.modules", {"supabase": MagicMock()})
+def test_load_all_columns():
+    import sys
+
+    mock_create_client = sys.modules["supabase"].create_client
+
+    mock_client = MagicMock()
+    mock_create_client.return_value = mock_client
+    mock_select = mock_client.table.return_value.select.return_value
+    mock_execute = mock_select.execute.return_value
+    mock_execute.data = [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+
+    loader = SupabaseLoader("users", supabase_url="http://url", supabase_key="key")
+    docs = loader.load()
+
+    mock_client.table.assert_called_with("users")
+    mock_client.table.return_value.select.assert_called_with("*")
+    mock_select.execute.assert_called_once()
+
+    assert len(docs) == 2
+    assert docs[0].text == "id: 1\nname: Alice"
+    assert docs[0].metadata["table"] == "users"
+    assert docs[0].metadata["row"] == 0
+    assert docs[1].text == "id: 2\nname: Bob"
+
+
+@patch.dict("sys.modules", {"supabase": MagicMock()})
+def test_load_text_columns_only():
+    import sys
+
+    mock_create_client = sys.modules["supabase"].create_client
+
+    mock_client = MagicMock()
+    mock_create_client.return_value = mock_client
+    mock_execute = mock_client.table.return_value.select.return_value.execute.return_value
+    mock_execute.data = [{"id": 1, "title": "Doc1", "content": "Hello"}]
+
+    loader = SupabaseLoader(
+        "docs", supabase_url="http://url", supabase_key="key", text_columns=["title", "content"]
+    )
+    docs = loader.load()
+
+    mock_client.table.return_value.select.assert_called_with("title,content")
+
+    assert len(docs) == 1
+    assert docs[0].text == "title: Doc1\ncontent: Hello"
+    assert docs[0].metadata["id"] == 1
+    assert docs[0].metadata["table"] == "docs"
+
+
+@patch.dict("sys.modules", {"supabase": MagicMock()})
+def test_load_text_and_metadata_columns():
+    import sys
+
+    mock_create_client = sys.modules["supabase"].create_client
+
+    mock_client = MagicMock()
+    mock_create_client.return_value = mock_client
+    mock_execute = mock_client.table.return_value.select.return_value.execute.return_value
+    mock_execute.data = [{"id": 1, "title": "Doc1", "content": "Hello", "author": "Alice"}]
+
+    loader = SupabaseLoader(
+        "docs",
+        supabase_url="http://url",
+        supabase_key="key",
+        text_columns=["content"],
+        metadata_columns=["id", "author"],
+    )
+    docs = loader.load()
+
+    mock_client.table.return_value.select.assert_called_with("content,id,author")
+
+    assert len(docs) == 1
+    assert docs[0].text == "content: Hello"
+    assert docs[0].metadata["id"] == 1
+    assert docs[0].metadata["author"] == "Alice"
+    assert "title" not in docs[0].metadata


### PR DESCRIPTION
Closes #92

## Description
This PR adds \SupabaseLoader\ to fetch rows from a Supabase table. 
- Uses the optional \supabase\ python package.
- Supports picking specific \	ext_columns\ and mapping others to \metadata_columns\.
- Credentials can be passed as args or auto-loaded from environment variables \SUPABASE_URL\ and \SUPABASE_KEY\.

## Changes Made
- Added \src/synapsekit/loaders/supabase.py\
- Added \supabase\ to optional dependencies in \pyproject.toml\
- Exported loader via lazy map in \src/synapsekit/loaders/__init__.py\
- Added mocked tests covering missing dependency, missing credentials, and data loading filters.
- Ran tests and linting (ruff format + check) successfully.