### PR TITLE
chore: release v1.5.5 — LMStudio base_url fix, ConfigLoader .env.local, RTFLoader encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,27 @@ SynapseKit uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased]
+## [1.5.5] — 2026-04-13
 
 ### Added
 
 - **Recursive Subgraph Support** — allow a `StateGraph` to be passed to `subgraph_node()`, enabling self-referential / recursive workflows; implements a `max_recursion_depth` guard (default 10) to prevent infinite loops; tracks depth via internal `__recursion_depth__` state key; adds `RecursionDepthError` to handle limit breaches; lazy compilation supports definition-time self-referencing.
 - **Discord community link** — added Discord server link to README community section.
-- **`LMStudioLLM`** — local model provider via LM Studio's OpenAI-compatible API; connects to a running LM Studio server (default `http://localhost:1234/v1`); supports streaming, tool calling, and custom `base_url`; no API key required; `pip install synapsekit[lmstudio]`; closes #176
+- **`LMStudioLLM`** — local model provider via LM Studio's OpenAI-compatible API; connects to a running LM Studio server (default `http://localhost:1234/v1`); supports streaming, tool calling, and custom `base_url` via constructor kwarg; no API key required; `pip install synapsekit[lmstudio]`; closes #176
 - **`MCPServer` SSE transport + package refactor** — `MCPServer` now lives in `synapsekit.mcp.server` package; adds `run_sse(host, port, api_key)` for HTTP/SSE MCP serving with optional Bearer auth; backwards-compatible with existing `MCPServer(tools=[...])`, `MCPServer(rag)`, and `MCPServer(agent)` usage
 - **`LaTeXLoader`** — load `.tex` files as plain text; strips commands, environments, inline/display math, and comments via regex; captures section/subsection titles into metadata; no external deps required
 - **`TSVLoader`** — load tab-separated files one Document per row; configurable `text_column` to extract a specific column as text; remaining columns become metadata; skips empty rows; async `aload()`
 - **`RTFLoader`** — load RTF files as plain text via `striprtf`; handles malformed RTF gracefully; `pip install synapsekit[rtf]`
 - **`EPUBLoader`** — load EPUB files chapter-by-chapter; extracts title, author, and chapter name into metadata; strips HTML tags safely; `pip install synapsekit[epub]`
-- **`ConfigLoader`** — load `.env`, `.ini`, `.cfg`, and `.toml` config files into Documents; redacts sensitive keys (password, secret, token, api_key, auth) automatically; one Document per INI section; Python 3.11+ uses stdlib `tomllib`, falls back to `tomli` on older versions
+- **`ConfigLoader`** — load `.env`, `.ini`, `.cfg`, `.toml`, and environment-specific dotfiles (`.env.local`, `.env.staging`, `.env.production`) into Documents; redacts sensitive keys (password, secret, token, api_key, auth) automatically; one Document per INI section; Python 3.11+ uses stdlib `tomllib`, falls back to `tomli` on older versions
 - **`OneDriveLoader`** — load files from OneDrive and SharePoint via Microsoft Graph API; folder traversal with optional recursion; extension filtering; `max_files` cap; extracts PDF, DOCX, XLSX, PPTX, CSV, JSON, HTML via existing loaders; async `aload()`; uses stdlib HTTP (no external SDK required)
+
+### Fixed
+
+- **`LMStudioLLM` `base_url`** — `LLMConfig` has no `base_url` field; passing it via `LLMConfig(base_url=...)` would raise `TypeError` before `LMStudioLLM.__init__` ran. Fixed by adding `base_url: str | None = None` as a keyword argument to `LMStudioLLM.__init__` directly (mirrors the `XaiLLM` / `NovitaLLM` pattern). Custom server usage: `LMStudioLLM(config, base_url="http://192.168.1.10:1234/v1")`
+- **`LMStudioLLM` stream stability** — removed `stream_options={"include_usage": True}` which caused API errors on older LM Studio builds; usage tracking now reads `chunk.usage` defensively via `getattr` so it still captures tokens when the server returns them
+- **`ConfigLoader` rejects `.env.local` / `.env.staging`** — `os.path.splitext(".env.local")` returns `('.env', '.local')` making `ext = '.local'` which fell through to `ValueError: Unsupported config file type`. Fixed by detecting any file whose basename starts with `.env` and treating it as the env format regardless of secondary extension
+- **`RTFLoader` default encoding** — changed default from `"utf-8"` to `"latin-1"` (Windows-1252 superset) since real-world RTF files from Office/WordPad are almost universally Windows-encoded, not UTF-8
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "synapsekit"
-version = "1.5.3"
+version = "1.5.5"
 description = "Async-native Python framework for building LLM applications — RAG pipelines, tool-using agents, and graph workflows. Streaming-first, transparent API, 2 hard deps."
 authors = [{ name = "Amit", email = "de.amit.nautiyal@gmail.com" }]
 license = { text = "Apache-2.0" }

--- a/src/synapsekit/llm/lmstudio.py
+++ b/src/synapsekit/llm/lmstudio.py
@@ -25,18 +25,16 @@ class LMStudioLLM(BaseLLM):
 
     Custom server URL::
 
-        config = LLMConfig(
-            model="mistral-7b-instruct",
-            provider="lmstudio",
+        llm = LMStudioLLM(
+            LLMConfig(model="mistral-7b-instruct", provider="lmstudio"),
             base_url="http://192.168.1.10:1234/v1",
         )
-        llm = LMStudioLLM(config)
     """
 
-    def __init__(self, config: LLMConfig) -> None:
+    def __init__(self, config: LLMConfig, *, base_url: str | None = None) -> None:
         super().__init__(config)
         self._client = None
-        self._base_url: str = getattr(config, "base_url", None) or _DEFAULT_BASE_URL
+        self._base_url: str = base_url or _DEFAULT_BASE_URL
 
     def _get_client(self):
         if self._client is None:
@@ -68,10 +66,9 @@ class LMStudioLLM(BaseLLM):
             temperature=kw.get("temperature", self.config.temperature),
             max_tokens=kw.get("max_tokens", self.config.max_tokens),
             stream=True,
-            stream_options={"include_usage": True},
         )
         async for chunk in stream:
-            if chunk.usage:
+            if getattr(chunk, "usage", None):
                 self._input_tokens += chunk.usage.prompt_tokens or 0
                 self._output_tokens += chunk.usage.completion_tokens or 0
             if chunk.choices and chunk.choices[0].delta.content:

--- a/src/synapsekit/loaders/config.py
+++ b/src/synapsekit/loaders/config.py
@@ -70,11 +70,13 @@ class ConfigLoader:
         if not os.path.exists(self._path):
             raise FileNotFoundError(f"Config file not found: {self._path}")
 
+        basename = os.path.basename(self._path).lower()
         ext = os.path.splitext(self._path)[1].lower()
-        # dotfiles like ".env" have no extension; treat the whole filename as the ext
-        if not ext:
-            ext = os.path.basename(self._path).lower()
-            if not ext.startswith("."):
+        # dotfiles like ".env" have no extension; treat the whole filename as the ext.
+        # Also handles ".env.local", ".env.staging", etc.
+        if not ext or basename.startswith(".env"):
+            ext = ".env" if basename.startswith(".env") else basename
+            if ext and not ext.startswith("."):
                 ext = f".{ext}"
         if ext not in _SUPPORTED_EXTENSIONS:
             raise ValueError(f"Unsupported config file type: {ext!r}")

--- a/src/synapsekit/loaders/rtf.py
+++ b/src/synapsekit/loaders/rtf.py
@@ -12,7 +12,7 @@ class RTFLoader:
     Requires: pip install synapsekit[rtf]
     """
 
-    def __init__(self, path: str, encoding: str = "utf-8") -> None:
+    def __init__(self, path: str, encoding: str = "latin-1") -> None:
         self._path = path
         self._encoding = encoding
 

--- a/tests/llm/test_lmstudio.py
+++ b/tests/llm/test_lmstudio.py
@@ -51,11 +51,9 @@ class TestGetClient:
             )
 
     def test_uses_custom_base_url(self):
-        config = make_config()
-        config.base_url = "http://192.168.1.10:1234/v1"
         mock_openai = _make_mock_openai()
         with patch.dict("sys.modules", {"openai": mock_openai}):
-            llm = LMStudioLLM(config)
+            llm = LMStudioLLM(make_config(), base_url="http://192.168.1.10:1234/v1")
             llm._client = None
             llm._get_client()
             mock_openai.AsyncOpenAI.assert_called_once_with(

--- a/tests/loaders/test_config_loader.py
+++ b/tests/loaders/test_config_loader.py
@@ -56,6 +56,21 @@ class TestEnvLoader:
         docs = ConfigLoader(str(p)).load()
         assert "abc123" not in docs[0].text
 
+    def test_env_local_treated_as_env(self, tmp_path):
+        """Regression: .env.local / .env.staging must be parsed as .env, not raise ValueError."""
+        p = tmp_path / ".env.local"
+        p.write_text("STAGE=local\nDB_HOST=localhost\n")
+        docs = ConfigLoader(str(p)).load()
+        assert len(docs) == 1
+        assert "STAGE: local" in docs[0].text
+        assert docs[0].metadata["type"] == "env"
+
+    def test_env_staging_treated_as_env(self, tmp_path):
+        p = tmp_path / ".env.staging"
+        p.write_text("STAGE=staging\n")
+        docs = ConfigLoader(str(p)).load()
+        assert docs[0].metadata["type"] == "env"
+
     def test_metadata_type(self, tmp_path):
         p = tmp_path / ".env"
         p.write_text("HOST=localhost\n")


### PR DESCRIPTION
## Summary

- **fix(llm):** `LMStudioLLM` — `base_url` is now a constructor keyword argument (`LMStudioLLM(config, base_url="...")`) instead of being read from `LLMConfig` which has no such field; old pattern raised `TypeError` in production
- **fix(llm):** Removed `stream_options={"include_usage": True}` from LM Studio streaming — older LM Studio builds reject this parameter; usage tracking now uses `getattr` defensively
- **fix(loaders):** `ConfigLoader` now correctly handles `.env.local`, `.env.staging`, `.env.production` — previously `os.path.splitext` returned `('.env', '.local')` making `ext = '.local'` which triggered `ValueError: Unsupported config file type`
- **fix(loaders):** `RTFLoader` default encoding changed from `utf-8` to `latin-1` — real-world RTF files from Microsoft Office/WordPad are Windows-1252 encoded
- **docs:** `FEATURE_PARITY.md` updated to v1.5.5 — `MCPServer` marked as shipped (was "Planned v1.8.0"), loader count updated to 37

## Test plan

- [x] All 2041 tests pass (`uv run pytest tests/ -q`)
- [x] Regression test: `test_env_local_treated_as_env` and `test_env_staging_treated_as_env`
- [x] `test_uses_custom_base_url` updated to use new constructor kwarg pattern