### PR TITLE
feat(mcp): expose SynapseKit pipelines as MCP servers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ aleph-alpha = ["aleph-alpha-client>=7.0"]
 llamacpp = ["llama-cpp-python>=0.2"]
 ernie = ["erniebot>=0.5"]
 minimax = ["httpx>=0.27"]
-serve = ["fastapi>=0.110", "uvicorn[standard]>=0.29"]
+serve = ["fastapi>=0.110", "starlette>=0.37", "uvicorn[standard]>=0.29"]
 postgres = ["psycopg[binary]>=3.1"]
 pgvector = ["psycopg[binary]>=3.1", "pgvector>=0.2"]
 wolfram = ["wolframalpha>=5.0"]
@@ -143,6 +143,7 @@ all = [
     "aiomcache>=0.8",
     "google-cloud-aiplatform>=1.38",
     "fastapi>=0.110",
+    "starlette>=0.37",
     "uvicorn[standard]>=0.29",
     "psycopg[binary]>=3.1",
     "groq>=0.9",


### PR DESCRIPTION
Resolves #508.

- Implemented MCPServer(rag) to expose RAG pipelines as queryable MCP tools + documents as MCP resources.
- Implemented MCPServer(agent) to expose FunctionCallingAgent or AgentExecutor as a single MCP tool.
- Restructured src/synapsekit/mcp/server.py into a sub-package.
- Added un_sse API key authentication using Starlette middleware.
- Added tests for RAG and Agent pipeline MCP modes.