### PR TITLE
feat(Loaders): Added Teams docs loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ excel = ["openpyxl>=3.1"]
 pptx = ["python-pptx>=0.6"]
 docx = ["python-docx>=1.0"]
 yaml = ["PyYAML>=6.0"]
+teams = ["httpx>=0.27"]
 http = ["aiohttp>=3.9"]
 search = ["duckduckgo-search>=6.0"]
 huggingface = ["huggingface-hub>=0.20"]
@@ -172,6 +173,7 @@ packages = ["src/synapsekit"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+addopts = "--tb=line"
 
 [tool.ruff]
 target-version = "py310"

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -168,6 +168,7 @@ from .loaders.markdown import MarkdownLoader
 from .loaders.pdf import PDFLoader
 from .loaders.rss import RSSLoader
 from .loaders.sql import SQLLoader
+from .loaders.teams import TeamsLoader
 from .loaders.text import StringLoader, TextLoader
 from .loaders.web import WebLoader
 from .loaders.wikipedia import WikipediaLoader
@@ -352,6 +353,7 @@ __all__ = [
     "MarkdownLoader",
     "SQLLoader",
     "SupabaseLoader",
+    "TeamsLoader",
     "WebLoader",
     "RSSLoader",
     "WikipediaLoader",
@@ -595,6 +597,7 @@ _LAZY_IMPORTS = {
     "DocxLoader": "loaders.docx",
     "ExcelLoader": "loaders.excel",
     "PowerPointLoader": "loaders.pptx",
+    "TeamsLoader": "loaders.teams",
     "YAMLLoader": "loaders.yaml_loader",
     "DiscordLoader": "loaders.discord",
     "XMLLoader": "loaders.xml_loader",

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     "SlackLoader",
     "StringLoader",
     "SupabaseLoader",
+    "TeamsLoader",
     "TextLoader",
     "VideoLoader",
     "WebLoader",
@@ -64,6 +65,7 @@ _LOADERS = {
     "RSSLoader": ".rss",
     "SQLLoader": ".sql",
     "SupabaseLoader": ".supabase",
+    "TeamsLoader": ".teams",
     "WikipediaLoader": ".wikipedia",
     "ConfluenceLoader": ".confluence",
 }

--- a/src/synapsekit/loaders/teams.py
+++ b/src/synapsekit/loaders/teams.py
@@ -1,0 +1,225 @@
+"""TeamsLoader — load messages from Microsoft Teams channels via Microsoft Graph API."""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from .base import Document
+
+if TYPE_CHECKING:
+    import httpx
+
+logger = logging.getLogger(__name__)
+
+_GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0"
+
+
+class TeamsLoader:
+    """Load messages from Microsoft Teams channels into Documents.
+
+    This loader uses the Microsoft Graph API to fetch messages from a specified
+    Teams channel. It handles pagination automatically and converts HTML message
+    content to plain text.
+
+    Prerequisites:
+        - A valid Microsoft Graph OAuth access token
+        - The token must have Channels.Read.All or similar permissions
+
+    Example::
+
+        loader = TeamsLoader(
+            access_token="eyJ0eXAiOiJKV1QiLCJhbGc...",
+            team_id="02bd9fd6-8f93-4758-87c3-1e7375baf356",
+            channel_id="19:09fc54a3141a45d0bc769cf506d2e079@thread.skype",
+            limit=100,
+        )
+        docs = loader.load()        # synchronous
+        # or
+        docs = await loader.aload()  # asynchronous
+    """
+
+    def __init__(
+        self,
+        access_token: str,
+        team_id: str,
+        channel_id: str,
+        limit: int | None = None,
+    ) -> None:
+        self.access_token = access_token
+        self.team_id = team_id
+        self.channel_id = channel_id
+        self.limit = limit
+
+    def load(self) -> list[Document]:
+        """Synchronously fetch messages and return them as Documents."""
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            return loop.run_until_complete(self.aload())
+        finally:
+            loop.close()
+
+    async def aload(self) -> list[Document]:
+        """Asynchronously fetch messages and return them as Documents."""
+        try:
+            import httpx
+        except ImportError:
+            raise ImportError("httpx required: pip install synapsekit[teams]") from None
+
+        headers = {
+            "Authorization": f"Bearer {self.access_token}",
+            "Accept": "application/json",
+        }
+
+        messages: list[dict[str, Any]] = []
+        url = f"{_GRAPH_BASE_URL}/teams/{self.team_id}/channels/{self.channel_id}/messages"
+
+        async with httpx.AsyncClient() as client:
+            while url:
+                response = await self._request_with_retry(client, url, headers)
+                if response is None:
+                    break
+
+                data = response.json()
+                batch = data.get("value", [])
+                messages.extend(batch)
+
+                if self.limit and len(messages) >= self.limit:
+                    messages = messages[: self.limit]
+                    break
+
+                # Handle pagination via @odata.nextLink
+                url = data.get("@odata.nextLink")
+
+        documents = []
+        for msg in messages:
+            text = self._extract_text(msg)
+            if not text:
+                continue
+
+            metadata = self._extract_metadata(msg)
+            documents.append(Document(text=text, metadata=metadata))
+
+        return documents
+
+    async def _request_with_retry(
+        self,
+        client: httpx.AsyncClient,
+        url: str,
+        headers: dict[str, str],
+    ) -> httpx.Response | None:
+        """Make HTTP request with exponential backoff retry for 429/5xx errors."""
+        max_retries = 3
+        base_delay = 1.0
+
+        for attempt in range(max_retries):
+            try:
+                response = await client.get(url, headers=headers, timeout=30.0)
+
+                if response.status_code == 200:
+                    return response
+
+                # Don't retry for auth/permission errors
+                if response.status_code in (401, 403, 404):
+                    logger.warning(
+                        "TeamsLoader: request failed with status %d - %s",
+                        response.status_code,
+                        response.text[:200] if response.text else "no content",
+                    )
+                    return None
+
+                # Retry for 429 (rate limit) or 5xx (server error)
+                if response.status_code == 429 or response.status_code >= 500:
+                    retry_after = response.headers.get("Retry-After")
+                    if retry_after:
+                        delay = float(retry_after)
+                    else:
+                        delay = base_delay * (2**attempt)
+
+                    logger.warning(
+                        "TeamsLoader: rate limited or server error (status %d), retrying in %.1fs (attempt %d/%d)",
+                        response.status_code,
+                        delay,
+                        attempt + 1,
+                        max_retries,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+
+                # Other errors - don't retry
+                logger.warning(
+                    "TeamsLoader: request failed with status %d - %s",
+                    response.status_code,
+                    response.text[:200] if response.text else "no content",
+                )
+                return None
+
+            except Exception as e:
+                # Handle httpx.RequestError and similar network errors
+                if attempt < max_retries - 1:
+                    delay = base_delay * (2**attempt)
+                    logger.warning(
+                        "TeamsLoader: request error %s, retrying in %.1fs (attempt %d/%d)",
+                        e,
+                        delay,
+                        attempt + 1,
+                        max_retries,
+                    )
+                    await asyncio.sleep(delay)
+                else:
+                    logger.error("TeamsLoader: request failed after %d retries: %s", max_retries, e)
+                    return None
+
+        return None
+
+    def _extract_text(self, message: dict[str, Any]) -> str:
+        """Extract and clean text from message body.
+
+        Microsoft Teams messages are in HTML format. This method extracts
+        the body.content field and strips HTML tags to produce plain text.
+        """
+        body = message.get("body", {})
+        if not body:
+            return ""
+
+        content = body.get("content", "")
+        if not content:
+            return ""
+
+        # Decode HTML entities first (e.g., &nbsp; → space)
+        text = html.unescape(content)
+
+        # Remove HTML tags using simple regex
+        # This handles common cases like <p>, <b>, <span>, etc.
+        text = re.sub(r"<[^>]+>", "", text)
+
+        # Clean up whitespace
+        text = re.sub(r"\s+", " ", text).strip()
+
+        return text
+
+    def _extract_metadata(self, message: dict[str, Any]) -> dict[str, Any]:
+        """Extract metadata from a Teams message."""
+        # Extract author
+        author = "unknown"
+        from_user = message.get("from", {})
+        if from_user:
+            user_info = from_user.get("user", {})
+            if user_info:
+                author = user_info.get("displayName", "unknown")
+
+        # Extract timestamp
+        timestamp = message.get("createdDateTime", "")
+
+        return {
+            "source": "teams",
+            "team_id": self.team_id,
+            "channel_id": self.channel_id,
+            "message_id": message.get("id", ""),
+            "author": author,
+            "timestamp": timestamp,
+        }

--- a/tests/loaders/test_teams_loader.py
+++ b/tests/loaders/test_teams_loader.py
@@ -1,0 +1,695 @@
+"""Tests for TeamsLoader."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from synapsekit.loaders.teams import TeamsLoader
+
+
+def _make_mock_response(status_code: int, json_data: dict | None = None, headers: dict | None = None) -> MagicMock:
+    """Create a mock httpx.Response object."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = headers or {}
+    response.text = ""
+    if json_data is not None:
+        response.json = MagicMock(return_value=json_data)
+    return response
+
+
+class TestTeamsLoaderValidation:
+    """Test TeamsLoader initialization and validation."""
+
+    def test_valid_construction(self):
+        """Test basic initialization."""
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+        assert loader.access_token == "test-token"
+        assert loader.team_id == "team-123"
+        assert loader.channel_id == "channel-456"
+        assert loader.limit is None
+
+    def test_custom_params(self):
+        """Test initialization with custom limit."""
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+            limit=50,
+        )
+        assert loader.limit == 50
+
+    def test_load_sync_wraps_aload(self):
+        """Test that load() wraps aload() synchronously."""
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+        expected = []
+        with patch.object(loader, "aload", new=AsyncMock(return_value=expected)):
+            result = loader.load()
+        assert result == expected
+
+
+class TestTeamsLoaderImport:
+    """Test import error handling."""
+
+    @pytest.mark.asyncio
+    async def test_missing_httpx_raises_import_error(self):
+        """Test that missing httpx raises ImportError."""
+        import sys
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+        with patch.dict(sys.modules, {"httpx": None}):
+            with pytest.raises(ImportError, match=r"httpx required"):
+                await loader.aload()
+
+
+class TestTeamsLoaderDocuments:
+    """Test document creation from Teams messages."""
+
+    @pytest.mark.asyncio
+    async def test_load_returns_documents(self):
+        """Test that messages are converted to documents."""
+        messages = [
+            {
+                "id": "msg-1",
+                "body": {"content": "<p>Hello from Teams</p>"},
+                "from": {"user": {"displayName": "John Doe"}},
+                "createdDateTime": "2024-01-01T10:00:00Z",
+            },
+            {
+                "id": "msg-2",
+                "body": {"content": "<p>Second message</p>"},
+                "from": {"user": {"displayName": "Jane Smith"}},
+                "createdDateTime": "2024-01-01T11:00:00Z",
+            },
+        ]
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=_make_mock_response(200, {"value": messages}))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert len(docs) == 2
+        assert docs[0].text == "Hello from Teams"
+        assert docs[1].text == "Second message"
+
+    @pytest.mark.asyncio
+    async def test_load_with_metadata(self):
+        """Test that metadata is correctly extracted."""
+        messages = [
+            {
+                "id": "msg-123",
+                "body": {"content": "<p>Test message</p>"},
+                "from": {"user": {"displayName": "Test User"}},
+                "createdDateTime": "2024-01-15T14:30:00Z",
+            },
+        ]
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-abc",
+            channel_id="channel-xyz",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=_make_mock_response(200, {"value": messages}))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert len(docs) == 1
+        meta = docs[0].metadata
+        assert meta["source"] == "teams"
+        assert meta["team_id"] == "team-abc"
+        assert meta["channel_id"] == "channel-xyz"
+        assert meta["message_id"] == "msg-123"
+        assert meta["author"] == "Test User"
+        assert meta["timestamp"] == "2024-01-15T14:30:00Z"
+
+    @pytest.mark.asyncio
+    async def test_load_skips_empty_messages(self):
+        """Test that empty messages are skipped."""
+        messages = [
+            {"id": "msg-1", "body": {"content": "<p>Valid message</p>"}},
+            {"id": "msg-2", "body": {"content": ""}},  # Empty content
+            {"id": "msg-3", "body": {}},  # Missing content
+            {"id": "msg-4", "body": {"content": "<p>   </p>"}},  # Whitespace only
+            {"id": "msg-5", "body": {"content": "<p>Another valid</p>"}},
+        ]
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=_make_mock_response(200, {"value": messages}))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert len(docs) == 2
+        assert docs[0].text == "Valid message"
+        assert docs[1].text == "Another valid"
+
+
+class TestTeamsLoaderHTMLStripping:
+    """Test HTML to plain text conversion."""
+
+    @pytest.mark.asyncio
+    async def test_simple_html_tags(self):
+        """Test stripping simple HTML tags."""
+        messages = [
+            {"id": "msg-1", "body": {"content": "<p>Hello <b>world</b></p>"}},
+        ]
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=_make_mock_response(200, {"value": messages}))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert docs[0].text == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_html_entities(self):
+        """Test decoding HTML entities."""
+        messages = [
+            {"id": "msg-1", "body": {"content": "<p>Hello &amp; welcome</p>"}},
+        ]
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=_make_mock_response(200, {"value": messages}))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert docs[0].text == "Hello & welcome"
+
+    @pytest.mark.asyncio
+    async def test_complex_html(self):
+        """Test stripping complex HTML with multiple nested tags."""
+        messages = [
+            {
+                "id": "msg-1",
+                "body": {
+                    "content": "<div><p>Hello <span style='color:red'>world</span>!</p><p>Second paragraph.</p></div>"
+                },
+            },
+        ]
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=_make_mock_response(200, {"value": messages}))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert docs[0].text == "Hello world!Second paragraph."
+
+    @pytest.mark.asyncio
+    async def test_html_with_mentions(self):
+        """Test handling HTML with user mentions."""
+        messages = [
+            {
+                "id": "msg-1",
+                "body": {
+                    "content": "<p>Hi <at>John Doe</at>, please review this.</p>"
+                },
+            },
+        ]
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=_make_mock_response(200, {"value": messages}))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert docs[0].text == "Hi John Doe, please review this."
+
+
+class TestTeamsLoaderPagination:
+    """Test pagination handling."""
+
+    @pytest.mark.asyncio
+    async def test_pagination_with_next_link(self):
+        """Test that pagination follows @odata.nextLink."""
+        first_batch = [
+            {"id": "msg-1", "body": {"content": "<p>Message 1</p>"}},
+            {"id": "msg-2", "body": {"content": "<p>Message 2</p>"}},
+        ]
+        second_batch = [
+            {"id": "msg-3", "body": {"content": "<p>Message 3</p>"}},
+            {"id": "msg-4", "body": {"content": "<p>Message 4</p>"}},
+        ]
+
+        call_count = 0
+
+        def create_response(url: str):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _make_mock_response(
+                    200,
+                    {
+                        "value": first_batch,
+                        "@odata.nextLink": "https://graph.microsoft.com/v1.0/next-page",
+                    },
+                )
+            else:
+                return _make_mock_response(200, {"value": second_batch})
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+
+            async def mock_get(url: str, **kwargs):
+                return create_response(url)
+
+            mock_client.get = mock_get
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert len(docs) == 4
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_pagination_respects_limit(self):
+        """Test that limit stops pagination early."""
+        first_batch = [
+            {"id": "msg-1", "body": {"content": "<p>Message 1</p>"}},
+            {"id": "msg-2", "body": {"content": "<p>Message 2</p>"}},
+            {"id": "msg-3", "body": {"content": "<p>Message 3</p>"}},
+        ]
+        second_batch = [
+            {"id": "msg-4", "body": {"content": "<p>Message 4</p>"}},
+        ]
+
+        call_count = 0
+
+        def create_response(url: str):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _make_mock_response(
+                    200,
+                    {
+                        "value": first_batch,
+                        "@odata.nextLink": "https://graph.microsoft.com/v1.0/next-page",
+                    },
+                )
+            else:
+                return _make_mock_response(200, {"value": second_batch})
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+            limit=4,
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+
+            async def mock_get(url: str, **kwargs):
+                return create_response(url)
+
+            mock_client.get = mock_get
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert len(docs) == 4
+        assert call_count == 2  # Second page fetched but only 1 message used
+
+
+class TestTeamsLoaderEdgeCases:
+    """Test edge cases and missing fields."""
+
+    @pytest.mark.asyncio
+    async def test_empty_response(self):
+        """Test handling empty response."""
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=_make_mock_response(200, {"value": []}))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert docs == []
+
+    @pytest.mark.asyncio
+    async def test_missing_author_uses_unknown(self):
+        """Test that missing author defaults to 'unknown'."""
+        messages = [
+            {
+                "id": "msg-1",
+                "body": {"content": "<p>Test</p>"},
+                "from": {},  # Missing user
+            },
+        ]
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=_make_mock_response(200, {"value": messages}))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert docs[0].metadata["author"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_missing_display_name_uses_unknown(self):
+        """Test that missing displayName defaults to 'unknown'."""
+        messages = [
+            {
+                "id": "msg-1",
+                "body": {"content": "<p>Test</p>"},
+                "from": {"user": {}},  # Missing displayName
+            },
+        ]
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=_make_mock_response(200, {"value": messages}))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert docs[0].metadata["author"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_missing_timestamp_empty_string(self):
+        """Test that missing timestamp is empty string."""
+        messages = [
+            {
+                "id": "msg-1",
+                "body": {"content": "<p>Test</p>"},
+                # No createdDateTime
+            },
+        ]
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=_make_mock_response(200, {"value": messages}))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert docs[0].metadata["timestamp"] == ""
+
+    @pytest.mark.asyncio
+    async def test_missing_body_handled(self):
+        """Test that missing body is handled gracefully."""
+        messages = [
+            {"id": "msg-1"},  # No body at all
+            {"id": "msg-2", "body": {"content": "<p>Valid</p>"}},
+        ]
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=_make_mock_response(200, {"value": messages}))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert len(docs) == 1
+        assert docs[0].text == "Valid"
+
+
+class TestTeamsLoaderRetry:
+    """Test retry logic for rate limiting and server errors."""
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_retry(self):
+        """Test retry on 429 rate limit response."""
+        call_count = 0
+
+        def create_response(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _make_mock_response(429, headers={"Retry-After": "0"})
+            else:
+                return _make_mock_response(
+                    200,
+                    {"value": [{"id": "msg-1", "body": {"content": "<p>Success</p>"}}]},
+                )
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(side_effect=create_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert len(docs) == 1
+        assert docs[0].text == "Success"
+        assert call_count == 2  # Retried once
+
+    @pytest.mark.asyncio
+    async def test_server_error_retry(self):
+        """Test retry on 5xx server error."""
+        call_count = 0
+
+        def create_response(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _make_mock_response(503)
+            else:
+                return _make_mock_response(
+                    200,
+                    {"value": [{"id": "msg-1", "body": {"content": "<p>Success</p>"}}]},
+                )
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(side_effect=create_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert len(docs) == 1
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_auth_error_no_retry(self):
+        """Test that 401 errors are not retried."""
+        call_count = 0
+
+        def create_response(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            response = _make_mock_response(401)
+            response.text = "Unauthorized"
+            return response
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(side_effect=create_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert docs == []
+        assert call_count == 1  # No retry
+
+    @pytest.mark.asyncio
+    async def test_forbidden_error_no_retry(self):
+        """Test that 403 errors are not retried."""
+        call_count = 0
+
+        def create_response(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            response = _make_mock_response(403)
+            response.text = "Forbidden"
+            return response
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(side_effect=create_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert docs == []
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_not_found_error_no_retry(self):
+        """Test that 404 errors are not retried."""
+        call_count = 0
+
+        def create_response(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            response = _make_mock_response(404)
+            response.text = "Not Found"
+            return response
+
+        loader = TeamsLoader(
+            access_token="test-token",
+            team_id="team-123",
+            channel_id="channel-456",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(side_effect=create_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            docs = await loader.aload()
+
+        assert docs == []
+        assert call_count == 1

--- a/tests/loaders/test_teams_loader.py
+++ b/tests/loaders/test_teams_loader.py
@@ -9,7 +9,9 @@ import pytest
 from synapsekit.loaders.teams import TeamsLoader
 
 
-def _make_mock_response(status_code: int, json_data: dict | None = None, headers: dict | None = None) -> MagicMock:
+def _make_mock_response(
+    status_code: int, json_data: dict | None = None, headers: dict | None = None
+) -> MagicMock:
     """Create a mock httpx.Response object."""
     response = MagicMock()
     response.status_code = status_code
@@ -269,9 +271,7 @@ class TestTeamsLoaderHTMLStripping:
         messages = [
             {
                 "id": "msg-1",
-                "body": {
-                    "content": "<p>Hi <at>John Doe</at>, please review this.</p>"
-                },
+                "body": {"content": "<p>Hi <at>John Doe</at>, please review this.</p>"},
             },
         ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -7378,7 +7378,7 @@ wheels = [
 
 [[package]]
 name = "synapsekit"
-version = "1.5.1"
+version = "1.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -7607,6 +7607,9 @@ supabase = [
 tavily = [
     { name = "tavily-python" },
 ]
+teams = [
+    { name = "httpx" },
+]
 vertex = [
     { name = "google-cloud-aiplatform" },
 ]
@@ -7707,6 +7710,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'jira'", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'minimax'", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'notion'", specifier = ">=0.27" },
+    { name = "httpx", marker = "extra == 'teams'", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'web'", specifier = ">=0.27" },
     { name = "huggingface-hub", marker = "extra == 'all'", specifier = ">=0.20" },
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.20" },
@@ -7769,7 +7773,7 @@ requires-dist = [
     { name = "youtube-search-python", marker = "extra == 'all'", specifier = ">=1.6" },
     { name = "youtube-search-python", marker = "extra == 'youtube'", specifier = ">=1.6" },
 ]
-provides-extras = ["openai", "anthropic", "semantic", "colbert", "pdf", "wikipedia", "arxiv", "html", "web", "chroma", "faiss", "qdrant", "pinecone", "weaviate", "milvus", "lancedb", "ollama", "ai21", "cohere", "mistral", "gemini", "bedrock", "gcal-tool", "aws-lambda", "rss", "groq", "audio", "video", "excel", "pptx", "docx", "yaml", "http", "search", "huggingface", "google-search", "tavily", "youtube", "mcp", "redis", "memcached", "vertex", "cloudflare", "aleph-alpha", "llamacpp", "ernie", "minimax", "serve", "postgres", "pgvector", "wolfram", "dynamodb", "discord", "gcs", "gdrive", "git", "gsheets", "jira", "sql", "slack", "supabase", "notion", "confluence", "all"]
+provides-extras = ["openai", "anthropic", "semantic", "colbert", "pdf", "wikipedia", "arxiv", "html", "web", "chroma", "faiss", "qdrant", "pinecone", "weaviate", "milvus", "lancedb", "ollama", "ai21", "cohere", "mistral", "gemini", "bedrock", "gcal-tool", "aws-lambda", "rss", "groq", "audio", "video", "excel", "pptx", "docx", "yaml", "teams", "http", "search", "huggingface", "google-search", "tavily", "youtube", "mcp", "redis", "memcached", "vertex", "cloudflare", "aleph-alpha", "llamacpp", "ernie", "minimax", "serve", "postgres", "pgvector", "wolfram", "dynamodb", "discord", "gcs", "gdrive", "git", "gsheets", "jira", "sql", "slack", "supabase", "notion", "confluence", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Add `TeamsLoader` to load messages from Microsoft Teams channels via the Microsoft Graph API. Supports automatic pagination, HTML-to-text conversion, retry logic for rate limits/server errors, and comprehensive edge-case handling.

Closes #51 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / internal improvement
- [ ] Dependency / tooling update

## Changes

- **`src/synapsekit/loaders/teams.py`:**
  - New `TeamsLoader` class that fetches messages from Microsoft Teams channels using the Microsoft Graph API
  - Supports both sync (`load()`) and async (`aload()`) interfaces
  - Automatic pagination via `@odata.nextLink`
  - HTML-to-plain-text conversion (strips tags, decodes entities)
  - Exponential backoff retry for 429 (rate limit) and 5xx (server error) responses
  - Graceful handling of missing fields (author → `"unknown"`, empty body, missing timestamps)

- **`tests/loaders/test_teams_loader.py`:**
  - 23 comprehensive tests covering:
    - Initialization and validation
    - Document creation and metadata extraction
    - HTML stripping (simple tags, entities, complex nested HTML, @mentions)
    - Pagination with `@odata.nextLink` and `limit` enforcement
    - Edge cases (empty responses, missing author/displayName/timestamp/body)
    - Retry logic (429 retry, 5xx retry, no-retry for 401/403/404)

- **`src/synapsekit/__init__.py`:**
  - Added `TeamsLoader` to package exports (direct import + lazy import)
  - Listed in `__all__` for public API

- **`pyproject.toml`:**
  - Added `teams` optional dependency group (requires `httpx`)

## Testing

- [x] All existing tests pass (`uv run pytest tests/ -q`)
- [x] New tests added for new behaviour (23 tests in `test_teams_loader.py`)
- [x] No API keys or secrets in the code