### PR TITLE
Add Discord invite link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) to get started. Look for issues tagged [
 
 ## Community
 
+💬 [Discord](https://discord.gg/INVITE) — chat, help, show and tell
 - 💬 [Discussions](https://github.com/SynapseKit/SynapseKit/discussions) — ask questions, share ideas
 - 🧭 [Discord roles draft](DISCORD_ROLES.md) — proposed roles and permissions for issue #389
 - 🧭 [Discord release webhook draft](DISCORD_RELEASE_WEBHOOKS.md) — automate release announcements for issue #390


### PR DESCRIPTION
## Summary
Added Discord invite link to the Community section in README to improve discoverability.

Closes #398

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / internal improvement
- [ ] Dependency / tooling update

## Changes
- Added Discord invite link at the top of the Community section in README