### PR TITLE
feat(loaders): add AzureBlobLoader for Azure Blob Storage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,6 +285,7 @@ slack-sdk = "slack_sdk"
 weaviate-client = "weaviate"
 atlassian-python-api = "atlassian"
 gitpython = "git"
+azure-storage-blob = "azure"
 
 [tool.deptry.per_rule_ignores]
 DEP001 = ["sqlalchemy", "pydantic", "aiohttp", "opentelemetry", "whisper", "botocore", "aiomcache", "nest_asyncio", "huggingface_hub", "serpapi", "weaviate"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ git = ["gitpython>=3.1"]
 gsheets = ["google-api-python-client>=2.0", "google-auth>=2.0"]
 jira = ["httpx>=0.27"]
 sql = ["sqlalchemy>=2.0"]
+azure = ["azure-storage-blob>=12.0"]
 slack = ["slack-sdk>=3.0"]
 supabase = ["supabase>=2.0"]
 notion = ["httpx>=0.27"]
@@ -151,6 +152,7 @@ all = [
     "feedparser>=6.0",
     "gitpython>=3.1",
     "supabase>=2.0",
+    "azure-storage-blob>=12.0",
 ]
 
 [dependency-groups]
@@ -286,6 +288,6 @@ gitpython = "git"
 
 [tool.deptry.per_rule_ignores]
 DEP001 = ["sqlalchemy", "pydantic", "aiohttp", "opentelemetry", "whisper", "botocore", "aiomcache", "nest_asyncio", "huggingface_hub", "serpapi", "weaviate"]
-DEP002 = ["numpy", "rank-bm25", "beautifulsoup4", "lxml", "faiss-cpu", "google-generativeai", "tavily-python", "youtube-search-python", "psycopg", "google-search-results", "discord.py", "google-auth", "weaviate-client", "pymilvus", "lancedb", "pgvector", "slack-sdk", "supabase"]
+DEP002 = ["numpy", "rank-bm25", "beautifulsoup4", "lxml", "faiss-cpu", "google-generativeai", "tavily-python", "youtube-search-python", "psycopg", "google-search-results", "discord.py", "google-auth", "weaviate-client", "pymilvus", "lancedb", "pgvector", "slack-sdk", "supabase", "azure-storage-blob"]
 DEP003 = ["sqlalchemy", "botocore", "nest_asyncio"]
 DEP004 = ["pydantic"]

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -152,6 +152,7 @@ from .llm.fallback_chain import FallbackChain, FallbackChainConfig
 from .llm.multimodal import AudioContent, ImageContent, MultimodalMessage
 from .llm.structured import generate_structured
 from .loaders.arxiv import ArXivLoader
+from .loaders.azure_blob import AzureBlobLoader
 from .loaders.base import Document
 from .loaders.confluence import ConfluenceLoader
 from .loaders.csv import CSVLoader
@@ -337,6 +338,7 @@ __all__ = [
     "Document",
     "TextLoader",
     "ArXivLoader",
+    "AzureBlobLoader",
     "StringLoader",
     "PDFLoader",
     "HTMLLoader",
@@ -604,6 +606,7 @@ _LAZY_IMPORTS = {
     "DiscordLoader": "loaders.discord",
     "XMLLoader": "loaders.xml_loader",
     "GoogleDriveLoader": "loaders.google_drive",
+    "AzureBlobLoader": "loaders.azure_blob",
 }
 
 

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from .azure_blob import AzureBlobLoader
 from .base import Document
 from .markdown import MarkdownLoader
 from .text import StringLoader, TextLoader
@@ -7,6 +8,7 @@ from .text import StringLoader, TextLoader
 __all__ = [
     "ArXivLoader",
     "AudioLoader",
+    "AzureBlobLoader",
     "CSVLoader",
     "ConfluenceLoader",
     "DirectoryLoader",
@@ -41,6 +43,7 @@ __all__ = [
 
 _LOADERS = {
     "ArXivLoader": ".arxiv",
+    "AzureBlobLoader": ".azure_blob",
     "PDFLoader": ".pdf",
     "HTMLLoader": ".html",
     "CSVLoader": ".csv",

--- a/src/synapsekit/loaders/azure_blob.py
+++ b/src/synapsekit/loaders/azure_blob.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import os
 import tempfile
-from typing import Any
+from typing import Any, cast
 
 from .base import Document
 
@@ -104,7 +104,8 @@ class AzureBlobLoader:
                 blob_client = container_client.get_blob_client(blob.name)
                 content_bytes = await loop.run_in_executor(
                     None,
-                    lambda bc=blob_client: bc.download_blob().readall(),
+                    self._download_blob_bytes,
+                    blob_client,
                 )
                 content_type = self._blob_content_type(blob)
                 text = self._extract_text(blob.name, content_bytes, content_type)
@@ -129,6 +130,10 @@ class AzureBlobLoader:
                 logger.warning("AzureBlobLoader: skipping blob %r — %s", blob.name, exc)
 
         return docs
+
+    @staticmethod
+    def _download_blob_bytes(blob_client: Any) -> bytes:
+        return cast(bytes, blob_client.download_blob().readall())
 
     def _blob_content_type(self, blob: Any) -> str | None:
         content_settings = getattr(blob, "content_settings", None)

--- a/src/synapsekit/loaders/azure_blob.py
+++ b/src/synapsekit/loaders/azure_blob.py
@@ -1,0 +1,206 @@
+"""AzureBlobLoader — load files from Azure Blob Storage."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import tempfile
+from typing import Any
+
+from .base import Document
+
+logger = logging.getLogger(__name__)
+
+
+class AzureBlobLoader:
+    """Load files from Azure Blob Storage into Documents.
+
+    Supports authentication via either connection string or account URL + credential.
+    """
+
+    _TEXT_EXTENSIONS = {
+        ".txt",
+        ".md",
+        ".yaml",
+        ".yml",
+        ".xml",
+        ".log",
+        ".rst",
+        ".py",
+    }
+
+    _EXTRACTABLE_EXTENSIONS = {".pdf", ".docx", ".xlsx", ".pptx", ".csv", ".json", ".html", ".htm"}
+
+    def __init__(
+        self,
+        container_name: str,
+        connection_string: str | None = None,
+        account_url: str | None = None,
+        credential: str | None = None,
+        prefix: str | None = None,
+        max_files: int | None = None,
+    ) -> None:
+        if not container_name:
+            raise ValueError("container_name must be provided")
+
+        if not connection_string and not (account_url and credential):
+            raise ValueError("Provide either connection_string or both account_url and credential")
+
+        self.container_name = container_name
+        self.connection_string = connection_string
+        self.account_url = account_url
+        self.credential = credential
+        self.prefix = prefix
+        self.max_files = max_files
+
+    def load(self) -> list[Document]:
+        """Synchronously fetch files from Azure Blob Storage."""
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            return loop.run_until_complete(self.aload())
+        finally:
+            loop.close()
+
+    async def aload(self) -> list[Document]:
+        """Asynchronously fetch files from Azure Blob Storage."""
+        try:
+            from azure.storage.blob import BlobServiceClient
+        except ImportError:
+            raise ImportError(
+                "Azure Blob Storage dependencies required: pip install synapsekit[azure]"
+            ) from None
+
+        loop = asyncio.get_running_loop()
+
+        if self.connection_string:
+            client = await loop.run_in_executor(
+                None,
+                lambda: BlobServiceClient.from_connection_string(self.connection_string),
+            )
+        else:
+            client = await loop.run_in_executor(
+                None,
+                lambda: BlobServiceClient(account_url=self.account_url, credential=self.credential),
+            )
+
+        container_client = client.get_container_client(self.container_name)
+        blobs = await loop.run_in_executor(
+            None,
+            lambda: list(container_client.list_blobs(name_starts_with=self.prefix)),
+        )
+
+        if self.max_files is not None:
+            blobs = blobs[: self.max_files]
+
+        docs: list[Document] = []
+
+        for blob in blobs:
+            if blob.name.endswith("/"):
+                continue
+
+            try:
+                blob_client = container_client.get_blob_client(blob.name)
+                content_bytes = await loop.run_in_executor(
+                    None,
+                    lambda bc=blob_client: bc.download_blob().readall(),
+                )
+                content_type = self._blob_content_type(blob)
+                text = self._extract_text(blob.name, content_bytes, content_type)
+                docs.append(
+                    Document(
+                        text=text,
+                        metadata={
+                            "source": "azure_blob",
+                            "container": self.container_name,
+                            "blob_name": blob.name,
+                            "size": getattr(blob, "size", None),
+                            "content_type": content_type,
+                            "last_modified": (
+                                blob.last_modified.isoformat()
+                                if getattr(blob, "last_modified", None)
+                                else None
+                            ),
+                        },
+                    )
+                )
+            except Exception as exc:
+                logger.warning("AzureBlobLoader: skipping blob %r — %s", blob.name, exc)
+
+        return docs
+
+    def _blob_content_type(self, blob: Any) -> str | None:
+        content_settings = getattr(blob, "content_settings", None)
+        if content_settings is None:
+            return None
+        return getattr(content_settings, "content_type", None)
+
+    def _extract_text(self, blob_name: str, content: bytes, content_type: str | None) -> str:
+        ext = os.path.splitext(blob_name)[1].lower()
+
+        if ext in self._TEXT_EXTENSIONS:
+            return content.decode("utf-8", errors="replace")
+
+        extracted = self._extract_with_supported_loader(blob_name, content, ext)
+        if extracted is not None:
+            return extracted
+
+        try:
+            return content.decode("utf-8")
+        except UnicodeDecodeError:
+            descriptor = content_type or ext or "unknown"
+            return f"[Binary file: {descriptor}]"
+
+    def _extract_with_supported_loader(
+        self, blob_name: str, content: bytes, ext: str
+    ) -> str | None:
+        if ext not in self._EXTRACTABLE_EXTENSIONS:
+            return None
+
+        temp_path: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmp:
+                tmp.write(content)
+                temp_path = tmp.name
+
+            docs = self._run_loader_for_extension(ext, temp_path)
+            return "\n\n".join(doc.text for doc in docs if doc.text)
+        except Exception as exc:
+            logger.warning("AzureBlobLoader: extraction fallback for %r — %s", blob_name, exc)
+            return None
+        finally:
+            if temp_path and os.path.exists(temp_path):
+                os.remove(temp_path)
+
+    def _run_loader_for_extension(self, ext: str, path: str) -> list[Document]:
+        if ext == ".pdf":
+            from .pdf import PDFLoader
+
+            return PDFLoader(path).load()
+        if ext == ".docx":
+            from .docx import DocxLoader
+
+            return DocxLoader(path).load()
+        if ext == ".xlsx":
+            from .excel import ExcelLoader
+
+            return ExcelLoader(path).load()
+        if ext == ".pptx":
+            from .pptx import PowerPointLoader
+
+            return PowerPointLoader(path).load()
+        if ext == ".csv":
+            from .csv import CSVLoader
+
+            return CSVLoader(path).load()
+        if ext == ".json":
+            from .json_loader import JSONLoader
+
+            return JSONLoader(path).load()
+        if ext in {".html", ".htm"}:
+            from .html import HTMLLoader
+
+            return HTMLLoader(path).load()
+
+        return []

--- a/tests/loaders/test_azure_blob_loader.py
+++ b/tests/loaders/test_azure_blob_loader.py
@@ -1,0 +1,261 @@
+"""Tests for AzureBlobLoader."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapsekit.loaders import AzureBlobLoader, Document
+
+
+class TestAzureBlobLoader:
+    def test_init_requires_container_name(self):
+        with pytest.raises(ValueError, match="container_name must be provided"):
+            AzureBlobLoader(container_name="", connection_string="UseDevelopmentStorage=true")
+
+    def test_init_requires_auth(self):
+        with pytest.raises(
+            ValueError,
+            match="Provide either connection_string or both account_url and credential",
+        ):
+            AzureBlobLoader(container_name="docs")
+
+    def test_init_allows_connection_string(self):
+        loader = AzureBlobLoader(container_name="docs", connection_string="conn")
+        assert loader.container_name == "docs"
+        assert loader.connection_string == "conn"
+        assert loader.account_url is None
+        assert loader.credential is None
+
+    def test_init_allows_account_credentials(self):
+        loader = AzureBlobLoader(
+            container_name="docs",
+            account_url="https://acct.blob.core.windows.net",
+            credential="secret",
+            prefix="reports/",
+            max_files=5,
+        )
+        assert loader.container_name == "docs"
+        assert loader.account_url == "https://acct.blob.core.windows.net"
+        assert loader.credential == "secret"
+        assert loader.prefix == "reports/"
+        assert loader.max_files == 5
+
+    @pytest.mark.asyncio
+    async def test_aload_missing_dependencies(self):
+        import sys
+
+        loader = AzureBlobLoader(container_name="docs", connection_string="conn")
+
+        with patch.dict(sys.modules, {"azure": None, "azure.storage": None}):
+            with pytest.raises(ImportError, match="synapsekit\\[azure\\]"):
+                await loader.aload()
+
+    @patch.dict("sys.modules", {"azure.storage.blob": MagicMock()})
+    def test_load_with_text_and_binary_blobs_connection_string(self):
+        import sys
+
+        blob_service_client_cls = sys.modules["azure.storage.blob"].BlobServiceClient
+
+        mock_service = MagicMock()
+        blob_service_client_cls.from_connection_string.return_value = mock_service
+
+        container_client = MagicMock()
+        mock_service.get_container_client.return_value = container_client
+
+        txt_blob = MagicMock()
+        txt_blob.name = "docs/readme.txt"
+        txt_blob.size = 13
+        txt_blob.content_settings = MagicMock(content_type="text/plain")
+        txt_blob.last_modified = MagicMock()
+        txt_blob.last_modified.isoformat.return_value = "2026-04-01T10:00:00+00:00"
+
+        bin_blob = MagicMock()
+        bin_blob.name = "images/logo.png"
+        bin_blob.size = 2048
+        bin_blob.content_settings = MagicMock(content_type="image/png")
+        bin_blob.last_modified = MagicMock()
+        bin_blob.last_modified.isoformat.return_value = "2026-04-01T11:00:00+00:00"
+
+        container_client.list_blobs.return_value = [txt_blob, bin_blob]
+
+        txt_blob_client = MagicMock()
+        txt_blob_client.download_blob.return_value.readall.return_value = b"hello from azure"
+
+        bin_blob_client = MagicMock()
+        bin_blob_client.download_blob.return_value.readall.return_value = b"\x89PNG\x00\x01"
+
+        def get_blob_client(name: str):
+            if name == "docs/readme.txt":
+                return txt_blob_client
+            return bin_blob_client
+
+        container_client.get_blob_client.side_effect = get_blob_client
+
+        loader = AzureBlobLoader(container_name="docs", connection_string="conn")
+        docs = loader.load()
+
+        assert len(docs) == 2
+        assert all(isinstance(d, Document) for d in docs)
+
+        assert docs[0].text == "hello from azure"
+        assert docs[0].metadata["source"] == "azure_blob"
+        assert docs[0].metadata["container"] == "docs"
+        assert docs[0].metadata["blob_name"] == "docs/readme.txt"
+        assert docs[0].metadata["content_type"] == "text/plain"
+
+        assert docs[1].text == "[Binary file: image/png]"
+        assert docs[1].metadata["blob_name"] == "images/logo.png"
+
+        container_client.list_blobs.assert_called_once_with(name_starts_with=None)
+
+    @patch.dict("sys.modules", {"azure.storage.blob": MagicMock()})
+    def test_load_extracts_supported_file_via_loader(self):
+        import sys
+
+        blob_service_client_cls = sys.modules["azure.storage.blob"].BlobServiceClient
+
+        mock_service = MagicMock()
+        blob_service_client_cls.from_connection_string.return_value = mock_service
+
+        container_client = MagicMock()
+        mock_service.get_container_client.return_value = container_client
+
+        pdf_blob = MagicMock()
+        pdf_blob.name = "reports/monthly.pdf"
+        pdf_blob.size = 1024
+        pdf_blob.content_settings = MagicMock(content_type="application/pdf")
+        pdf_blob.last_modified = None
+
+        container_client.list_blobs.return_value = [pdf_blob]
+
+        pdf_blob_client = MagicMock()
+        pdf_blob_client.download_blob.return_value.readall.return_value = b"%PDF-1.7 fake bytes"
+        container_client.get_blob_client.return_value = pdf_blob_client
+
+        loader = AzureBlobLoader(container_name="docs", connection_string="conn")
+
+        with patch.object(loader, "_run_loader_for_extension") as run_loader:
+            run_loader.return_value = [
+                Document(text="Extracted Page 1", metadata={}),
+                Document(text="Extracted Page 2", metadata={}),
+            ]
+            docs = loader.load()
+
+        assert len(docs) == 1
+        assert docs[0].text == "Extracted Page 1\n\nExtracted Page 2"
+        run_loader.assert_called_once()
+
+    @patch.dict("sys.modules", {"azure.storage.blob": MagicMock()})
+    def test_load_with_account_url_and_credential(self):
+        import sys
+
+        blob_service_client_cls = sys.modules["azure.storage.blob"].BlobServiceClient
+
+        mock_service = MagicMock()
+        blob_service_client_cls.return_value = mock_service
+
+        container_client = MagicMock()
+        mock_service.get_container_client.return_value = container_client
+
+        blob = MagicMock()
+        blob.name = "reports/weekly.md"
+        blob.size = 42
+        blob.content_settings = MagicMock(content_type="text/markdown")
+        blob.last_modified = None
+
+        container_client.list_blobs.return_value = [blob]
+
+        blob_client = MagicMock()
+        blob_client.download_blob.return_value.readall.return_value = b"# Weekly report"
+        container_client.get_blob_client.return_value = blob_client
+
+        loader = AzureBlobLoader(
+            container_name="reports",
+            account_url="https://acct.blob.core.windows.net",
+            credential="secret",
+            prefix="reports/",
+            max_files=1,
+        )
+
+        docs = loader.load()
+
+        assert len(docs) == 1
+        assert docs[0].text == "# Weekly report"
+        assert docs[0].metadata["container"] == "reports"
+
+        blob_service_client_cls.assert_called_once_with(
+            account_url="https://acct.blob.core.windows.net",
+            credential="secret",
+        )
+        container_client.list_blobs.assert_called_once_with(name_starts_with="reports/")
+
+    @patch.dict("sys.modules", {"azure.storage.blob": MagicMock()})
+    def test_load_skips_virtual_directories(self):
+        import sys
+
+        blob_service_client_cls = sys.modules["azure.storage.blob"].BlobServiceClient
+
+        mock_service = MagicMock()
+        blob_service_client_cls.from_connection_string.return_value = mock_service
+
+        container_client = MagicMock()
+        mock_service.get_container_client.return_value = container_client
+
+        folder_marker = MagicMock()
+        folder_marker.name = "folder/"
+
+        real_blob = MagicMock()
+        real_blob.name = "folder/file.txt"
+        real_blob.size = 5
+        real_blob.content_settings = MagicMock(content_type="text/plain")
+        real_blob.last_modified = None
+
+        container_client.list_blobs.return_value = [folder_marker, real_blob]
+
+        blob_client = MagicMock()
+        blob_client.download_blob.return_value.readall.return_value = b"hello"
+        container_client.get_blob_client.return_value = blob_client
+
+        loader = AzureBlobLoader(container_name="docs", connection_string="conn")
+        docs = loader.load()
+
+        assert len(docs) == 1
+        assert docs[0].metadata["blob_name"] == "folder/file.txt"
+
+    @patch.dict("sys.modules", {"azure.storage.blob": MagicMock()})
+    def test_aload_runs(self):
+        import sys
+
+        blob_service_client_cls = sys.modules["azure.storage.blob"].BlobServiceClient
+
+        mock_service = MagicMock()
+        blob_service_client_cls.from_connection_string.return_value = mock_service
+
+        container_client = MagicMock()
+        mock_service.get_container_client.return_value = container_client
+
+        blob = MagicMock()
+        blob.name = "note.txt"
+        blob.size = 4
+        blob.content_settings = MagicMock(content_type="text/plain")
+        blob.last_modified = None
+
+        container_client.list_blobs.return_value = [blob]
+
+        blob_client = MagicMock()
+        blob_client.download_blob.return_value.readall.return_value = b"test"
+        container_client.get_blob_client.return_value = blob_client
+
+        loader = AzureBlobLoader(container_name="docs", connection_string="conn")
+        docs = asyncio.run(loader.aload())
+
+        assert len(docs) == 1
+        assert docs[0].text == "test"
+
+    def test_extract_with_supported_loader_returns_none_for_unsupported_ext(self):
+        loader = AzureBlobLoader(container_name="docs", connection_string="conn")
+        out = loader._extract_with_supported_loader("blob.bin", b"raw", ".bin")
+        assert out is None


### PR DESCRIPTION
## Summary
- add `AzureBlobLoader` for loading files from Azure Blob Storage
- support auth via connection string or account URL + credential
- support container + optional prefix + max_files
- return `list[Document]` with blob metadata
- add optional dependency `azure = ["azure-storage-blob>=12.0"]`
- export loader through `synapsekit.loaders` and top-level `synapsekit`

## Text extraction behavior
- direct UTF-8 decode for text-like files
- extraction path for supported formats (`.pdf`, `.docx`, `.xlsx`, `.pptx`, `.csv`, `.json`, `.html`, `.htm`) using existing SynapseKit loaders
- binary fallback marker when extraction is not possible

## Tests
- add `tests/loaders/test_azure_blob_loader.py`
- cover constructor validation, auth modes, blob listing behavior, async path, and extraction flow

## Validation
- `python -m ruff check src/synapsekit/loaders/azure_blob.py tests/loaders/test_azure_blob_loader.py`
- `python -m pytest tests/loaders/test_azure_blob_loader.py -q`

Closes #57
