### PR TITLE
hotfix: Errors while testing in Windows11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,10 @@ packages = ["src/synapsekit"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+# Windows asyncio transport cleanup warnings are harmless GC artifacts
+filterwarnings = [
+    "ignore::pytest.PytestUnraisableExceptionWarning",
+]
 
 [tool.ruff]
 target-version = "py310"

--- a/src/synapsekit/agents/tools/shell.py
+++ b/src/synapsekit/agents/tools/shell.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import platform
 import shlex
 from typing import Any
 
@@ -56,14 +57,27 @@ class ShellTool(BaseTool):
             )
 
         try:
-            proc = await asyncio.create_subprocess_exec(
-                *argv,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
+            # On Windows, use shell=True to support builtins like echo, dir, etc.
+            if platform.system() == "Windows":
+                proc = await asyncio.create_subprocess_shell(
+                    target,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+            else:
+                proc = await asyncio.create_subprocess_exec(
+                    *argv,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=self.timeout)
             output = stdout.decode() if stdout else ""
             err = stderr.decode() if stderr else ""
+
+            # Ensure subprocess is fully cleaned up
+            if proc.returncode is None:
+                proc.kill()
+                await proc.wait()
 
             if proc.returncode != 0:
                 return ToolResult(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,2 @@
 # Shared test fixtures live here.
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,1 @@
 # Shared test fixtures live here.
-

--- a/uv.lock
+++ b/uv.lock
@@ -7378,7 +7378,7 @@ wheels = [
 
 [[package]]
 name = "synapsekit"
-version = "1.5.1"
+version = "1.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Make `ShellTool` cross-platform compatible by using `create_subprocess_shell` on Windows (supports shell builtins like `echo`, `dir`) while keeping `create_subprocess_exec` on Unix. Also silences harmless Windows asyncio transport cleanup warnings in tests.

Closes #502 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Dependency / tooling update

## Changes

- **`src/synapsekit/agents/tools/shell.py`:**
  - Use `asyncio.create_subprocess_shell()` on Windows to support shell builtins (`echo`, `dir`, etc.) that don't exist as standalone executables
  - Keep `asyncio.create_subprocess_exec()` on Unix/Linux/macOS for direct process execution
  - Add subprocess cleanup logic to prevent orphaned processes

- **`pyproject.toml`:**
  - Add `filterwarnings` to ignore `PytestUnraisableExceptionWarning` during tests (Windows-only asyncio GC artifact — see note below)

## Note for Maintainer

The `filterwarnings` change suppresses warnings like:
- PytestUnraisableExceptionWarning: Exception ignored in: <function _ProactorBasePipeTransport.del>
- ValueError: I/O operation on closed pipe
- RuntimeError: Event loop is closed

These are a known Windows asyncio proactor loop quirk they happen in `__del__` during garbage collection **after** the event loop closes. They don't indicate real errors or resource leaks (transports *are* being cleaned up, just in the wrong order).

**I'm happy to explore a different approach if you prefer:**
1. Keep the warnings as-is (tests still pass, just noisy output on Windows)
2. Use a pytest hook in `conftest.py` to close transports before loop shutdown
3. Add a `try/except` wrapper in a custom pytest plugin
4. Something else you'd prefer?

Let me know and I'll adjust!

## Checklist

- [x] Tests pass locally (`1799 passed, 46 skipped` on Windows)
- [x] No regressions (same behavior on Unix/Linux)
- [x] Ready for review