### PR TITLE
feat(loaders): add MongoDBLoader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ git = ["gitpython>=3.1"]
 gsheets = ["google-api-python-client>=2.0", "google-auth>=2.0"]
 jira = ["httpx>=0.27"]
 sql = ["sqlalchemy>=2.0"]
+mongodb = ["pymongo>=4.0"]
 slack = ["slack-sdk>=3.0"]
 supabase = ["supabase>=2.0"]
 notion = ["httpx>=0.27"]
@@ -151,6 +152,7 @@ all = [
     "feedparser>=6.0",
     "gitpython>=3.1",
     "supabase>=2.0",
+    "pymongo>=4.0",
 ]
 
 [dependency-groups]
@@ -286,6 +288,6 @@ gitpython = "git"
 
 [tool.deptry.per_rule_ignores]
 DEP001 = ["sqlalchemy", "pydantic", "aiohttp", "opentelemetry", "whisper", "botocore", "aiomcache", "nest_asyncio", "huggingface_hub", "serpapi", "weaviate"]
-DEP002 = ["numpy", "rank-bm25", "beautifulsoup4", "lxml", "faiss-cpu", "google-generativeai", "tavily-python", "youtube-search-python", "psycopg", "google-search-results", "discord.py", "google-auth", "weaviate-client", "pymilvus", "lancedb", "pgvector", "slack-sdk", "supabase"]
+DEP002 = ["numpy", "rank-bm25", "beautifulsoup4", "lxml", "faiss-cpu", "google-generativeai", "tavily-python", "youtube-search-python", "psycopg", "google-search-results", "discord.py", "google-auth", "weaviate-client", "pymilvus", "lancedb", "pgvector", "slack-sdk", "supabase", "pymongo"]
 DEP003 = ["sqlalchemy", "botocore", "nest_asyncio"]
 DEP004 = ["pydantic"]

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -166,6 +166,7 @@ from .loaders.image import ImageLoader
 from .loaders.jira import JiraLoader
 from .loaders.json_loader import JSONLoader
 from .loaders.markdown import MarkdownLoader
+from .loaders.mongodb import MongoDBLoader
 from .loaders.pdf import PDFLoader
 from .loaders.rss import RSSLoader
 from .loaders.sql import SQLLoader
@@ -352,6 +353,7 @@ __all__ = [
     "GoogleSheetsLoader",
     "JiraLoader",
     "MarkdownLoader",
+    "MongoDBLoader",
     "SQLLoader",
     "SupabaseLoader",
     "TeamsLoader",
@@ -604,6 +606,7 @@ _LAZY_IMPORTS = {
     "DiscordLoader": "loaders.discord",
     "XMLLoader": "loaders.xml_loader",
     "GoogleDriveLoader": "loaders.google_drive",
+    "MongoDBLoader": "loaders.mongodb",
 }
 
 

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from .base import Document
 from .markdown import MarkdownLoader
+from .mongodb import MongoDBLoader
 from .text import StringLoader, TextLoader
 
 __all__ = [
@@ -23,6 +24,7 @@ __all__ = [
     "JSONLoader",
     "JiraLoader",
     "MarkdownLoader",
+    "MongoDBLoader",
     "NotionLoader",
     "PDFLoader",
     "RSSLoader",
@@ -68,6 +70,7 @@ _LOADERS = {
     "TeamsLoader": ".teams",
     "WikipediaLoader": ".wikipedia",
     "ConfluenceLoader": ".confluence",
+    "MongoDBLoader": ".mongodb",
 }
 
 

--- a/src/synapsekit/loaders/mongodb.py
+++ b/src/synapsekit/loaders/mongodb.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from typing import Any
+
+from .base import Document
+
+
+class MongoDBLoader:
+    """Load documents from a MongoDB collection."""
+
+    def __init__(
+        self,
+        connection_string: str,
+        database: str,
+        collection: str,
+        query_filter: Mapping[str, Any] | None = None,
+        text_fields: list[str] | None = None,
+        metadata_fields: list[str] | None = None,
+    ) -> None:
+        if not connection_string:
+            raise ValueError("connection_string must be provided")
+        if not database:
+            raise ValueError("database must be provided")
+        if not collection:
+            raise ValueError("collection must be provided")
+
+        self._connection_string = connection_string
+        self._database = database
+        self._collection = collection
+        self._query_filter = dict(query_filter or {})
+        self._text_fields = text_fields
+        self._metadata_fields = metadata_fields
+
+    def load(self) -> list[Document]:
+        try:
+            from pymongo import MongoClient
+        except ImportError:
+            raise ImportError("pymongo required: pip install synapsekit[mongodb]") from None
+
+        client = MongoClient(self._connection_string)
+        try:
+            coll = client[self._database][self._collection]
+            projection = self._build_projection()
+            if projection is None:
+                rows = list(coll.find(self._query_filter))
+            else:
+                rows = list(coll.find(self._query_filter, projection))
+        finally:
+            client.close()
+
+        docs: list[Document] = []
+        for idx, row in enumerate(rows):
+            text = self._build_text(row)
+            metadata = self._build_metadata(row, idx)
+            docs.append(Document(text=text, metadata=metadata))
+
+        return docs
+
+    async def aload(self) -> list[Document]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.load)
+
+    def _build_projection(self) -> dict[str, int] | None:
+        fields: set[str] = set()
+        if self._text_fields:
+            fields.update(self._text_fields)
+        if self._metadata_fields:
+            fields.update(self._metadata_fields)
+
+        if not fields:
+            return None
+
+        # Keep _id by default so callers can include it in metadata if desired.
+        fields.add("_id")
+        return {field: 1 for field in fields}
+
+    def _build_text(self, row: Mapping[str, Any]) -> str:
+        if self._text_fields:
+            parts = []
+            for field in self._text_fields:
+                value = row.get(field, "")
+                parts.append("" if value is None else str(value))
+            return "\n".join(parts)
+
+        return "\n".join(f"{key}: {value}" for key, value in row.items())
+
+    def _build_metadata(self, row: Mapping[str, Any], idx: int) -> dict[str, Any]:
+        metadata: dict[str, Any] = {
+            "source": "mongodb",
+            "database": self._database,
+            "collection": self._collection,
+            "row": idx,
+            "query": dict(self._query_filter),
+        }
+
+        if self._metadata_fields:
+            for field in self._metadata_fields:
+                if field in row:
+                    metadata[field] = row[field]
+        else:
+            metadata.update(row)
+
+        return metadata

--- a/tests/loaders/test_mongodb_loader.py
+++ b/tests/loaders/test_mongodb_loader.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapsekit.loaders import Document
+from synapsekit.loaders.mongodb import MongoDBLoader
+
+
+def test_init_requires_connection_string() -> None:
+    with pytest.raises(ValueError, match="connection_string must be provided"):
+        MongoDBLoader(connection_string="", database="db", collection="col")
+
+
+def test_init_requires_database() -> None:
+    with pytest.raises(ValueError, match="database must be provided"):
+        MongoDBLoader(connection_string="mongodb://localhost:27017", database="", collection="col")
+
+
+def test_init_requires_collection() -> None:
+    with pytest.raises(ValueError, match="collection must be provided"):
+        MongoDBLoader(connection_string="mongodb://localhost:27017", database="db", collection="")
+
+
+def test_load_import_error_missing_pymongo() -> None:
+    with patch.dict("sys.modules", {"pymongo": None}):
+        loader = MongoDBLoader(
+            connection_string="mongodb://localhost:27017",
+            database="analytics",
+            collection="events",
+        )
+        with pytest.raises(ImportError, match="pymongo required"):
+            loader.load()
+
+
+@patch.dict("sys.modules", {"pymongo": MagicMock()})
+def test_load_with_default_text_and_metadata() -> None:
+    import sys
+
+    mock_mongo_client = sys.modules["pymongo"].MongoClient
+    mock_client = MagicMock()
+    mock_mongo_client.return_value = mock_client
+
+    rows = [
+        {"_id": "a1", "title": "First", "content": "Hello", "author": "Alice"},
+        {"_id": "a2", "title": "Second", "content": "World", "author": "Bob"},
+    ]
+
+    mock_collection = MagicMock()
+    mock_collection.find.return_value = rows
+
+    mock_db = MagicMock()
+    mock_db.__getitem__.return_value = mock_collection
+    mock_client.__getitem__.return_value = mock_db
+
+    loader = MongoDBLoader(
+        connection_string="mongodb://localhost:27017",
+        database="analytics",
+        collection="articles",
+        query_filter={"author": "Alice"},
+    )
+
+    docs = loader.load()
+
+    assert len(docs) == 2
+    assert all(isinstance(doc, Document) for doc in docs)
+
+    assert "title: First" in docs[0].text
+    assert "content: Hello" in docs[0].text
+
+    assert docs[0].metadata["source"] == "mongodb"
+    assert docs[0].metadata["database"] == "analytics"
+    assert docs[0].metadata["collection"] == "articles"
+    assert docs[0].metadata["row"] == 0
+    assert docs[0].metadata["query"] == {"author": "Alice"}
+    assert docs[0].metadata["author"] == "Alice"
+
+    mock_collection.find.assert_called_once_with({"author": "Alice"})
+    mock_client.close.assert_called_once()
+
+
+@patch.dict("sys.modules", {"pymongo": MagicMock()})
+def test_load_with_text_fields_and_metadata_fields() -> None:
+    import sys
+
+    mock_mongo_client = sys.modules["pymongo"].MongoClient
+    mock_client = MagicMock()
+    mock_mongo_client.return_value = mock_client
+
+    rows = [
+        {
+            "_id": "x1",
+            "title": "Mongo Intro",
+            "body": "A beginner guide",
+            "author": "Carol",
+            "tags": ["db", "mongo"],
+        }
+    ]
+
+    mock_collection = MagicMock()
+    mock_collection.find.return_value = rows
+
+    mock_db = MagicMock()
+    mock_db.__getitem__.return_value = mock_collection
+    mock_client.__getitem__.return_value = mock_db
+
+    loader = MongoDBLoader(
+        connection_string="mongodb://localhost:27017",
+        database="content",
+        collection="posts",
+        text_fields=["title", "body"],
+        metadata_fields=["_id", "author"],
+    )
+
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].text == "Mongo Intro\nA beginner guide"
+
+    assert docs[0].metadata["source"] == "mongodb"
+    assert docs[0].metadata["database"] == "content"
+    assert docs[0].metadata["collection"] == "posts"
+    assert docs[0].metadata["_id"] == "x1"
+    assert docs[0].metadata["author"] == "Carol"
+    assert "tags" not in docs[0].metadata
+
+    mock_collection.find.assert_called_once_with({}, {"_id": 1, "title": 1, "body": 1, "author": 1})
+
+
+@patch.dict("sys.modules", {"pymongo": MagicMock()})
+def test_load_empty_results() -> None:
+    import sys
+
+    mock_mongo_client = sys.modules["pymongo"].MongoClient
+    mock_client = MagicMock()
+    mock_mongo_client.return_value = mock_client
+
+    mock_collection = MagicMock()
+    mock_collection.find.return_value = []
+
+    mock_db = MagicMock()
+    mock_db.__getitem__.return_value = mock_collection
+    mock_client.__getitem__.return_value = mock_db
+
+    loader = MongoDBLoader(
+        connection_string="mongodb://localhost:27017",
+        database="content",
+        collection="posts",
+    )
+
+    docs = loader.load()
+    assert docs == []
+
+
+def test_query_filter_defensive_copy() -> None:
+    query = {"status": "active"}
+    loader = MongoDBLoader(
+        connection_string="mongodb://localhost:27017",
+        database="content",
+        collection="posts",
+        query_filter=query,
+    )
+    query["status"] = "inactive"
+
+    assert loader._query_filter == {"status": "active"}
+
+
+@patch.dict("sys.modules", {"pymongo": MagicMock()})
+def test_text_fields_none_values_are_empty_strings() -> None:
+    import sys
+
+    mock_mongo_client = sys.modules["pymongo"].MongoClient
+    mock_client = MagicMock()
+    mock_mongo_client.return_value = mock_client
+
+    rows = [{"_id": "1", "title": None, "body": "content"}]
+
+    mock_collection = MagicMock()
+    mock_collection.find.return_value = rows
+
+    mock_db = MagicMock()
+    mock_db.__getitem__.return_value = mock_collection
+    mock_client.__getitem__.return_value = mock_db
+
+    loader = MongoDBLoader(
+        connection_string="mongodb://localhost:27017",
+        database="db",
+        collection="col",
+        text_fields=["title", "body"],
+    )
+
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].text == "\ncontent"
+
+
+@patch.dict("sys.modules", {"pymongo": MagicMock()})
+def test_aload() -> None:
+    import sys
+
+    mock_mongo_client = sys.modules["pymongo"].MongoClient
+    mock_client = MagicMock()
+    mock_mongo_client.return_value = mock_client
+
+    rows = [{"_id": "1", "text": "hello"}]
+
+    mock_collection = MagicMock()
+    mock_collection.find.return_value = rows
+
+    mock_db = MagicMock()
+    mock_db.__getitem__.return_value = mock_collection
+    mock_client.__getitem__.return_value = mock_db
+
+    loader = MongoDBLoader(
+        connection_string="mongodb://localhost:27017",
+        database="db",
+        collection="col",
+        text_fields=["text"],
+    )
+
+    docs = asyncio.run(loader.aload())
+
+    assert len(docs) == 1
+    assert docs[0].text == "hello"


### PR DESCRIPTION
## Summary
This PR adds a new `MongoDBLoader` for loading documents from MongoDB collections.

## Changes
- Added `src/synapsekit/loaders/mongodb.py`
- Added optional dependency:
  - `mongodb = ["pymongo>=4.0"]` in `pyproject.toml`
- Exported `MongoDBLoader` from:
  - `synapsekit.loaders`
  - top-level `synapsekit`
- Added tests with mocked `pymongo`:
  - `tests/loaders/test_mongodb_loader.py`

## Validation
- `python -m ruff check src/synapsekit/loaders/mongodb.py tests/loaders/test_mongodb_loader.py`
- `python -m pytest tests/loaders/test_mongodb_loader.py -q`

## Scope
- Clean branch from latest `main`
- Contains only the two MongoDB loader commits

Closes #59
