### PR TITLE
feat(eval): implement fine-tune data flywheel for EvalCI (#515)

### DIFF
--- a/examples/fine_tune_flywheel.py
+++ b/examples/fine_tune_flywheel.py
@@ -1,0 +1,37 @@
+"""EvalCI fine-tune flywheel example.
+
+Run evals first:
+    synapsekit test tests/evals --save baseline
+
+Then:
+    synapsekit eval export baseline --format openai --max-score 0.8 --output dataset.jsonl
+    synapsekit finetune submit dataset.jsonl --provider openai --base-model gpt-4o-mini
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from synapsekit.evaluation import EvalDataset, FineTuner
+
+
+async def main() -> None:
+    dataset = EvalDataset.from_snapshot("baseline")
+    weak = dataset.filter_score(max_score=0.8)
+    weak.export("dataset.jsonl", format="openai")
+
+    tuner = FineTuner(provider="openai", api_key="YOUR_OPENAI_API_KEY")
+    job = await tuner.submit(
+        dataset="dataset.jsonl",
+        base_model="gpt-4o-mini",
+        job_name="rag-improvement-v1",
+        n_epochs=3,
+    )
+    print("Submitted:", job)
+
+    final = await tuner.wait(job.id, timeout_s=7200, poll_interval_s=15)
+    print("Completed:", final)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/synapsekit/cli/eval.py
+++ b/src/synapsekit/cli/eval.py
@@ -1,0 +1,66 @@
+"""``synapsekit eval`` commands: report/export/compare."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+from ..evaluation.dataset import EvalDataset
+from ..evaluation.regression import EvalRegression
+from .test import _print_regression_report
+
+
+def run_eval(args: Any) -> None:
+    subcommand = getattr(args, "eval_command", None)
+
+    if subcommand == "report":
+        _run_report(args)
+        return
+
+    if subcommand == "export":
+        _run_export(args)
+        return
+
+    if subcommand == "compare":
+        _run_compare(args)
+        return
+
+    raise SystemExit("Missing eval subcommand. Use: report, export, or compare")
+
+
+def _run_report(args: Any) -> None:
+    dataset = EvalDataset.from_snapshot(args.snapshot, snapshot_dir=args.snapshot_dir)
+    scores = [r.score for r in dataset.records if r.score is not None]
+
+    print(f"Snapshot: {args.snapshot}")
+    print(f"Cases: {len(dataset)}")
+    if scores:
+        print(f"Mean score: {mean(scores):.4f}")
+        threshold = getattr(args, "threshold", None)
+        if threshold is not None:
+            weak = [r for r in dataset.records if r.score is not None and r.score < threshold]
+            print(f"Below {threshold:.2f}: {len(weak)}")
+            for rec in weak:
+                print(f"  - {rec.name}: {rec.score:.4f}")
+    else:
+        print("No score values found in snapshot.")
+
+
+def _run_export(args: Any) -> None:
+    dataset = EvalDataset.from_snapshot(args.snapshot, snapshot_dir=args.snapshot_dir)
+    dataset = dataset.filter_score(min_score=args.min_score, max_score=args.max_score)
+
+    output_path = dataset.export(args.output, format=args.format)
+    rows = 0
+    with Path(output_path).open("r", encoding="utf-8") as f:
+        for _ in f:
+            rows += 1
+
+    print(f"Exported {rows} rows -> {output_path}")
+
+
+def _run_compare(args: Any) -> None:
+    reg = EvalRegression(store_dir=args.snapshot_dir)
+    report = reg.compare(args.baseline, args.current)
+    _print_regression_report(report)

--- a/src/synapsekit/cli/finetune.py
+++ b/src/synapsekit/cli/finetune.py
@@ -1,0 +1,84 @@
+"""``synapsekit finetune`` commands: submit/status/wait."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+from ..evaluation.finetune import FineTuner
+
+
+async def _submit(args: Any) -> None:
+    api_key = _resolve_api_key(args)
+    tuner = FineTuner(provider=args.provider, api_key=api_key)
+    job = await tuner.submit(
+        dataset=args.dataset,
+        base_model=args.base_model,
+        job_name=args.job_name,
+        n_epochs=args.n_epochs,
+    )
+    print(f"Job created: {job.id}")
+    print(f"Status: {job.status}")
+    if job.model_id:
+        print(f"Model: {job.model_id}")
+
+
+async def _status(args: Any) -> None:
+    api_key = _resolve_api_key(args)
+    tuner = FineTuner(provider=args.provider, api_key=api_key)
+    job = await tuner.status(args.job_id)
+    print(f"Job: {job.id}")
+    print(f"Status: {job.status}")
+    if job.model_id:
+        print(f"Model: {job.model_id}")
+    if job.error:
+        print(f"Error: {job.error}")
+
+
+async def _wait(args: Any) -> None:
+    api_key = _resolve_api_key(args)
+    tuner = FineTuner(provider=args.provider, api_key=api_key)
+    job = await tuner.wait(args.job_id, timeout_s=args.timeout, poll_interval_s=args.interval)
+    print(f"Job completed: {job.id}")
+    print(f"Status: {job.status}")
+    if job.model_id:
+        print(f"Model: {job.model_id}")
+
+
+def run_finetune(args: Any) -> None:
+    subcommand = getattr(args, "finetune_command", None)
+
+    if subcommand == "submit":
+        asyncio.run(_submit(args))
+        return
+    if subcommand == "status":
+        asyncio.run(_status(args))
+        return
+    if subcommand == "wait":
+        asyncio.run(_wait(args))
+        return
+
+    raise SystemExit("Missing finetune subcommand. Use: submit, status, or wait")
+
+
+def _resolve_api_key(args: Any) -> str:
+    raw_api_key = getattr(args, "api_key", None)
+    if raw_api_key:
+        return str(raw_api_key)
+
+    provider = str(getattr(args, "provider", "")).lower()
+    if provider == "openai":
+        env_key = os.getenv("OPENAI_API_KEY")
+    elif provider == "together":
+        env_key = os.getenv("TOGETHER_API_KEY")
+    else:
+        env_key = None
+
+    if env_key:
+        return env_key
+
+    raise ValueError(
+        f"Missing API key for provider '{provider}'. "
+        "Pass --api-key or set the provider environment variable."
+    )

--- a/src/synapsekit/cli/main.py
+++ b/src/synapsekit/cli/main.py
@@ -52,6 +52,59 @@ def _add_test_parser(subparsers: argparse._SubParsersAction) -> None:  # type: i
     )
 
 
+def _add_eval_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    p = subparsers.add_parser("eval", help="EvalCI snapshot report/export/compare")
+    eval_sub = p.add_subparsers(dest="eval_command")
+
+    report = eval_sub.add_parser("report", help="Summarize a saved eval snapshot")
+    report.add_argument("snapshot", help="Snapshot name")
+    report.add_argument("--threshold", type=float, default=0.8, help="Weak-case threshold")
+    report.add_argument("--snapshot-dir", default=".synapsekit_evals", help="Snapshot storage dir")
+
+    export = eval_sub.add_parser("export", help="Export snapshot to fine-tune dataset")
+    export.add_argument("snapshot", help="Snapshot name")
+    export.add_argument(
+        "--format",
+        choices=["openai", "anthropic", "together", "jsonl", "dpo"],
+        default="openai",
+        help="Export format",
+    )
+    export.add_argument("--min-score", type=float, default=None, help="Minimum score filter")
+    export.add_argument("--max-score", type=float, default=None, help="Maximum score filter")
+    export.add_argument("--output", required=True, help="Output JSONL path")
+    export.add_argument("--snapshot-dir", default=".synapsekit_evals", help="Snapshot storage dir")
+
+    compare = eval_sub.add_parser("compare", help="Compare two saved eval snapshots")
+    compare.add_argument("baseline", help="Baseline snapshot")
+    compare.add_argument("current", help="Current snapshot")
+    compare.add_argument("--snapshot-dir", default=".synapsekit_evals", help="Snapshot storage dir")
+
+
+def _add_finetune_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    p = subparsers.add_parser("finetune", help="Submit and monitor fine-tuning jobs")
+    ft_sub = p.add_subparsers(dest="finetune_command")
+
+    submit = ft_sub.add_parser("submit", help="Submit fine-tuning job")
+    submit.add_argument("dataset", help="Dataset file ID/path accepted by provider")
+    submit.add_argument("--provider", choices=["openai", "together"], required=True)
+    submit.add_argument("--base-model", required=True, help="Base model name")
+    submit.add_argument("--job-name", default=None, help="Optional job suffix/name")
+    submit.add_argument("--n-epochs", type=int, default=3, help="Training epochs")
+    submit.add_argument("--api-key", default=None, help="Provider API key")
+
+    status = ft_sub.add_parser("status", help="Get fine-tune job status")
+    status.add_argument("job_id", help="Fine-tune job ID")
+    status.add_argument("--provider", choices=["openai", "together"], required=True)
+    status.add_argument("--api-key", default=None, help="Provider API key")
+
+    wait = ft_sub.add_parser("wait", help="Wait for fine-tune job completion")
+    wait.add_argument("job_id", help="Fine-tune job ID")
+    wait.add_argument("--provider", choices=["openai", "together"], required=True)
+    wait.add_argument("--interval", type=float, default=10.0, help="Poll interval seconds")
+    wait.add_argument("--timeout", type=float, default=3600.0, help="Timeout seconds")
+    wait.add_argument("--api-key", default=None, help="Provider API key")
+
+
 def main(argv: list[str] | None = None) -> None:
     """CLI entry point."""
     parser = argparse.ArgumentParser(
@@ -63,6 +116,8 @@ def main(argv: list[str] | None = None) -> None:
     subparsers = parser.add_subparsers(dest="command")
     _add_serve_parser(subparsers)
     _add_test_parser(subparsers)
+    _add_eval_parser(subparsers)
+    _add_finetune_parser(subparsers)
 
     args = parser.parse_args(argv)
 
@@ -80,6 +135,14 @@ def main(argv: list[str] | None = None) -> None:
         from .test import run_test
 
         run_test(args)
+    elif args.command == "eval":
+        from .eval import run_eval
+
+        run_eval(args)
+    elif args.command == "finetune":
+        from .finetune import run_finetune
+
+        run_finetune(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/synapsekit/cli/test.py
+++ b/src/synapsekit/cli/test.py
@@ -113,18 +113,23 @@ def run_test(args: Any) -> None:
             if not passed:
                 any_failed = True
 
-            results.append(
-                {
-                    "file": str(filepath),
-                    "name": name,
-                    "passed": passed,
-                    "score": result.get("score"),
-                    "cost_usd": result.get("cost_usd"),
-                    "latency_ms": result.get("latency_ms"),
-                    "failures": failures,
-                    "tags": meta.tags,
-                }
-            )
+            case_result: dict[str, Any] = {
+                "file": str(filepath),
+                "name": name,
+                "passed": passed,
+                "score": result.get("score"),
+                "cost_usd": result.get("cost_usd"),
+                "latency_ms": result.get("latency_ms"),
+                "failures": failures,
+                "tags": meta.tags,
+            }
+
+            if getattr(meta, "capture_io", False):
+                case_result["input"] = result.get("input")
+                case_result["output"] = result.get("output")
+                case_result["ideal"] = result.get("ideal")
+
+            results.append(case_result)
 
     # Output
     if args.output_format == "json":

--- a/src/synapsekit/evaluation/__init__.py
+++ b/src/synapsekit/evaluation/__init__.py
@@ -1,6 +1,8 @@
 from .base import MetricResult
+from .dataset import EvalDataset, EvalRecord
 from .decorators import EvalCaseMeta, eval_case
 from .faithfulness import FaithfulnessMetric
+from .finetune import FineTuneJob, FineTuner
 from .groundedness import GroundednessMetric
 from .pipeline import EvaluationPipeline, EvaluationResult
 from .regression import EvalRegression, EvalSnapshot, MetricDelta, RegressionReport
@@ -8,11 +10,15 @@ from .relevancy import RelevancyMetric
 
 __all__ = [
     "EvalCaseMeta",
+    "EvalDataset",
+    "EvalRecord",
     "EvalRegression",
     "EvalSnapshot",
     "EvaluationPipeline",
     "EvaluationResult",
     "FaithfulnessMetric",
+    "FineTuneJob",
+    "FineTuner",
     "GroundednessMetric",
     "MetricDelta",
     "MetricResult",

--- a/src/synapsekit/evaluation/dataset.py
+++ b/src/synapsekit/evaluation/dataset.py
@@ -1,0 +1,188 @@
+"""Eval dataset helpers for filtering and exporting fine-tuning data."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .regression import EvalRegression
+
+
+@dataclass
+class EvalRecord:
+    """Single eval result record."""
+
+    name: str
+    score: float | None = None
+    cost_usd: float | None = None
+    latency_ms: float | None = None
+    input: str | None = None
+    output: str | None = None
+    ideal: str | None = None
+    raw: dict[str, Any] | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EvalRecord:
+        return cls(
+            name=str(data.get("name", "")),
+            score=_to_float(data.get("score")),
+            cost_usd=_to_float(data.get("cost_usd")),
+            latency_ms=_to_float(data.get("latency_ms")),
+            input=_to_str_or_none(data.get("input")),
+            output=_to_str_or_none(data.get("output")),
+            ideal=_to_str_or_none(data.get("ideal")),
+            raw=data,
+        )
+
+    @property
+    def assistant_target(self) -> str | None:
+        """Preferred assistant target for SFT exports."""
+        return self.ideal if self.ideal is not None else self.output
+
+
+class EvalDataset:
+    """A filterable/exportable collection of evaluation records."""
+
+    def __init__(self, records: list[EvalRecord]) -> None:
+        self.records = records
+
+    def __len__(self) -> int:
+        return len(self.records)
+
+    @classmethod
+    def from_snapshot(cls, name: str, snapshot_dir: str = ".synapsekit_evals") -> EvalDataset:
+        reg = EvalRegression(store_dir=snapshot_dir)
+        snap = reg.load_snapshot(name)
+        return cls([EvalRecord.from_dict(r) for r in snap.results])
+
+    def filter(self, predicate: Any) -> EvalDataset:
+        return EvalDataset([r for r in self.records if predicate(r)])
+
+    def filter_score(
+        self,
+        *,
+        min_score: float | None = None,
+        max_score: float | None = None,
+    ) -> EvalDataset:
+        def _ok(rec: EvalRecord) -> bool:
+            if rec.score is None:
+                return False
+            if min_score is not None and rec.score < min_score:
+                return False
+            return not (max_score is not None and rec.score > max_score)
+
+        return self.filter(_ok)
+
+    def export(
+        self,
+        output: str | Path,
+        *,
+        format: str = "openai",
+        system_prompt: str | None = "You are a helpful assistant.",
+    ) -> Path:
+        fmt = format.lower()
+        output_path = Path(output)
+
+        if fmt in {"openai", "anthropic", "together", "jsonl"}:
+            rows = self._export_supervised_rows(fmt, system_prompt=system_prompt)
+        elif fmt == "dpo":
+            rows = self._export_dpo_rows()
+        else:
+            raise ValueError(f"Unsupported export format: {format}")
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as f:
+            for row in rows:
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+        return output_path
+
+    def _export_supervised_rows(
+        self,
+        fmt: str,
+        *,
+        system_prompt: str | None,
+    ) -> list[dict[str, Any]]:
+        self._require_io_fields()
+
+        rows: list[dict[str, Any]] = []
+        for rec in self.records:
+            if rec.input is None:
+                continue
+            target = rec.assistant_target
+            if target is None:
+                continue
+
+            if fmt == "openai":
+                messages: list[dict[str, str]] = []
+                if system_prompt:
+                    messages.append({"role": "system", "content": system_prompt})
+                messages.extend(
+                    [
+                        {"role": "user", "content": rec.input},
+                        {"role": "assistant", "content": target},
+                    ]
+                )
+                rows.append({"messages": messages})
+            elif fmt == "anthropic":
+                rows.append(
+                    {
+                        "prompt": f"Human: {rec.input}\\nAssistant:",
+                        "completion": f" {target}",
+                    }
+                )
+            else:  # together/jsonl generic
+                rows.append({"prompt": rec.input, "completion": target})
+
+        return rows
+
+    def _export_dpo_rows(self) -> list[dict[str, Any]]:
+        self._require_io_fields()
+
+        by_input: dict[str, list[EvalRecord]] = {}
+        for rec in self.records:
+            if rec.input is None or rec.output is None or rec.score is None:
+                continue
+            by_input.setdefault(rec.input, []).append(rec)
+
+        rows: list[dict[str, Any]] = []
+        for prompt, records in by_input.items():
+            if len(records) < 2:
+                continue
+            ordered = sorted(records, key=lambda r: r.score if r.score is not None else -1.0)
+            rejected = ordered[0]
+            chosen = ordered[-1]
+            if chosen.output is None or rejected.output is None:
+                continue
+            if chosen.output == rejected.output:
+                continue
+            rows.append({"prompt": prompt, "chosen": chosen.output, "rejected": rejected.output})
+
+        return rows
+
+    def _require_io_fields(self) -> None:
+        has_input = any(r.input is not None for r in self.records)
+        has_output = any(r.output is not None for r in self.records)
+        if not has_input or not has_output:
+            raise ValueError(
+                "Snapshot is missing captured input/output fields. "
+                "Run evals with @eval_case(capture_io=True) and return input/output in the case result."
+            )
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_str_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return str(value)

--- a/src/synapsekit/evaluation/decorators.py
+++ b/src/synapsekit/evaluation/decorators.py
@@ -16,6 +16,7 @@ class EvalCaseMeta:
     max_cost_usd: float | None = None
     max_latency_ms: float | None = None
     tags: list[str] = field(default_factory=list)
+    capture_io: bool = False
 
 
 def eval_case(
@@ -24,6 +25,7 @@ def eval_case(
     max_cost_usd: float | None = None,
     max_latency_ms: float | None = None,
     tags: list[str] | None = None,
+    capture_io: bool = False,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Decorator to mark a function as an evaluation case.
 
@@ -46,6 +48,7 @@ def eval_case(
             max_cost_usd=max_cost_usd,
             max_latency_ms=max_latency_ms,
             tags=tags or [],
+            capture_io=capture_io,
         )
         fn._eval_case_meta = meta  # type: ignore[attr-defined]
 

--- a/src/synapsekit/evaluation/finetune.py
+++ b/src/synapsekit/evaluation/finetune.py
@@ -1,0 +1,284 @@
+"""Fine-tuning orchestration and provider adapters."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class FineTuneJob:
+    """Provider fine-tuning job state."""
+
+    id: str
+    provider: str
+    status: str
+    base_model: str | None = None
+    model_id: str | None = None
+    error: str | None = None
+
+
+class FineTuneAdapter:
+    """Provider adapter protocol."""
+
+    async def submit(
+        self,
+        *,
+        dataset: str,
+        base_model: str,
+        job_name: str | None,
+        n_epochs: int,
+    ) -> FineTuneJob:
+        raise NotImplementedError
+
+    async def status(self, job_id: str) -> FineTuneJob:
+        raise NotImplementedError
+
+
+Transport = Callable[[str, str, dict[str, str], dict[str, Any] | None], dict[str, Any]]
+
+
+def _http_json_transport(
+    method: str,
+    url: str,
+    headers: dict[str, str],
+    body: dict[str, Any] | None,
+) -> dict[str, Any]:
+    data = None
+    req_headers = {"Content-Type": "application/json", **headers}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+
+    request = urllib.request.Request(url=url, method=method, headers=req_headers, data=data)
+    try:
+        with urllib.request.urlopen(request, timeout=60) as resp:
+            payload = resp.read().decode("utf-8")
+            if not payload:
+                return {}
+            parsed = json.loads(payload)
+            if not isinstance(parsed, dict):
+                raise RuntimeError("Unexpected API response shape")
+            return parsed
+    except urllib.error.HTTPError as exc:
+        details = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Provider API request failed ({exc.code}): {details}") from exc
+
+
+class OpenAIFineTuneAdapter(FineTuneAdapter):
+    """OpenAI fine-tuning API adapter."""
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        api_base: str = "https://api.openai.com/v1",
+        transport: Transport | None = None,
+    ) -> None:
+        self._api_base = api_base.rstrip("/")
+        self._transport = transport or _http_json_transport
+        self._headers = {"Authorization": f"Bearer {api_key}"}
+
+    async def submit(
+        self,
+        *,
+        dataset: str,
+        base_model: str,
+        job_name: str | None,
+        n_epochs: int,
+    ) -> FineTuneJob:
+        payload: dict[str, Any] = {
+            "training_file": dataset,
+            "model": base_model,
+            "hyperparameters": {"n_epochs": n_epochs},
+        }
+        if job_name:
+            payload["suffix"] = job_name
+
+        data = await asyncio.to_thread(
+            self._transport,
+            "POST",
+            f"{self._api_base}/fine_tuning/jobs",
+            self._headers,
+            payload,
+        )
+        return FineTuneJob(
+            id=str(data.get("id", "")),
+            provider="openai",
+            status=str(data.get("status", "created")),
+            base_model=str(data.get("model", base_model)),
+            model_id=_str_or_none(data.get("fine_tuned_model")),
+            error=_extract_error(data),
+        )
+
+    async def status(self, job_id: str) -> FineTuneJob:
+        data = await asyncio.to_thread(
+            self._transport,
+            "GET",
+            f"{self._api_base}/fine_tuning/jobs/{job_id}",
+            self._headers,
+            None,
+        )
+        return FineTuneJob(
+            id=str(data.get("id", job_id)),
+            provider="openai",
+            status=str(data.get("status", "unknown")),
+            base_model=_str_or_none(data.get("model")),
+            model_id=_str_or_none(data.get("fine_tuned_model")),
+            error=_extract_error(data),
+        )
+
+
+class TogetherFineTuneAdapter(FineTuneAdapter):
+    """Together AI fine-tuning adapter."""
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        api_base: str = "https://api.together.xyz/v1",
+        transport: Transport | None = None,
+    ) -> None:
+        self._api_base = api_base.rstrip("/")
+        self._transport = transport or _http_json_transport
+        self._headers = {"Authorization": f"Bearer {api_key}"}
+
+    async def submit(
+        self,
+        *,
+        dataset: str,
+        base_model: str,
+        job_name: str | None,
+        n_epochs: int,
+    ) -> FineTuneJob:
+        payload: dict[str, Any] = {
+            "training_file": dataset,
+            "model": base_model,
+            "n_epochs": n_epochs,
+        }
+        if job_name:
+            payload["suffix"] = job_name
+
+        data = await asyncio.to_thread(
+            self._transport,
+            "POST",
+            f"{self._api_base}/fine-tuning/jobs",
+            self._headers,
+            payload,
+        )
+        return FineTuneJob(
+            id=str(data.get("id", "")),
+            provider="together",
+            status=str(data.get("status", "created")),
+            base_model=_str_or_none(data.get("model")) or base_model,
+            model_id=_str_or_none(data.get("output_name"))
+            or _str_or_none(data.get("model_output_name")),
+            error=_extract_error(data),
+        )
+
+    async def status(self, job_id: str) -> FineTuneJob:
+        data = await asyncio.to_thread(
+            self._transport,
+            "GET",
+            f"{self._api_base}/fine-tuning/jobs/{job_id}",
+            self._headers,
+            None,
+        )
+        return FineTuneJob(
+            id=str(data.get("id", job_id)),
+            provider="together",
+            status=str(data.get("status", "unknown")),
+            base_model=_str_or_none(data.get("model")),
+            model_id=_str_or_none(data.get("output_name"))
+            or _str_or_none(data.get("model_output_name")),
+            error=_extract_error(data),
+        )
+
+
+class FineTuner:
+    """High-level fine-tuning orchestration."""
+
+    TERMINAL_SUCCESS = {"succeeded", "completed", "success"}
+    TERMINAL_FAILURE = {"failed", "cancelled", "canceled", "error"}
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        api_key: str,
+        adapter: FineTuneAdapter | None = None,
+    ) -> None:
+        self.provider = provider.lower().strip()
+        self._adapter = adapter or _build_default_adapter(self.provider, api_key)
+
+    async def submit(
+        self,
+        *,
+        dataset: str,
+        base_model: str,
+        job_name: str | None = None,
+        n_epochs: int = 3,
+    ) -> FineTuneJob:
+        if n_epochs < 1:
+            raise ValueError("n_epochs must be >= 1")
+        return await self._adapter.submit(
+            dataset=dataset,
+            base_model=base_model,
+            job_name=job_name,
+            n_epochs=n_epochs,
+        )
+
+    async def status(self, job_id: str) -> FineTuneJob:
+        return await self._adapter.status(job_id)
+
+    async def wait(
+        self,
+        job_id: str,
+        *,
+        timeout_s: float = 3600,
+        poll_interval_s: float = 10,
+    ) -> FineTuneJob:
+        start = time.monotonic()
+
+        while True:
+            job = await self.status(job_id)
+            status = job.status.lower()
+            if status in self.TERMINAL_SUCCESS:
+                return job
+            if status in self.TERMINAL_FAILURE:
+                message = job.error or f"Fine-tune job failed with status '{job.status}'"
+                raise RuntimeError(message)
+
+            if (time.monotonic() - start) >= timeout_s:
+                raise TimeoutError(f"Timed out waiting for fine-tune job '{job_id}'")
+
+            await asyncio.sleep(poll_interval_s)
+
+
+def _build_default_adapter(provider: str, api_key: str) -> FineTuneAdapter:
+    if provider == "openai":
+        return OpenAIFineTuneAdapter(api_key)
+    if provider == "together":
+        return TogetherFineTuneAdapter(api_key)
+    raise ValueError(f"Unsupported fine-tuning provider: {provider}")
+
+
+def _extract_error(data: dict[str, Any]) -> str | None:
+    err = data.get("error")
+    if isinstance(err, dict):
+        msg = err.get("message")
+        return str(msg) if msg is not None else json.dumps(err)
+    if isinstance(err, str):
+        return err
+    return None
+
+
+def _str_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)

--- a/tests/test_v150_finetune_flywheel.py
+++ b/tests/test_v150_finetune_flywheel.py
@@ -1,0 +1,239 @@
+"""Tests for eval fine-tune flywheel primitives (issue #515)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from synapsekit.cli.main import _add_eval_parser, _add_finetune_parser
+from synapsekit.cli.test import run_test
+from synapsekit.evaluation.dataset import EvalDataset
+from synapsekit.evaluation.finetune import (
+    FineTuneJob,
+    FineTuner,
+    OpenAIFineTuneAdapter,
+    TogetherFineTuneAdapter,
+)
+from synapsekit.evaluation.regression import EvalRegression
+
+
+class TestEvalCaseCaptureIO:
+    def test_capture_io_fields_saved_in_snapshot(self, tmp_path):
+        eval_file = tmp_path / "eval_sample.py"
+        eval_file.write_text(
+            """
+from synapsekit.evaluation.decorators import eval_case
+
+@eval_case(capture_io=True)
+def eval_case_a():
+    return {
+        \"score\": 0.95,
+        \"input\": \"What is the capital of France?\",
+        \"output\": \"Paris\",
+        \"ideal\": \"Paris\",
+    }
+""".strip()
+        )
+
+        args = SimpleNamespace(
+            path=str(eval_file),
+            threshold=0.7,
+            output_format="json",
+            save_snapshot="baseline",
+            compare_baseline=None,
+            fail_on_regression=False,
+            snapshot_dir=str(tmp_path / "snaps"),
+        )
+        run_test(args)
+
+        reg = EvalRegression(store_dir=args.snapshot_dir)
+        snap = reg.load_snapshot("baseline")
+        assert len(snap.results) == 1
+        row = snap.results[0]
+        assert row["input"] == "What is the capital of France?"
+        assert row["output"] == "Paris"
+        assert row["ideal"] == "Paris"
+
+
+class TestEvalDataset:
+    def test_filter_and_export_openai(self, tmp_path):
+        reg = EvalRegression(store_dir=str(tmp_path))
+        reg.save_snapshot(
+            "baseline",
+            [
+                {
+                    "name": "case_1",
+                    "score": 0.6,
+                    "input": "Q1",
+                    "output": "bad",
+                    "ideal": "good",
+                },
+                {
+                    "name": "case_2",
+                    "score": 0.9,
+                    "input": "Q2",
+                    "output": "ok",
+                    "ideal": "ok",
+                },
+            ],
+        )
+
+        dataset = EvalDataset.from_snapshot("baseline", snapshot_dir=str(tmp_path))
+        weak = dataset.filter_score(max_score=0.8)
+        out = tmp_path / "openai.jsonl"
+        weak.export(out, format="openai")
+
+        line = out.read_text().strip()
+        row = json.loads(line)
+        assert row["messages"][1]["content"] == "Q1"
+        assert row["messages"][2]["content"] == "good"
+
+    def test_export_anthropic(self, tmp_path):
+        reg = EvalRegression(store_dir=str(tmp_path))
+        reg.save_snapshot(
+            "baseline",
+            [{"name": "case", "score": 0.7, "input": "hello", "output": "world"}],
+        )
+
+        dataset = EvalDataset.from_snapshot("baseline", snapshot_dir=str(tmp_path))
+        out = tmp_path / "anthropic.jsonl"
+        dataset.export(out, format="anthropic")
+
+        row = json.loads(out.read_text().strip())
+        assert row["prompt"].startswith("Human: hello")
+        assert row["completion"].strip() == "world"
+
+    def test_export_dpo_pairs_high_low(self, tmp_path):
+        reg = EvalRegression(store_dir=str(tmp_path))
+        reg.save_snapshot(
+            "baseline",
+            [
+                {"name": "a", "score": 0.2, "input": "Q", "output": "bad"},
+                {"name": "b", "score": 0.9, "input": "Q", "output": "good"},
+            ],
+        )
+
+        dataset = EvalDataset.from_snapshot("baseline", snapshot_dir=str(tmp_path))
+        out = tmp_path / "dpo.jsonl"
+        dataset.export(out, format="dpo")
+
+        row = json.loads(out.read_text().strip())
+        assert row == {"prompt": "Q", "chosen": "good", "rejected": "bad"}
+
+    def test_export_raises_without_capture_io(self, tmp_path):
+        reg = EvalRegression(store_dir=str(tmp_path))
+        reg.save_snapshot("baseline", [{"name": "case", "score": 0.8}])
+
+        dataset = EvalDataset.from_snapshot("baseline", snapshot_dir=str(tmp_path))
+        with pytest.raises(ValueError, match="capture_io=True"):
+            dataset.export(tmp_path / "x.jsonl", format="openai")
+
+
+class TestFineTuningAdapters:
+    async def test_openai_adapter_submit_uses_expected_payload(self):
+        calls = []
+
+        def transport(method, url, headers, body):
+            calls.append((method, url, headers, body))
+            return {"id": "ftjob_1", "status": "validating_files", "model": "gpt-4o-mini"}
+
+        adapter = OpenAIFineTuneAdapter("k", transport=transport)
+        job = await adapter.submit(
+            dataset="file-123", base_model="gpt-4o-mini", job_name="x", n_epochs=3
+        )
+
+        assert job.id == "ftjob_1"
+        assert calls[0][0] == "POST"
+        assert calls[0][1].endswith("/fine_tuning/jobs")
+        assert calls[0][3]["training_file"] == "file-123"
+        assert calls[0][3]["model"] == "gpt-4o-mini"
+
+    async def test_together_adapter_submit_uses_expected_payload(self):
+        calls = []
+
+        def transport(method, url, headers, body):
+            calls.append((method, url, headers, body))
+            return {"id": "job_2", "status": "queued", "model": "meta-llama/Llama-3.1-8B-Instruct"}
+
+        adapter = TogetherFineTuneAdapter("k", transport=transport)
+        job = await adapter.submit(
+            dataset="file-xyz",
+            base_model="meta-llama/Llama-3.1-8B-Instruct",
+            job_name=None,
+            n_epochs=4,
+        )
+
+        assert job.id == "job_2"
+        assert calls[0][0] == "POST"
+        assert calls[0][1].endswith("/fine-tuning/jobs")
+        assert calls[0][3]["training_file"] == "file-xyz"
+
+    async def test_finetuner_wait_returns_on_success(self):
+        class _Adapter:
+            def __init__(self):
+                self.calls = 0
+
+            async def submit(self, *, dataset, base_model, job_name, n_epochs):
+                return FineTuneJob(id="j", provider="openai", status="created")
+
+            async def status(self, job_id):
+                self.calls += 1
+                if self.calls < 2:
+                    return FineTuneJob(id=job_id, provider="openai", status="running")
+                return FineTuneJob(
+                    id=job_id, provider="openai", status="succeeded", model_id="ft:model"
+                )
+
+        adapter = _Adapter()
+        tuner = FineTuner(provider="openai", api_key="k", adapter=adapter)
+        job = await tuner.wait("job_1", timeout_s=2, poll_interval_s=0.01)
+        assert job.status == "succeeded"
+        assert job.model_id == "ft:model"
+
+
+class TestCLIParsers:
+    def test_eval_cli_parser(self):
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="command")
+        _add_eval_parser(subparsers)
+
+        args = parser.parse_args(
+            [
+                "eval",
+                "export",
+                "baseline",
+                "--format",
+                "openai",
+                "--max-score",
+                "0.8",
+                "--output",
+                "data.jsonl",
+            ]
+        )
+        assert args.command == "eval"
+        assert args.eval_command == "export"
+        assert args.snapshot == "baseline"
+        assert args.max_score == 0.8
+
+    def test_finetune_cli_parser(self):
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="command")
+        _add_finetune_parser(subparsers)
+
+        args = parser.parse_args(
+            [
+                "finetune",
+                "submit",
+                "dataset.jsonl",
+                "--provider",
+                "openai",
+                "--base-model",
+                "gpt-4o-mini",
+            ]
+        )
+        assert args.command == "finetune"
+        assert args.finetune_command == "submit"
+        assert args.dataset == "dataset.jsonl"


### PR DESCRIPTION
## Summary
- add @eval_case(capture_io=True) support and persist input/output/ideal in snapshots
- add EvalDataset with score filtering and export formats (OpenAI, Anthropic, Together/generic JSONL, DPO)
- add FineTuner with OpenAI + Together adapters and CLI commands: synapsekit finetune submit|status|wait
- add synapsekit eval report|export|compare CLI flow
- add flywheel tests and examples/fine_tune_flywheel.py

## Validation
- uff check src/ tests/
- uff format --check src/ tests/
- python -m pytest tests/test_v150_finetune_flywheel.py tests/test_v130_eval_regression.py -q

Closes #515