### PR TITLE
feat(loaders): add OneDrive / SharePoint document loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ sql = ["sqlalchemy>=2.0"]
 mongodb = ["pymongo>=4.0"]
 azure = ["azure-storage-blob>=12.0"]
 s3 = ["boto3>=1.34"]
+onedrive = ["msgraph-sdk>=1.0"]
 slack = ["slack-sdk>=3.0"]
 supabase = ["supabase>=2.0"]
 notion = ["httpx>=0.27"]
@@ -157,6 +158,7 @@ all = [
     "supabase>=2.0",
     "pymongo>=4.0",
     "azure-storage-blob>=12.0",
+    "msgraph-sdk>=1.0",
 ]
 
 [dependency-groups]
@@ -292,9 +294,10 @@ weaviate-client = "weaviate"
 atlassian-python-api = "atlassian"
 gitpython = "git"
 azure-storage-blob = "azure"
+msgraph-sdk = "msgraph"
 
 [tool.deptry.per_rule_ignores]
 DEP001 = ["sqlalchemy", "pydantic", "aiohttp", "opentelemetry", "whisper", "botocore", "aiomcache", "nest_asyncio", "huggingface_hub", "serpapi", "weaviate"]
-DEP002 = ["numpy", "rank-bm25", "beautifulsoup4", "lxml", "faiss-cpu", "google-generativeai", "tavily-python", "youtube-search-python", "psycopg", "google-search-results", "discord.py", "google-auth", "weaviate-client", "pymilvus", "lancedb", "pgvector", "slack-sdk", "supabase", "pymongo", "azure-storage-blob"]
+DEP002 = ["numpy", "rank-bm25", "beautifulsoup4", "lxml", "faiss-cpu", "google-generativeai", "tavily-python", "youtube-search-python", "psycopg", "google-search-results", "discord.py", "google-auth", "weaviate-client", "pymilvus", "lancedb", "pgvector", "slack-sdk", "supabase", "pymongo", "azure-storage-blob", "msgraph-sdk"]
 DEP003 = ["sqlalchemy", "botocore", "nest_asyncio"]
 DEP004 = ["pydantic"]

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -169,6 +169,7 @@ from .loaders.jira import JiraLoader
 from .loaders.json_loader import JSONLoader
 from .loaders.markdown import MarkdownLoader
 from .loaders.mongodb import MongoDBLoader
+from .loaders.onedrive import OneDriveLoader
 from .loaders.pdf import PDFLoader
 from .loaders.rss import RSSLoader
 from .loaders.s3 import S3Loader
@@ -359,6 +360,7 @@ __all__ = [
     "JiraLoader",
     "MarkdownLoader",
     "MongoDBLoader",
+    "OneDriveLoader",
     "SQLLoader",
     "SupabaseLoader",
     "TeamsLoader",
@@ -614,6 +616,7 @@ _LAZY_IMPORTS = {
     "XMLLoader": "loaders.xml_loader",
     "GoogleDriveLoader": "loaders.google_drive",
     "MongoDBLoader": "loaders.mongodb",
+    "OneDriveLoader": "loaders.onedrive",
     "AzureBlobLoader": "loaders.azure_blob",
     "S3Loader": "loaders.s3",
     "DropboxLoader": "loaders.dropbox",

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -4,6 +4,7 @@ from .azure_blob import AzureBlobLoader
 from .base import Document
 from .markdown import MarkdownLoader
 from .mongodb import MongoDBLoader
+from .onedrive import OneDriveLoader
 from .s3 import S3Loader
 from .text import StringLoader, TextLoader
 
@@ -30,6 +31,7 @@ __all__ = [
     "MarkdownLoader",
     "MongoDBLoader",
     "NotionLoader",
+    "OneDriveLoader",
     "PDFLoader",
     "RSSLoader",
     "S3Loader",
@@ -70,6 +72,7 @@ _LOADERS = {
     "JiraLoader": ".jira",
     "SlackLoader": ".slack",
     "NotionLoader": ".notion",
+    "OneDriveLoader": ".onedrive",
     "RSSLoader": ".rss",
     "S3Loader": ".s3",
     "SQLLoader": ".sql",

--- a/src/synapsekit/loaders/onedrive.py
+++ b/src/synapsekit/loaders/onedrive.py
@@ -72,7 +72,9 @@ class OneDriveLoader:
         try:
             import msgraph  # noqa: F401
         except ImportError:
-            raise ImportError("OneDrive dependencies required: pip install synapsekit[onedrive]") from None
+            raise ImportError(
+                "OneDrive dependencies required: pip install synapsekit[onedrive]"
+            ) from None
 
         loop = asyncio.get_running_loop()
         queue: list[str] = [self._children_url(self.folder_id)]
@@ -125,7 +127,9 @@ class OneDriveLoader:
                             )
                         )
                     except Exception as exc:
-                        logger.warning("OneDriveLoader: skipping item %r (%s) — %s", name, item_id, exc)
+                        logger.warning(
+                            "OneDriveLoader: skipping item %r (%s) — %s", name, item_id, exc
+                        )
 
                 page_url = page_data.get("@odata.nextLink")
 

--- a/src/synapsekit/loaders/onedrive.py
+++ b/src/synapsekit/loaders/onedrive.py
@@ -1,0 +1,248 @@
+"""OneDriveLoader — load files from OneDrive or SharePoint via Microsoft Graph."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+from typing import Any, cast
+from urllib.request import Request, urlopen
+
+from .base import Document
+
+logger = logging.getLogger(__name__)
+
+
+class OneDriveLoader:
+    """Load files from OneDrive or SharePoint into Documents.
+
+    Uses Microsoft Graph drive endpoints and supports folder traversal
+    with optional extension filtering.
+    """
+
+    _GRAPH_BASE = "https://graph.microsoft.com/v1.0"
+
+    _TEXT_EXTENSIONS = {
+        ".txt",
+        ".md",
+        ".yaml",
+        ".yml",
+        ".xml",
+        ".log",
+        ".rst",
+        ".py",
+    }
+
+    _EXTRACTABLE_EXTENSIONS = {".pdf", ".docx", ".xlsx", ".pptx", ".csv", ".json", ".html", ".htm"}
+
+    def __init__(
+        self,
+        access_token: str,
+        drive_id: str,
+        folder_id: str | None = None,
+        file_extensions: list[str] | None = None,
+        max_files: int | None = None,
+        recursive: bool = True,
+    ) -> None:
+        if not access_token:
+            raise ValueError("access_token must be provided")
+        if not drive_id:
+            raise ValueError("drive_id must be provided")
+
+        self.access_token = access_token
+        self.drive_id = drive_id
+        self.folder_id = folder_id
+        self.file_extensions = self._normalize_extensions(file_extensions)
+        self.max_files = max_files
+        self.recursive = recursive
+
+    def load(self) -> list[Document]:
+        """Synchronously fetch files from OneDrive/SharePoint."""
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            return loop.run_until_complete(self.aload())
+        finally:
+            loop.close()
+
+    async def aload(self) -> list[Document]:
+        """Asynchronously fetch files from OneDrive/SharePoint."""
+        try:
+            import msgraph  # noqa: F401
+        except ImportError:
+            raise ImportError("OneDrive dependencies required: pip install synapsekit[onedrive]") from None
+
+        loop = asyncio.get_running_loop()
+        queue: list[str] = [self._children_url(self.folder_id)]
+        documents: list[Document] = []
+
+        while queue:
+            page_url: str | None = queue.pop(0)
+
+            while page_url:
+                page_data = await loop.run_in_executor(None, self._graph_get_json, page_url)
+                for item in page_data.get("value", []):
+                    if self.max_files is not None and len(documents) >= self.max_files:
+                        return documents
+
+                    item_id = item.get("id")
+                    if not item_id:
+                        continue
+
+                    # Folder item
+                    if item.get("folder") is not None:
+                        if self.recursive:
+                            queue.append(self._children_url(item_id))
+                        continue
+
+                    name = item.get("name", "")
+                    if self.file_extensions and not self._matches_extension(name):
+                        continue
+
+                    mime_type = self._item_mime_type(item)
+                    try:
+                        content = await loop.run_in_executor(
+                            None,
+                            self._graph_get_bytes,
+                            self._content_url(item_id),
+                        )
+                        text = self._extract_text(name, content, mime_type)
+                        documents.append(
+                            Document(
+                                text=text,
+                                metadata={
+                                    "source": "onedrive",
+                                    "drive_id": self.drive_id,
+                                    "item_id": item_id,
+                                    "file_name": name,
+                                    "mime_type": mime_type,
+                                    "size": item.get("size"),
+                                    "web_url": item.get("webUrl"),
+                                    "last_modified": item.get("lastModifiedDateTime"),
+                                },
+                            )
+                        )
+                    except Exception as exc:
+                        logger.warning("OneDriveLoader: skipping item %r (%s) — %s", name, item_id, exc)
+
+                page_url = page_data.get("@odata.nextLink")
+
+        return documents
+
+    def _children_url(self, folder_id: str | None) -> str:
+        if folder_id:
+            return f"{self._GRAPH_BASE}/drives/{self.drive_id}/items/{folder_id}/children"
+        return f"{self._GRAPH_BASE}/drives/{self.drive_id}/root/children"
+
+    def _content_url(self, item_id: str) -> str:
+        return f"{self._GRAPH_BASE}/drives/{self.drive_id}/items/{item_id}/content"
+
+    def _auth_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.access_token}"}
+
+    def _graph_get_json(self, url: str) -> dict[str, Any]:
+        req = Request(url=url, headers=self._auth_headers(), method="GET")
+        with urlopen(req, timeout=30) as response:
+            payload = cast(bytes, response.read())
+        return cast(dict[str, Any], json.loads(payload.decode("utf-8")))
+
+    def _graph_get_bytes(self, url: str) -> bytes:
+        req = Request(url=url, headers=self._auth_headers(), method="GET")
+        with urlopen(req, timeout=30) as response:
+            return cast(bytes, response.read())
+
+    @staticmethod
+    def _item_mime_type(item: dict[str, Any]) -> str | None:
+        file_info = item.get("file")
+        if not isinstance(file_info, dict):
+            return None
+        mime = file_info.get("mimeType")
+        return mime if isinstance(mime, str) else None
+
+    def _extract_text(self, filename: str, content: bytes, mime_type: str | None) -> str:
+        ext = os.path.splitext(filename)[1].lower()
+
+        if ext in self._TEXT_EXTENSIONS:
+            return content.decode("utf-8", errors="replace")
+
+        extracted = self._extract_with_supported_loader(filename, content, ext)
+        if extracted is not None:
+            return extracted
+
+        try:
+            return content.decode("utf-8")
+        except UnicodeDecodeError:
+            descriptor = mime_type or ext or "unknown"
+            return f"[Binary file: {descriptor}]"
+
+    def _extract_with_supported_loader(self, filename: str, content: bytes, ext: str) -> str | None:
+        if ext not in self._EXTRACTABLE_EXTENSIONS:
+            return None
+
+        temp_path: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmp:
+                tmp.write(content)
+                temp_path = tmp.name
+
+            docs = self._run_loader_for_extension(ext, temp_path)
+            return "\n\n".join(doc.text for doc in docs if doc.text)
+        except Exception as exc:
+            logger.warning("OneDriveLoader: extraction fallback for %r — %s", filename, exc)
+            return None
+        finally:
+            if temp_path and os.path.exists(temp_path):
+                os.remove(temp_path)
+
+    def _run_loader_for_extension(self, ext: str, path: str) -> list[Document]:
+        if ext == ".pdf":
+            from .pdf import PDFLoader
+
+            return PDFLoader(path).load()
+        if ext == ".docx":
+            from .docx import DocxLoader
+
+            return DocxLoader(path).load()
+        if ext == ".xlsx":
+            from .excel import ExcelLoader
+
+            return ExcelLoader(path).load()
+        if ext == ".pptx":
+            from .pptx import PowerPointLoader
+
+            return PowerPointLoader(path).load()
+        if ext == ".csv":
+            from .csv import CSVLoader
+
+            return CSVLoader(path).load()
+        if ext == ".json":
+            from .json_loader import JSONLoader
+
+            return JSONLoader(path).load()
+        if ext in {".html", ".htm"}:
+            from .html import HTMLLoader
+
+            return HTMLLoader(path).load()
+
+        return []
+
+    @staticmethod
+    def _normalize_extensions(file_extensions: list[str] | None) -> set[str] | None:
+        if file_extensions is None:
+            return None
+
+        normalized: set[str] = set()
+        for ext in file_extensions:
+            ext_clean = ext.strip().lower()
+            if not ext_clean:
+                continue
+            if not ext_clean.startswith("."):
+                ext_clean = f".{ext_clean}"
+            normalized.add(ext_clean)
+        return normalized
+
+    def _matches_extension(self, filename: str) -> bool:
+        ext = os.path.splitext(filename)[1].lower()
+        return bool(self.file_extensions and ext in self.file_extensions)

--- a/tests/graph/test_recursive_subgraph.py
+++ b/tests/graph/test_recursive_subgraph.py
@@ -328,12 +328,12 @@ async def test_recursion_depth_error_with_on_error_skip():
 
 
 def test_recursion_depth_error_importable_from_synapsekit():
-    from synapsekit import RecursionDepthError as RDE  # noqa: F401
+    from synapsekit import RecursionDepthError as RDE
 
     assert RDE is RecursionDepthError
 
 
 def test_recursion_depth_error_importable_from_graph():
-    from synapsekit.graph import RecursionDepthError as RDE  # noqa: F401
+    from synapsekit.graph import RecursionDepthError as RDE
 
     assert RDE is RecursionDepthError

--- a/tests/loaders/test_onedrive_loader.py
+++ b/tests/loaders/test_onedrive_loader.py
@@ -79,8 +79,9 @@ class TestOneDriveLoader:
                 return b"hello world"
             return b"\x89PNG\x00\x01"
 
-        with patch.object(loader, "_graph_get_json", side_effect=mock_get_json), patch.object(
-            loader, "_graph_get_bytes", side_effect=mock_get_bytes
+        with (
+            patch.object(loader, "_graph_get_json", side_effect=mock_get_json),
+            patch.object(loader, "_graph_get_bytes", side_effect=mock_get_bytes),
         ):
             docs = loader.load()
 
@@ -111,8 +112,9 @@ class TestOneDriveLoader:
             ]
         }
 
-        with patch.object(loader, "_graph_get_json", return_value=root_children), patch.object(
-            loader, "_graph_get_bytes", return_value=b"ok"
+        with (
+            patch.object(loader, "_graph_get_json", return_value=root_children),
+            patch.object(loader, "_graph_get_bytes", return_value=b"ok"),
         ):
             docs = loader.load()
 
@@ -133,9 +135,11 @@ class TestOneDriveLoader:
             ]
         }
 
-        with patch.object(loader, "_graph_get_json", return_value=root_children), patch.object(
-            loader, "_graph_get_bytes", return_value=b"%PDF-1.7 fake"
-        ), patch.object(loader, "_run_loader_for_extension") as run_loader:
+        with (
+            patch.object(loader, "_graph_get_json", return_value=root_children),
+            patch.object(loader, "_graph_get_bytes", return_value=b"%PDF-1.7 fake"),
+            patch.object(loader, "_run_loader_for_extension") as run_loader,
+        ):
             run_loader.return_value = [
                 Document(text="Extracted Page 1", metadata={}),
                 Document(text="Extracted Page 2", metadata={}),
@@ -178,8 +182,9 @@ class TestOneDriveLoader:
                 return b"root"
             return b"child"
 
-        with patch.object(loader, "_graph_get_json", side_effect=mock_get_json), patch.object(
-            loader, "_graph_get_bytes", side_effect=mock_get_bytes
+        with (
+            patch.object(loader, "_graph_get_json", side_effect=mock_get_json),
+            patch.object(loader, "_graph_get_bytes", side_effect=mock_get_bytes),
         ):
             docs = loader.load()
 
@@ -198,8 +203,9 @@ class TestOneDriveLoader:
             ]
         }
 
-        with patch.object(loader, "_graph_get_json", return_value=root_children), patch.object(
-            loader, "_graph_get_bytes", return_value=b"root"
+        with (
+            patch.object(loader, "_graph_get_json", return_value=root_children),
+            patch.object(loader, "_graph_get_bytes", return_value=b"root"),
         ):
             docs = loader.load()
 
@@ -217,8 +223,9 @@ class TestOneDriveLoader:
             ]
         }
 
-        with patch.object(loader, "_graph_get_json", return_value=root_children), patch.object(
-            loader, "_graph_get_bytes", return_value=b"x"
+        with (
+            patch.object(loader, "_graph_get_json", return_value=root_children),
+            patch.object(loader, "_graph_get_bytes", return_value=b"x"),
         ):
             docs = loader.load()
 
@@ -229,15 +236,18 @@ class TestOneDriveLoader:
     def test_aload_runs(self):
         loader = OneDriveLoader(access_token="token", drive_id="drive123")
 
-        with patch.object(
-            loader,
-            "_graph_get_json",
-            return_value={
-                "value": [
-                    {"id": "file-1", "name": "note.txt", "file": {"mimeType": "text/plain"}}
-                ]
-            },
-        ), patch.object(loader, "_graph_get_bytes", return_value=b"test"):
+        with (
+            patch.object(
+                loader,
+                "_graph_get_json",
+                return_value={
+                    "value": [
+                        {"id": "file-1", "name": "note.txt", "file": {"mimeType": "text/plain"}}
+                    ]
+                },
+            ),
+            patch.object(loader, "_graph_get_bytes", return_value=b"test"),
+        ):
             docs = asyncio.run(loader.aload())
 
         assert len(docs) == 1

--- a/tests/loaders/test_onedrive_loader.py
+++ b/tests/loaders/test_onedrive_loader.py
@@ -1,0 +1,249 @@
+"""Tests for OneDriveLoader."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapsekit.loaders import Document, OneDriveLoader
+
+
+class TestOneDriveLoader:
+    def test_init_requires_access_token(self):
+        with pytest.raises(ValueError, match="access_token must be provided"):
+            OneDriveLoader(access_token="", drive_id="drive123")
+
+    def test_init_requires_drive_id(self):
+        with pytest.raises(ValueError, match="drive_id must be provided"):
+            OneDriveLoader(access_token="token", drive_id="")
+
+    def test_init_with_defaults(self):
+        loader = OneDriveLoader(access_token="token", drive_id="drive123")
+        assert loader.drive_id == "drive123"
+        assert loader.folder_id is None
+        assert loader.file_extensions is None
+        assert loader.max_files is None
+        assert loader.recursive is True
+
+    def test_init_normalizes_extensions(self):
+        loader = OneDriveLoader(
+            access_token="token",
+            drive_id="drive123",
+            file_extensions=["txt", ".PDF", "  .json  "],
+        )
+        assert loader.file_extensions == {".txt", ".pdf", ".json"}
+
+    @pytest.mark.asyncio
+    async def test_aload_missing_dependencies(self):
+        import sys
+
+        loader = OneDriveLoader(access_token="token", drive_id="drive123")
+
+        with patch.dict(sys.modules, {"msgraph": None}):
+            with pytest.raises(ImportError, match="synapsekit\\[onedrive\\]"):
+                await loader.aload()
+
+    @patch.dict("sys.modules", {"msgraph": MagicMock()})
+    def test_load_with_text_and_binary_files(self):
+        loader = OneDriveLoader(access_token="token", drive_id="drive123")
+
+        root_children = {
+            "value": [
+                {
+                    "id": "item-1",
+                    "name": "notes.txt",
+                    "size": 11,
+                    "webUrl": "https://example/notes",
+                    "lastModifiedDateTime": "2026-04-01T10:00:00Z",
+                    "file": {"mimeType": "text/plain"},
+                },
+                {
+                    "id": "item-2",
+                    "name": "image.png",
+                    "size": 2048,
+                    "webUrl": "https://example/image",
+                    "lastModifiedDateTime": "2026-04-01T11:00:00Z",
+                    "file": {"mimeType": "image/png"},
+                },
+            ]
+        }
+
+        def mock_get_json(url: str):
+            assert url.endswith("/drives/drive123/root/children")
+            return root_children
+
+        def mock_get_bytes(url: str):
+            if url.endswith("/items/item-1/content"):
+                return b"hello world"
+            return b"\x89PNG\x00\x01"
+
+        with patch.object(loader, "_graph_get_json", side_effect=mock_get_json), patch.object(
+            loader, "_graph_get_bytes", side_effect=mock_get_bytes
+        ):
+            docs = loader.load()
+
+        assert len(docs) == 2
+        assert all(isinstance(d, Document) for d in docs)
+
+        assert docs[0].text == "hello world"
+        assert docs[0].metadata["source"] == "onedrive"
+        assert docs[0].metadata["drive_id"] == "drive123"
+        assert docs[0].metadata["item_id"] == "item-1"
+        assert docs[0].metadata["file_name"] == "notes.txt"
+
+        assert docs[1].text == "[Binary file: image/png]"
+        assert docs[1].metadata["item_id"] == "item-2"
+
+    @patch.dict("sys.modules", {"msgraph": MagicMock()})
+    def test_load_applies_extension_filters(self):
+        loader = OneDriveLoader(
+            access_token="token",
+            drive_id="drive123",
+            file_extensions=[".txt"],
+        )
+
+        root_children = {
+            "value": [
+                {"id": "a", "name": "a.txt", "file": {"mimeType": "text/plain"}},
+                {"id": "b", "name": "b.pdf", "file": {"mimeType": "application/pdf"}},
+            ]
+        }
+
+        with patch.object(loader, "_graph_get_json", return_value=root_children), patch.object(
+            loader, "_graph_get_bytes", return_value=b"ok"
+        ):
+            docs = loader.load()
+
+        assert len(docs) == 1
+        assert docs[0].metadata["file_name"] == "a.txt"
+
+    @patch.dict("sys.modules", {"msgraph": MagicMock()})
+    def test_load_extracts_supported_file_via_loader(self):
+        loader = OneDriveLoader(access_token="token", drive_id="drive123")
+
+        root_children = {
+            "value": [
+                {
+                    "id": "pdf-id",
+                    "name": "report.pdf",
+                    "file": {"mimeType": "application/pdf"},
+                }
+            ]
+        }
+
+        with patch.object(loader, "_graph_get_json", return_value=root_children), patch.object(
+            loader, "_graph_get_bytes", return_value=b"%PDF-1.7 fake"
+        ), patch.object(loader, "_run_loader_for_extension") as run_loader:
+            run_loader.return_value = [
+                Document(text="Extracted Page 1", metadata={}),
+                Document(text="Extracted Page 2", metadata={}),
+            ]
+            docs = loader.load()
+
+        assert len(docs) == 1
+        assert docs[0].text == "Extracted Page 1\n\nExtracted Page 2"
+        run_loader.assert_called_once()
+
+    @patch.dict("sys.modules", {"msgraph": MagicMock()})
+    def test_load_handles_recursive_folder_traversal(self):
+        loader = OneDriveLoader(access_token="token", drive_id="drive123", recursive=True)
+
+        root_url = "https://graph.microsoft.com/v1.0/drives/drive123/root/children"
+        child_url = "https://graph.microsoft.com/v1.0/drives/drive123/items/folder-1/children"
+
+        def mock_get_json(url: str):
+            if url == root_url:
+                return {
+                    "value": [
+                        {"id": "folder-1", "name": "docs", "folder": {"childCount": 1}},
+                        {"id": "file-1", "name": "root.txt", "file": {"mimeType": "text/plain"}},
+                    ]
+                }
+            if url == child_url:
+                return {
+                    "value": [
+                        {
+                            "id": "file-2",
+                            "name": "child.txt",
+                            "file": {"mimeType": "text/plain"},
+                        }
+                    ]
+                }
+            raise AssertionError(f"unexpected url: {url}")
+
+        def mock_get_bytes(url: str):
+            if url.endswith("/items/file-1/content"):
+                return b"root"
+            return b"child"
+
+        with patch.object(loader, "_graph_get_json", side_effect=mock_get_json), patch.object(
+            loader, "_graph_get_bytes", side_effect=mock_get_bytes
+        ):
+            docs = loader.load()
+
+        assert len(docs) == 2
+        names = {doc.metadata["file_name"] for doc in docs}
+        assert names == {"root.txt", "child.txt"}
+
+    @patch.dict("sys.modules", {"msgraph": MagicMock()})
+    def test_load_non_recursive_skips_subfolder_items(self):
+        loader = OneDriveLoader(access_token="token", drive_id="drive123", recursive=False)
+
+        root_children = {
+            "value": [
+                {"id": "folder-1", "name": "docs", "folder": {"childCount": 1}},
+                {"id": "file-1", "name": "root.txt", "file": {"mimeType": "text/plain"}},
+            ]
+        }
+
+        with patch.object(loader, "_graph_get_json", return_value=root_children), patch.object(
+            loader, "_graph_get_bytes", return_value=b"root"
+        ):
+            docs = loader.load()
+
+        assert len(docs) == 1
+        assert docs[0].metadata["file_name"] == "root.txt"
+
+    @patch.dict("sys.modules", {"msgraph": MagicMock()})
+    def test_load_respects_max_files(self):
+        loader = OneDriveLoader(access_token="token", drive_id="drive123", max_files=1)
+
+        root_children = {
+            "value": [
+                {"id": "a", "name": "a.txt", "file": {"mimeType": "text/plain"}},
+                {"id": "b", "name": "b.txt", "file": {"mimeType": "text/plain"}},
+            ]
+        }
+
+        with patch.object(loader, "_graph_get_json", return_value=root_children), patch.object(
+            loader, "_graph_get_bytes", return_value=b"x"
+        ):
+            docs = loader.load()
+
+        assert len(docs) == 1
+        assert docs[0].metadata["item_id"] == "a"
+
+    @patch.dict("sys.modules", {"msgraph": MagicMock()})
+    def test_aload_runs(self):
+        loader = OneDriveLoader(access_token="token", drive_id="drive123")
+
+        with patch.object(
+            loader,
+            "_graph_get_json",
+            return_value={
+                "value": [
+                    {"id": "file-1", "name": "note.txt", "file": {"mimeType": "text/plain"}}
+                ]
+            },
+        ), patch.object(loader, "_graph_get_bytes", return_value=b"test"):
+            docs = asyncio.run(loader.aload())
+
+        assert len(docs) == 1
+        assert docs[0].text == "test"
+
+    def test_extract_with_supported_loader_returns_none_for_unsupported_ext(self):
+        loader = OneDriveLoader(access_token="token", drive_id="drive123")
+        out = loader._extract_with_supported_loader("blob.bin", b"raw", ".bin")
+        assert out is None


### PR DESCRIPTION
## Summary
Adds a new `OneDriveLoader` for loading files from OneDrive or SharePoint using Microsoft Graph drive endpoints.

## What’s included
- New loader: `src/synapsekit/loaders/onedrive.py`
- Optional dependency: `onedrive = ["msgraph-sdk>=1.0"]`
- Export wiring updates:
  - `src/synapsekit/loaders/__init__.py`
  - `src/synapsekit/__init__.py`
- Tests: `tests/loaders/test_onedrive_loader.py` (mocked Graph API behavior)

## Loader behavior
- Accepts OAuth bearer token + `drive_id` (+ optional `folder_id`)
- Traverses folder children (recursive toggle)
- Supports optional extension filtering + max_files
- Downloads file bytes and extracts text for supported types (`pdf/docx/xlsx/pptx/csv/json/html`) using existing SynapseKit loaders
- Returns `list[Document]` with metadata

## Validation
- `pytest tests/loaders/test_onedrive_loader.py -q`
- `pytest tests/loaders/test_loaders.py tests/loaders/test_s3_loader.py tests/loaders/test_azure_blob_loader.py tests/loaders/test_onedrive_loader.py -q`
- `ruff check src/synapsekit/loaders/onedrive.py tests/loaders/test_onedrive_loader.py src/synapsekit/loaders/__init__.py src/synapsekit/__init__.py pyproject.toml`

Closes #54
