### PR TITLE
feat(Loader): Added dropbox loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,7 @@ module = [
     "synapsekit.llm.vertex_ai",
     "synapsekit.loaders.excel",
     "synapsekit.loaders.pptx",
+    "synapsekit.loaders.dropbox",
     "synapsekit.loaders.gcs",
     "synapsekit.loaders.git",
     "synapsekit.loaders.google_sheets",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ slack = ["slack-sdk>=3.0"]
 supabase = ["supabase>=2.0"]
 notion = ["httpx>=0.27"]
 confluence = ["atlassian-python-api>=3.0", "beautifulsoup4>=4.12"]
+dropbox = ["dropbox>=12.0"]
 all = [
     "openai>=1.0",
     "anthropic>=0.25",
@@ -189,6 +190,7 @@ ignore = ["E501", "B008", "SIM108", "RUF022", "UP047", "RUF012", "SIM117"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["N817", "B017"]
+"tests/loaders/test_dropbox_loader.py" = ["SIM115"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["synapsekit"]

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -343,6 +343,7 @@ __all__ = [
     "CSVLoader",
     "JSONLoader",
     "DirectoryLoader",
+    "DropboxLoader",
     "ConfluenceLoader",
     "DocxLoader",
     "EmailLoader",
@@ -604,6 +605,7 @@ _LAZY_IMPORTS = {
     "DiscordLoader": "loaders.discord",
     "XMLLoader": "loaders.xml_loader",
     "GoogleDriveLoader": "loaders.google_drive",
+    "DropboxLoader": "loaders.dropbox",
 }
 
 

--- a/src/synapsekit/agents/tools/python_repl.py
+++ b/src/synapsekit/agents/tools/python_repl.py
@@ -97,12 +97,12 @@ class PythonREPLTool(BaseTool):
             raise _CodeTimeoutError(f"Code execution timed out after {self.timeout} seconds")
 
         try:
-            signal.signal(signal.SIGALRM, timeout_handler)
-            signal.alarm(max(1, math.ceil(self.timeout)))
+            signal.signal(signal.SIGALRM, timeout_handler)  # type: ignore[attr-defined]
+            signal.alarm(max(1, math.ceil(self.timeout)))  # type: ignore[attr-defined]
             try:
                 exec(code, self._namespace)
             finally:
-                signal.alarm(0)  # Cancel alarm
+                signal.alarm(0)  # type: ignore[attr-defined]
 
             output = buf.getvalue()
             return ToolResult(output=output or "(no output)")
@@ -112,7 +112,7 @@ class PythonREPLTool(BaseTool):
             return ToolResult(output="", error=f"{type(e).__name__}: {e}")
         finally:
             sys.stdout = old_stdout
-            signal.alarm(0)  # Ensure alarm is cancelled
+            signal.alarm(0)  # type: ignore[attr-defined]
 
     async def _run_windows(self, code: str) -> ToolResult:
         """Execute code with multiprocessing timeout (Windows).

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "DiscordLoader",
     "DocxLoader",
     "Document",
+    "DropboxLoader",
     "EmailLoader",
     "GCSLoader",
     "GitHubLoader",
@@ -68,6 +69,7 @@ _LOADERS = {
     "TeamsLoader": ".teams",
     "WikipediaLoader": ".wikipedia",
     "ConfluenceLoader": ".confluence",
+    "DropboxLoader": ".dropbox",
 }
 
 

--- a/src/synapsekit/loaders/dropbox.py
+++ b/src/synapsekit/loaders/dropbox.py
@@ -4,13 +4,36 @@ import asyncio
 import contextlib
 import os
 import time
+from typing import TYPE_CHECKING
 
 from .base import Document
 
+if TYPE_CHECKING:
+    from dropbox import Dropbox
+
 SUPPORTED_EXTENSIONS = {
-    ".txt", ".md", ".py", ".js", ".ts", ".java", ".cpp", ".c", ".h",
-    ".json", ".csv", ".xml", ".yaml", ".yml", ".html", ".css",
-    ".rb", ".go", ".rs", ".php", ".sh", ".bat",
+    ".txt",
+    ".md",
+    ".py",
+    ".js",
+    ".ts",
+    ".java",
+    ".cpp",
+    ".c",
+    ".h",
+    ".json",
+    ".csv",
+    ".xml",
+    ".yaml",
+    ".yml",
+    ".html",
+    ".css",
+    ".rb",
+    ".go",
+    ".rs",
+    ".php",
+    ".sh",
+    ".bat",
 }
 
 
@@ -31,9 +54,7 @@ class DropboxLoader:
         try:
             import dropbox
         except ImportError:
-            raise ImportError(
-                "dropbox required: pip install synapsekit[dropbox]"
-            ) from None
+            raise ImportError("dropbox required: pip install synapsekit[dropbox]") from None
 
         dbx = dropbox.Dropbox(self._access_token)
         docs: list[Document] = []
@@ -84,7 +105,7 @@ class DropboxLoader:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self.load)
 
-    def _list_folder(self, dbx: object, path: str) -> list[dict]:
+    def _list_folder(self, dbx: Dropbox, path: str) -> list[dict]:
         entries: list[dict] = []
 
         try:
@@ -104,7 +125,7 @@ class DropboxLoader:
 
         return entries
 
-    def _download_file(self, dbx: object, path: str) -> bytes:
+    def _download_file(self, dbx: Dropbox, path: str) -> bytes:
         import tempfile
 
         with tempfile.NamedTemporaryFile(delete=False) as tmp:

--- a/src/synapsekit/loaders/dropbox.py
+++ b/src/synapsekit/loaders/dropbox.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import time
+
+from .base import Document
+
+SUPPORTED_EXTENSIONS = {
+    ".txt", ".md", ".py", ".js", ".ts", ".java", ".cpp", ".c", ".h",
+    ".json", ".csv", ".xml", ".yaml", ".yml", ".html", ".css",
+    ".rb", ".go", ".rs", ".php", ".sh", ".bat",
+}
+
+
+class DropboxLoader:
+    """Load files from a Dropbox folder as Documents."""
+
+    def __init__(
+        self,
+        access_token: str,
+        path: str,
+        limit: int | None = None,
+    ) -> None:
+        self._access_token = access_token
+        self._path = path
+        self._limit = limit
+
+    def load(self) -> list[Document]:
+        try:
+            import dropbox
+        except ImportError:
+            raise ImportError(
+                "dropbox required: pip install synapsekit[dropbox]"
+            ) from None
+
+        dbx = dropbox.Dropbox(self._access_token)
+        docs: list[Document] = []
+
+        entries = self._list_folder(dbx, self._path)
+
+        for entry in entries:
+            if self._limit is not None and len(docs) >= self._limit:
+                break
+
+            if entry.get(".tag") != "file":
+                continue
+
+            name = entry.get("name", "")
+            path_display = entry.get("path_display", "")
+            server_modified = entry.get("server_modified", "")
+
+            ext = "." + name.rsplit(".", 1)[-1].lower() if "." in name else ""
+            if ext not in SUPPORTED_EXTENSIONS:
+                continue
+
+            try:
+                content = self._download_file(dbx, path_display)
+            except Exception:
+                continue
+
+            try:
+                text = content.decode("utf-8", errors="ignore")
+            except Exception:
+                continue
+
+            docs.append(
+                Document(
+                    text=text,
+                    metadata={
+                        "source": "dropbox",
+                        "filename": name,
+                        "path": path_display,
+                        "modified": server_modified,
+                    },
+                )
+            )
+
+        return docs
+
+    async def aload(self) -> list[Document]:
+        """Load files asynchronously."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.load)
+
+    def _list_folder(self, dbx: object, path: str) -> list[dict]:
+        entries: list[dict] = []
+
+        try:
+            result = dbx.files_list_folder(path)
+        except Exception:
+            return entries
+
+        entries.extend(result.entries)
+
+        while result.has_more:
+            time.sleep(0.1)
+            try:
+                result = dbx.files_list_folder_continue(result.cursor)
+                entries.extend(result.entries)
+            except Exception:
+                break
+
+        return entries
+
+    def _download_file(self, dbx: object, path: str) -> bytes:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            dbx.files_download_to_file(tmp_path, path)
+            with open(tmp_path, "rb") as f:
+                return f.read()
+        finally:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)

--- a/tests/loaders/test_dropbox_loader.py
+++ b/tests/loaders/test_dropbox_loader.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestDropboxLoader:
+    def _make_loader(self, **kwargs):
+        from synapsekit.loaders.dropbox import DropboxLoader
+
+        return DropboxLoader(
+            access_token=kwargs.get("access_token", "test-token"),
+            path=kwargs.get("path", "/test"),
+            limit=kwargs.get("limit"),
+        )
+
+    def _make_entry(self, name, path, tag="file", **kwargs):
+        return {
+            ".tag": tag,
+            "name": name,
+            "path_display": path,
+            "server_modified": kwargs.get("modified", "2024-01-01T00:00:00Z"),
+        }
+
+    def _make_list_result(self, entries, has_more=False, cursor="cursor1"):
+        result = MagicMock()
+        result.entries = entries
+        result.has_more = has_more
+        result.cursor = cursor
+        return result
+
+    def _mock_dropbox(self, mock_dbx):
+        """Create mock dropbox module and return it."""
+        mock_dropbox = MagicMock()
+        mock_dropbox.Dropbox.return_value = mock_dbx
+        return mock_dropbox
+
+    def test_import_error_without_dropbox(self):
+        loader = self._make_loader()
+        with patch.dict("sys.modules", {"dropbox": None}):
+            with pytest.raises(ImportError, match="dropbox required"):
+                loader.load()
+
+    def test_load_single_text_file(self):
+        loader = self._make_loader()
+        entry = self._make_entry("test.txt", "/test/test.txt")
+        list_result = self._make_list_result([entry])
+
+        mock_dbx = MagicMock()
+        mock_dbx.files_list_folder.return_value = list_result
+        mock_dbx.files_download_to_file.side_effect = (
+            lambda fp, dp: open(fp, "wb").write(b"Hello, world!")
+        )
+
+        mock_dropbox = self._mock_dropbox(mock_dbx)
+        with patch.dict(sys.modules, {"dropbox": mock_dropbox}):
+            docs = loader.load()
+
+        assert len(docs) == 1
+        assert docs[0].text == "Hello, world!"
+        assert docs[0].metadata["source"] == "dropbox"
+        assert docs[0].metadata["filename"] == "test.txt"
+        assert docs[0].metadata["path"] == "/test/test.txt"
+        assert docs[0].metadata["modified"] == "2024-01-01T00:00:00Z"
+
+    def test_load_multiple_files(self):
+        loader = self._make_loader()
+        entries = [
+            self._make_entry("a.txt", "/test/a.txt"),
+            self._make_entry("b.md", "/test/b.md"),
+            self._make_entry("c.py", "/test/c.py"),
+        ]
+        list_result = self._make_list_result(entries)
+
+        mock_dbx = MagicMock()
+        mock_dbx.files_list_folder.return_value = list_result
+        contents = [b"Text A", b"Markdown B", b"Python C"]
+        call_count = [0]
+
+        def write_content(fp, dp):
+            with open(fp, "wb") as f:
+                f.write(contents[call_count[0]])
+            call_count[0] += 1
+
+        mock_dbx.files_download_to_file.side_effect = write_content
+
+        mock_dropbox = self._mock_dropbox(mock_dbx)
+        with patch.dict(sys.modules, {"dropbox": mock_dropbox}):
+            docs = loader.load()
+
+        assert len(docs) == 3
+        assert docs[0].text == "Text A"
+        assert docs[1].text == "Markdown B"
+        assert docs[2].text == "Python C"
+
+    def test_skip_folders(self):
+        loader = self._make_loader()
+        entries = [
+            self._make_entry("file.txt", "/test/file.txt", tag="file"),
+            self._make_entry("folder", "/test/folder", tag="folder"),
+            self._make_entry("doc.md", "/test/doc.md", tag="file"),
+        ]
+        list_result = self._make_list_result(entries)
+
+        mock_dbx = MagicMock()
+        mock_dbx.files_list_folder.return_value = list_result
+        mock_dbx.files_download_to_file.side_effect = (
+            lambda fp, dp: open(fp, "wb").write(b"content")
+        )
+
+        mock_dropbox = self._mock_dropbox(mock_dbx)
+        with patch.dict(sys.modules, {"dropbox": mock_dropbox}):
+            docs = loader.load()
+
+        assert len(docs) == 2
+
+    def test_skip_unsupported_extensions(self):
+        loader = self._make_loader()
+        entries = [
+            self._make_entry("image.png", "/test/image.png"),
+            self._make_entry("video.mp4", "/test/video.mp4"),
+            self._make_entry("doc.pdf", "/test/doc.pdf"),
+            self._make_entry("text.txt", "/test/text.txt"),
+        ]
+        list_result = self._make_list_result(entries)
+
+        mock_dbx = MagicMock()
+        mock_dbx.files_list_folder.return_value = list_result
+        download_count = [0]
+
+        def write_content(fp, dp):
+            download_count[0] += 1
+            with open(fp, "wb") as f:
+                f.write(b"content")
+
+        mock_dbx.files_download_to_file.side_effect = write_content
+
+        mock_dropbox = self._mock_dropbox(mock_dbx)
+        with patch.dict(sys.modules, {"dropbox": mock_dropbox}):
+            docs = loader.load()
+
+        assert len(docs) == 1
+        assert download_count[0] == 1
+
+    def test_pagination_with_cursor(self):
+        loader = self._make_loader()
+        page1_entries = [
+            self._make_entry("file1.txt", "/test/file1.txt"),
+            self._make_entry("file2.txt", "/test/file2.txt"),
+        ]
+        page2_entries = [
+            self._make_entry("file3.txt", "/test/file3.txt"),
+        ]
+
+        page1_result = self._make_list_result(
+            page1_entries, has_more=True, cursor="cursor1"
+        )
+        page2_result = self._make_list_result(page2_entries, has_more=False)
+
+        mock_dbx = MagicMock()
+        mock_dbx.files_list_folder.return_value = page1_result
+        mock_dbx.files_list_folder_continue.return_value = page2_result
+        mock_dbx.files_download_to_file.side_effect = (
+            lambda fp, dp: open(fp, "wb").write(b"content")
+        )
+
+        mock_dropbox = self._mock_dropbox(mock_dbx)
+        with patch.dict(sys.modules, {"dropbox": mock_dropbox}):
+            docs = loader.load()
+
+        assert len(docs) == 3
+        mock_dbx.files_list_folder_continue.assert_called_once_with("cursor1")
+
+    def test_limit_stops_early(self):
+        loader = self._make_loader(limit=2)
+        entries = [
+            self._make_entry("file1.txt", "/test/file1.txt"),
+            self._make_entry("file2.txt", "/test/file2.txt"),
+            self._make_entry("file3.txt", "/test/file3.txt"),
+            self._make_entry("file4.txt", "/test/file4.txt"),
+        ]
+        list_result = self._make_list_result(entries)
+
+        mock_dbx = MagicMock()
+        mock_dbx.files_list_folder.return_value = list_result
+        download_count = [0]
+
+        def write_content(fp, dp):
+            download_count[0] += 1
+            with open(fp, "wb") as f:
+                f.write(b"content")
+
+        mock_dbx.files_download_to_file.side_effect = write_content
+
+        mock_dropbox = self._mock_dropbox(mock_dbx)
+        with patch.dict(sys.modules, {"dropbox": mock_dropbox}):
+            docs = loader.load()
+
+        assert len(docs) == 2
+        assert download_count[0] == 2
+
+    def test_empty_folder_returns_empty_list(self):
+        loader = self._make_loader()
+        list_result = self._make_list_result([])
+
+        mock_dbx = MagicMock()
+        mock_dbx.files_list_folder.return_value = list_result
+
+        mock_dropbox = self._mock_dropbox(mock_dbx)
+        with patch.dict(sys.modules, {"dropbox": mock_dropbox}):
+            docs = loader.load()
+
+        assert docs == []
+
+    def test_download_error_skips_file(self):
+        loader = self._make_loader()
+        entries = [
+            self._make_entry("good.txt", "/test/good.txt"),
+            self._make_entry("bad.txt", "/test/bad.txt"),
+            self._make_entry("also_good.txt", "/test/also_good.txt"),
+        ]
+        list_result = self._make_list_result(entries)
+
+        mock_dbx = MagicMock()
+        mock_dbx.files_list_folder.return_value = list_result
+        call_count = [0]
+
+        def write_content(fp, dp):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                raise Exception("Download failed")
+            with open(fp, "wb") as f:
+                f.write(b"content")
+
+        mock_dbx.files_download_to_file.side_effect = write_content
+
+        mock_dropbox = self._mock_dropbox(mock_dbx)
+        with patch.dict(sys.modules, {"dropbox": mock_dropbox}):
+            docs = loader.load()
+
+        assert len(docs) == 2
+
+    def test_decode_errors_skips_file(self):
+        loader = self._make_loader()
+        entries = [
+            self._make_entry("good.txt", "/test/good.txt"),
+            self._make_entry("bad.txt", "/test/bad.txt"),
+        ]
+        list_result = self._make_list_result(entries)
+
+        mock_dbx = MagicMock()
+        mock_dbx.files_list_folder.return_value = list_result
+        call_count = [0]
+
+        def write_content(fp, dp):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                with open(fp, "wb") as f:
+                    f.write(b"\x80\x81\x82\x83")
+            else:
+                with open(fp, "wb") as f:
+                    f.write(b"valid content")
+
+        mock_dbx.files_download_to_file.side_effect = write_content
+
+        mock_dropbox = self._mock_dropbox(mock_dbx)
+        with patch.dict(sys.modules, {"dropbox": mock_dropbox}):
+            docs = loader.load()
+
+        # Both files should be processed (UTF-8 with errors='ignore' won't fail)
+        assert len(docs) == 2
+
+    def test_supported_extensions(self):
+        loader = self._make_loader()
+        extensions = [
+            "file.txt",
+            "file.md",
+            "file.py",
+            "file.js",
+            "file.ts",
+            "file.java",
+            "file.json",
+            "file.csv",
+            "file.xml",
+            "file.yaml",
+            "file.html",
+            "file.css",
+            "file.cpp",
+            "file.go",
+            "file.rs",
+        ]
+        entries = [self._make_entry(ext, f"/test/{ext}") for ext in extensions]
+        list_result = self._make_list_result(entries)
+
+        mock_dbx = MagicMock()
+        mock_dbx.files_list_folder.return_value = list_result
+        mock_dbx.files_download_to_file.side_effect = (
+            lambda fp, dp: open(fp, "wb").write(b"content")
+        )
+
+        mock_dropbox = self._mock_dropbox(mock_dbx)
+        with patch.dict(sys.modules, {"dropbox": mock_dropbox}):
+            docs = loader.load()
+
+        assert len(docs) == len(extensions)
+
+    def test_missing_metadata_fields(self):
+        loader = self._make_loader()
+        # Entry with a valid filename but missing optional fields
+        entry = {".tag": "file", "name": "test.txt"}
+        list_result = self._make_list_result([entry])
+
+        mock_dbx = MagicMock()
+        mock_dbx.files_list_folder.return_value = list_result
+        mock_dbx.files_download_to_file.side_effect = (
+            lambda fp, dp: open(fp, "wb").write(b"content")
+        )
+
+        mock_dropbox = self._mock_dropbox(mock_dbx)
+        with patch.dict(sys.modules, {"dropbox": mock_dropbox}):
+            docs = loader.load()
+
+        assert len(docs) == 1
+        assert docs[0].metadata["filename"] == "test.txt"
+        assert docs[0].metadata["path"] == ""
+        assert docs[0].metadata["modified"] == ""
+
+    def test_list_folder_error_returns_empty(self):
+        loader = self._make_loader()
+
+        mock_dbx = MagicMock()
+        mock_dbx.files_list_folder.side_effect = Exception("API error")
+
+        mock_dropbox = self._mock_dropbox(mock_dbx)
+        with patch.dict(sys.modules, {"dropbox": mock_dropbox}):
+            docs = loader.load()
+
+        assert docs == []
+
+    @pytest.mark.asyncio
+    async def test_aload(self):
+        loader = self._make_loader()
+        entry = self._make_entry("test.txt", "/test/test.txt")
+        list_result = self._make_list_result([entry])
+
+        mock_dbx = MagicMock()
+        mock_dbx.files_list_folder.return_value = list_result
+        mock_dbx.files_download_to_file.side_effect = (
+            lambda fp, dp: open(fp, "wb").write(b"Async content")
+        )
+
+        mock_dropbox = self._mock_dropbox(mock_dbx)
+        with patch.dict(sys.modules, {"dropbox": mock_dropbox}):
+            docs = await loader.aload()
+
+        assert len(docs) == 1
+        assert docs[0].text == "Async content"
+        assert docs[0].metadata["source"] == "dropbox"

--- a/tests/loaders/test_dropbox_loader.py
+++ b/tests/loaders/test_dropbox_loader.py
@@ -50,8 +50,8 @@ class TestDropboxLoader:
 
         mock_dbx = MagicMock()
         mock_dbx.files_list_folder.return_value = list_result
-        mock_dbx.files_download_to_file.side_effect = (
-            lambda fp, dp: open(fp, "wb").write(b"Hello, world!")
+        mock_dbx.files_download_to_file.side_effect = lambda fp, dp: open(fp, "wb").write(
+            b"Hello, world!"
         )
 
         mock_dropbox = self._mock_dropbox(mock_dbx)
@@ -106,8 +106,8 @@ class TestDropboxLoader:
 
         mock_dbx = MagicMock()
         mock_dbx.files_list_folder.return_value = list_result
-        mock_dbx.files_download_to_file.side_effect = (
-            lambda fp, dp: open(fp, "wb").write(b"content")
+        mock_dbx.files_download_to_file.side_effect = lambda fp, dp: open(fp, "wb").write(
+            b"content"
         )
 
         mock_dropbox = self._mock_dropbox(mock_dbx)
@@ -154,16 +154,14 @@ class TestDropboxLoader:
             self._make_entry("file3.txt", "/test/file3.txt"),
         ]
 
-        page1_result = self._make_list_result(
-            page1_entries, has_more=True, cursor="cursor1"
-        )
+        page1_result = self._make_list_result(page1_entries, has_more=True, cursor="cursor1")
         page2_result = self._make_list_result(page2_entries, has_more=False)
 
         mock_dbx = MagicMock()
         mock_dbx.files_list_folder.return_value = page1_result
         mock_dbx.files_list_folder_continue.return_value = page2_result
-        mock_dbx.files_download_to_file.side_effect = (
-            lambda fp, dp: open(fp, "wb").write(b"content")
+        mock_dbx.files_download_to_file.side_effect = lambda fp, dp: open(fp, "wb").write(
+            b"content"
         )
 
         mock_dropbox = self._mock_dropbox(mock_dbx)
@@ -296,8 +294,8 @@ class TestDropboxLoader:
 
         mock_dbx = MagicMock()
         mock_dbx.files_list_folder.return_value = list_result
-        mock_dbx.files_download_to_file.side_effect = (
-            lambda fp, dp: open(fp, "wb").write(b"content")
+        mock_dbx.files_download_to_file.side_effect = lambda fp, dp: open(fp, "wb").write(
+            b"content"
         )
 
         mock_dropbox = self._mock_dropbox(mock_dbx)
@@ -314,8 +312,8 @@ class TestDropboxLoader:
 
         mock_dbx = MagicMock()
         mock_dbx.files_list_folder.return_value = list_result
-        mock_dbx.files_download_to_file.side_effect = (
-            lambda fp, dp: open(fp, "wb").write(b"content")
+        mock_dbx.files_download_to_file.side_effect = lambda fp, dp: open(fp, "wb").write(
+            b"content"
         )
 
         mock_dropbox = self._mock_dropbox(mock_dbx)
@@ -347,8 +345,8 @@ class TestDropboxLoader:
 
         mock_dbx = MagicMock()
         mock_dbx.files_list_folder.return_value = list_result
-        mock_dbx.files_download_to_file.side_effect = (
-            lambda fp, dp: open(fp, "wb").write(b"Async content")
+        mock_dbx.files_download_to_file.side_effect = lambda fp, dp: open(fp, "wb").write(
+            b"Async content"
         )
 
         mock_dropbox = self._mock_dropbox(mock_dbx)

--- a/uv.lock
+++ b/uv.lock
@@ -1470,6 +1470,20 @@ wheels = [
 ]
 
 [[package]]
+name = "dropbox"
+version = "12.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "six" },
+    { name = "stone" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/56/ac085f58e8e0d0bcafdf98c2605e454ac946e3d0c72679669ae112dc30be/dropbox-12.0.2.tar.gz", hash = "sha256:50057fd5ad5fcf047f542dfc6747a896e7ef982f1b5f8500daf51f3abd609962", size = 560236, upload-time = "2024-06-03T16:45:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/de/95d8204d9a20fbdb353c5f8e4229b0fcb90f22b96f8246ff1f47c8a45fd5/dropbox-12.0.2-py3-none-any.whl", hash = "sha256:c5b7e9c2668adb6b12dcecd84342565dc50f7d35ab6a748d155cb79040979d1c", size = 572076, upload-time = "2024-06-03T16:45:28.153Z" },
+]
+
+[[package]]
 name = "duckduckgo-search"
 version = "8.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5011,6 +5025,15 @@ wheels = [
 ]
 
 [[package]]
+name = "ply"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
+]
+
+[[package]]
 name = "portalocker"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -7282,6 +7305,19 @@ wheels = [
 ]
 
 [[package]]
+name = "stone"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ply" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/6f/ef25bbc1aefeb9c905d527f1d3cd3f41f22f40566d33001b8bb14ae0cdaf/stone-3.3.1.tar.gz", hash = "sha256:4ef0397512f609757975f7ec09b35639d72ba7e3e17ce4ddf399578346b4cb50", size = 190888, upload-time = "2022-01-25T21:32:16.729Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/92/d0c83f63d3518e5f0b8a311937c31347349ec9a47b209ddc17f7566f58fc/stone-3.3.1-py3-none-any.whl", hash = "sha256:e15866fad249c11a963cce3bdbed37758f2e88c8ff4898616bc0caeb1e216047", size = 162257, upload-time = "2022-01-25T21:32:15.155Z" },
+]
+
+[[package]]
 name = "storage3"
 version = "2.28.3"
 source = { registry = "https://pypi.org/simple" }
@@ -7478,6 +7514,9 @@ discord = [
 ]
 docx = [
     { name = "python-docx" },
+]
+dropbox = [
+    { name = "dropbox" },
 ]
 dynamodb = [
     { name = "boto3" },
@@ -7677,6 +7716,7 @@ requires-dist = [
     { name = "cohere", marker = "extra == 'cohere'", specifier = ">=5.0" },
     { name = "discord-py", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "discord-py", marker = "extra == 'discord'", specifier = ">=2.0" },
+    { name = "dropbox", marker = "extra == 'dropbox'", specifier = ">=12.0" },
     { name = "duckduckgo-search", marker = "extra == 'all'", specifier = ">=6.0" },
     { name = "duckduckgo-search", marker = "extra == 'search'", specifier = ">=6.0" },
     { name = "erniebot", marker = "extra == 'all'", specifier = ">=0.5" },
@@ -7773,7 +7813,7 @@ requires-dist = [
     { name = "youtube-search-python", marker = "extra == 'all'", specifier = ">=1.6" },
     { name = "youtube-search-python", marker = "extra == 'youtube'", specifier = ">=1.6" },
 ]
-provides-extras = ["openai", "anthropic", "semantic", "colbert", "pdf", "wikipedia", "arxiv", "html", "web", "chroma", "faiss", "qdrant", "pinecone", "weaviate", "milvus", "lancedb", "ollama", "ai21", "cohere", "mistral", "gemini", "bedrock", "gcal-tool", "aws-lambda", "rss", "groq", "audio", "video", "excel", "pptx", "docx", "yaml", "teams", "http", "search", "huggingface", "google-search", "tavily", "youtube", "mcp", "redis", "memcached", "vertex", "cloudflare", "aleph-alpha", "llamacpp", "ernie", "minimax", "serve", "postgres", "pgvector", "wolfram", "dynamodb", "discord", "gcs", "gdrive", "git", "gsheets", "jira", "sql", "slack", "supabase", "notion", "confluence", "all"]
+provides-extras = ["openai", "anthropic", "semantic", "colbert", "pdf", "wikipedia", "arxiv", "html", "web", "chroma", "faiss", "qdrant", "pinecone", "weaviate", "milvus", "lancedb", "ollama", "ai21", "cohere", "mistral", "gemini", "bedrock", "gcal-tool", "aws-lambda", "rss", "groq", "audio", "video", "excel", "pptx", "docx", "yaml", "teams", "http", "search", "huggingface", "google-search", "tavily", "youtube", "mcp", "redis", "memcached", "vertex", "cloudflare", "aleph-alpha", "llamacpp", "ernie", "minimax", "serve", "postgres", "pgvector", "wolfram", "dynamodb", "discord", "gcs", "gdrive", "git", "gsheets", "jira", "sql", "slack", "supabase", "notion", "confluence", "dropbox", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

This PR adds a DropboxLoader that downloads files from a Dropbox folder and extracts text content as list[Document].
Includes both sync (load()) and async (aload()) methods, pagination support, and comprehensive test coverage.

Closes #53 

## Type of change
 - [ ] Bug fix
 - [x] New feature
 - [ ] Documentation update
 - [ ] Refactor / internal improvement
 - [ ] Dependency / tooling update

## Changes
 - Created src/synapsekit/loaders/dropbox.py with DropboxLoader class
 - Added dropbox = ["dropbox>=12.0"] optional dependency to pyproject.toml
 - Implemented folder listing with pagination, file filtering, text extraction, and metadata tracking
 - Added exports in loaders/__init__.py and top-level __init__.py (lazy import)
 - Added async def aload() method for async support
 - Created 14 comprehensive tests in tests/loaders/test_dropbox_loader.py (all mock, no real API calls)

## Testing
 - [x] All existing tests pass (uv run pytest tests/ -q)
 - [x] New tests added for new behaviour
 - [x] No API keys or secrets in the code