### PR TITLE
fix(security): harden tools and loaders against injection, traversal, SSRF, and TOCTOU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ SynapseKit uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **`JiraLoader`** — load Jira issues via JQL queries; full Atlassian Document Format (ADF) parsing; pagination; rate-limit retry; async `aload()` via httpx; optional `limit`; `pip install synapsekit[jira]`
 - **`SupabaseLoader`** — load rows from a Supabase table as Documents; configurable text/metadata columns; env var auth (`SUPABASE_URL`, `SUPABASE_KEY`); `pip install synapsekit[supabase]`
 
+### Security
+
+- **SQL injection** — `SQLSchemaInspectionTool` now validates table names against `^[A-Za-z0-9_]+$` before interpolating into `PRAGMA table_info()`; closes #494
+- **Shell injection** — `ShellTool` switched from `create_subprocess_shell` to `create_subprocess_exec` with `shlex.split()`; allowlist now checked against the actual binary (`argv[0]`) instead of a whitespace split; closes #495
+- **Path traversal** — `FileReadTool` and `FileWriteTool` now accept an optional `base_dir`; all paths are resolved with `Path.resolve()` and checked to be within the sandbox before I/O; closes #496
+- **TOCTOU in VideoLoader** — replaced `tempfile.mktemp()` with `tempfile.NamedTemporaryFile(delete=False)` to eliminate the race window; closes #497
+- **SSRF** — `WebLoader` and `WebScraperTool` now validate URL scheme (must be `http`/`https`) and block requests to private/internal IP ranges (RFC 1918, loopback, link-local, IPv6 ULA); closes #498
+- **ReDoS** — `WebScraperTool` limits CSS selector length to 200 characters; closes #498
+
 ---
 
 ## [1.5.0] — 2026-04-07

--- a/src/synapsekit/agents/tools/file_read.py
+++ b/src/synapsekit/agents/tools/file_read.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from ..base import BaseTool, ToolResult
@@ -26,12 +27,18 @@ class FileReadTool(BaseTool):
         "required": ["path"],
     }
 
+    def __init__(self, base_dir: str | None = None) -> None:
+        self._base_dir = Path(base_dir).resolve() if base_dir else None
+
     async def run(self, path: str = "", encoding: str = "utf-8", **kwargs: Any) -> ToolResult:
         file_path = path or kwargs.get("input", "")
         if not file_path:
             return ToolResult(output="", error="No file path provided.")
         try:
-            with open(file_path, encoding=encoding) as f:
+            resolved = Path(file_path).resolve()
+            if self._base_dir is not None and not str(resolved).startswith(str(self._base_dir)):
+                return ToolResult(output="", error="Access denied: path is outside the allowed directory.")
+            with open(resolved, encoding=encoding) as f:
                 content = f.read()
             return ToolResult(output=content)
         except FileNotFoundError:

--- a/src/synapsekit/agents/tools/file_write.py
+++ b/src/synapsekit/agents/tools/file_write.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import os
+from pathlib import Path
 from typing import Any
 
 from ..base import BaseTool, ToolResult
@@ -28,6 +28,9 @@ class FileWriteTool(BaseTool):
         "required": ["path", "content"],
     }
 
+    def __init__(self, base_dir: str | None = None) -> None:
+        self._base_dir = Path(base_dir).resolve() if base_dir else None
+
     async def run(
         self,
         path: str = "",
@@ -39,12 +42,14 @@ class FileWriteTool(BaseTool):
             return ToolResult(output="", error="No file path provided.")
 
         try:
-            parent = os.path.dirname(path)
-            if parent:
-                os.makedirs(parent, exist_ok=True)
+            resolved = Path(path).resolve()
+            if self._base_dir is not None and not str(resolved).startswith(str(self._base_dir)):
+                return ToolResult(output="", error="Access denied: path is outside the allowed directory.")
+
+            resolved.parent.mkdir(parents=True, exist_ok=True)
 
             mode = "a" if append else "w"
-            with open(path, mode, encoding="utf-8") as f:
+            with open(resolved, mode, encoding="utf-8") as f:
                 f.write(content)
 
             action = "Appended to" if append else "Written to"

--- a/src/synapsekit/agents/tools/shell.py
+++ b/src/synapsekit/agents/tools/shell.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import shlex
 from typing import Any
 
 from ..base import BaseTool, ToolResult
@@ -40,17 +41,23 @@ class ShellTool(BaseTool):
         if not target:
             return ToolResult(output="", error="No command provided.")
 
-        if self.allowed_commands is not None:
-            base_cmd = target.split()[0]
-            if base_cmd not in self.allowed_commands:
-                return ToolResult(
-                    output="",
-                    error=f"Command {base_cmd!r} is not in the allowed list.",
-                )
+        try:
+            argv = shlex.split(target)
+        except ValueError as e:
+            return ToolResult(output="", error=f"Invalid command: {e}")
+
+        if not argv:
+            return ToolResult(output="", error="No command provided.")
+
+        if self.allowed_commands is not None and argv[0] not in self.allowed_commands:
+            return ToolResult(
+                output="",
+                error=f"Command {argv[0]!r} is not in the allowed list.",
+            )
 
         try:
-            proc = await asyncio.create_subprocess_shell(
-                target,
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )

--- a/src/synapsekit/agents/tools/sql_schema.py
+++ b/src/synapsekit/agents/tools/sql_schema.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import re
 import sqlite3
 from typing import Any
 
 from ..base import BaseTool, ToolResult
+
+_TABLE_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
 
 class SQLSchemaInspectionTool(BaseTool):
@@ -49,6 +52,8 @@ class SQLSchemaInspectionTool(BaseTool):
             conn.close()
 
     def _describe_table_sqlite(self, table_name: str) -> list[dict[str, Any]]:
+        if not _TABLE_NAME_RE.match(table_name):
+            raise ValueError(f"Invalid table name: {table_name!r}")
         conn = sqlite3.connect(self._connection_string)
         try:
             rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()

--- a/src/synapsekit/agents/tools/web_scraper.py
+++ b/src/synapsekit/agents/tools/web_scraper.py
@@ -1,8 +1,37 @@
 from __future__ import annotations
 
+import ipaddress
+import socket
 from typing import Any
+from urllib.parse import urlparse
 
 from ..base import BaseTool, ToolResult
+
+_PRIVATE_NETS = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+]
+_MAX_CSS_SELECTOR_LEN = 200
+
+
+def _validate_url(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"URL scheme {parsed.scheme!r} is not allowed; use http or https.")
+    host = parsed.hostname or ""
+    if not host:
+        raise ValueError("URL has no hostname.")
+    try:
+        addr = ipaddress.ip_address(socket.gethostbyname(host))
+    except (socket.gaierror, ValueError):
+        return
+    if any(addr in net for net in _PRIVATE_NETS):
+        raise ValueError(f"Requests to private/internal addresses are not allowed: {host!r}")
 
 
 class WebScraperTool(BaseTool):
@@ -46,6 +75,10 @@ class WebScraperTool(BaseTool):
             element.decompose()
 
         if css_selector:
+            if len(css_selector) > _MAX_CSS_SELECTOR_LEN:
+                raise ValueError(
+                    f"CSS selector exceeds maximum length of {_MAX_CSS_SELECTOR_LEN} characters."
+                )
             elements = soup.select(css_selector)
             if not elements:
                 return ""
@@ -67,6 +100,11 @@ class WebScraperTool(BaseTool):
         target_url = url or kwargs.get("input", "")
         if not target_url:
             return ToolResult(output="", error="No URL provided.")
+
+        try:
+            _validate_url(target_url)
+        except ValueError as e:
+            return ToolResult(output="", error=str(e))
 
         try:
             async with httpx.AsyncClient() as client:

--- a/src/synapsekit/loaders/video.py
+++ b/src/synapsekit/loaders/video.py
@@ -137,4 +137,7 @@ class VideoLoader:
         suffix = ".wav"
         if self._keep_audio:
             return self._path.with_suffix(suffix)
-        return Path(tempfile.mktemp(suffix=suffix, prefix="synapsekit_audio_"))
+        with tempfile.NamedTemporaryFile(
+            suffix=suffix, prefix="synapsekit_audio_", delete=False
+        ) as fd:
+            return Path(fd.name)

--- a/src/synapsekit/loaders/web.py
+++ b/src/synapsekit/loaders/web.py
@@ -1,12 +1,42 @@
 from __future__ import annotations
 
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
 from .base import Document
+
+_PRIVATE_NETS = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+]
+
+
+def _validate_url(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"URL scheme {parsed.scheme!r} is not allowed; use http or https.")
+    host = parsed.hostname or ""
+    if not host:
+        raise ValueError("URL has no hostname.")
+    try:
+        addr = ipaddress.ip_address(socket.gethostbyname(host))
+    except (socket.gaierror, ValueError):
+        return
+    if any(addr in net for net in _PRIVATE_NETS):
+        raise ValueError(f"Requests to private/internal addresses are not allowed: {host!r}")
 
 
 class WebLoader:
     """Fetch a URL and return its text content as a Document."""
 
     def __init__(self, url: str) -> None:
+        _validate_url(url)
         self._url = url
 
     def _parse(self, html: str) -> str:


### PR DESCRIPTION
## Summary

- **SQL injection** (`sql_schema.py`) — validate table name against `^[A-Za-z0-9_]+$` before PRAGMA interpolation; closes #494
- **Shell injection** (`shell.py`) — switch from `create_subprocess_shell` to `create_subprocess_exec` + `shlex.split()`; allowlist now enforced on `argv[0]` instead of whitespace split; closes #495
- **Path traversal** (`file_read.py`, `file_write.py`) — add optional `base_dir`; all paths resolved with `Path.resolve()` and checked to be within the sandbox before any I/O; closes #496
- **TOCTOU tempfile** (`video.py`) — replace deprecated `tempfile.mktemp()` with `NamedTemporaryFile(delete=False)` to eliminate race window; closes #497
- **SSRF** (`web.py`, `web_scraper.py`) — validate URL scheme (`http`/`https` only) and block requests to private/internal IP ranges (RFC 1918, loopback, link-local, IPv6 ULA); closes #498
- **ReDoS** (`web_scraper.py`) — limit CSS selector length to 200 characters; closes #498

## Test plan

- [x] All 1752 existing tests pass (`1752 passed, 48 skipped`)
- [x] Ruff clean on all modified files
- [x] No architecture changes — same public APIs, just input validation hardening