### PR TITLE
chore: collapse [1.5.4] into [1.5.5] in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ SynapseKit uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`S3Loader`** — load files from Amazon S3 buckets into Documents; supports text, binary fallback, and rich file extraction (PDF, DOCX, XLSX, PPTX, CSV, JSON, HTML) via existing loaders; prefix filtering, extension filtering, `max_files` limit; credential chain (explicit keys, session tokens, or ambient IAM role); async `aload()` via executor; `pip install synapsekit[s3]`; closes #522
+- **`AzureBlobLoader`** — load blobs from Azure Blob Storage containers; supports both connection-string and account URL + credential auth; same extraction chain as S3Loader; prefix filtering, `max_files`; `pip install synapsekit[azure]`; closes #520
+- **`MongoDBLoader`** — load documents from a MongoDB collection as Documents; configurable `text_fields` and `metadata_fields`; optional `query_filter`; projection builder fetches only requested fields; defensive copy of filter dict; sync + async; `pip install synapsekit[mongodb]`; closes #519
+- **`DropboxLoader`** — load files from a Dropbox folder; supports 20+ text/code extensions; pagination via cursor; `limit` stops fetching early; download-error skipping; `pip install synapsekit[dropbox]`; closes #517
+- **`EvalDataset` / `EvalRecord`** — filterable, exportable collection of eval result records; `filter_score(min_score, max_score)` narrows to weak/strong cases; `export()` writes fine-tuning datasets in OpenAI, Anthropic, Together, JSONL, and DPO pair formats; `from_snapshot()` loads from existing EvalCI snapshots
+- **`FineTuner`** — orchestrates fine-tuning jobs against OpenAI and Together AI; injectable adapter pattern for extensibility; `submit()`, `status()`, `wait()` (polls until terminal state with configurable timeout/interval); `FineTuneJob` dataclass tracks id, provider, status, model_id, error
+- **`@eval_case(capture_io=True)`** — opt-in capture of `input`, `output`, and `ideal` fields in eval case results; required for `EvalDataset.export()`
+- **`synapsekit eval` CLI** — `report <snapshot>` summarises scores and weak cases; `export <snapshot> --format openai --output data.jsonl` writes fine-tune dataset; `compare <baseline> <current>` runs regression comparison
+- **`synapsekit finetune` CLI** — `submit <dataset> --provider openai --base-model gpt-4o-mini`; `status <job_id>`; `wait <job_id>` blocks until completion
 - **Recursive Subgraph Support** — allow a `StateGraph` to be passed to `subgraph_node()`, enabling self-referential / recursive workflows; implements a `max_recursion_depth` guard (default 10) to prevent infinite loops; tracks depth via internal `__recursion_depth__` state key; adds `RecursionDepthError` to handle limit breaches; lazy compilation supports definition-time self-referencing.
 - **Discord community link** — added Discord server link to README community section.
 - **`LMStudioLLM`** — local model provider via LM Studio's OpenAI-compatible API; connects to a running LM Studio server (default `http://localhost:1234/v1`); supports streaming, tool calling, and custom `base_url` via constructor kwarg; no API key required; `pip install synapsekit[lmstudio]`; closes #176
@@ -24,30 +33,11 @@ SynapseKit uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`DropboxLoader` SDK compatibility** — original implementation called `.get()` on Dropbox SDK entry objects (`FileMetadata`, `FolderMetadata`), which are Stone-generated Python classes, not dicts; fixed with `_normalise_entry()` static method that converts SDK objects to canonical dicts via attribute access while passing test-mock dicts through unchanged
 - **`LMStudioLLM` `base_url`** — `LLMConfig` has no `base_url` field; passing it via `LLMConfig(base_url=...)` would raise `TypeError` before `LMStudioLLM.__init__` ran. Fixed by adding `base_url: str | None = None` as a keyword argument to `LMStudioLLM.__init__` directly (mirrors the `XaiLLM` / `NovitaLLM` pattern). Custom server usage: `LMStudioLLM(config, base_url="http://192.168.1.10:1234/v1")`
 - **`LMStudioLLM` stream stability** — removed `stream_options={"include_usage": True}` which caused API errors on older LM Studio builds; usage tracking now reads `chunk.usage` defensively via `getattr` so it still captures tokens when the server returns them
 - **`ConfigLoader` rejects `.env.local` / `.env.staging`** — `os.path.splitext(".env.local")` returns `('.env', '.local')` making `ext = '.local'` which fell through to `ValueError: Unsupported config file type`. Fixed by detecting any file whose basename starts with `.env` and treating it as the env format regardless of secondary extension
 - **`RTFLoader` default encoding** — changed default from `"utf-8"` to `"latin-1"` (Windows-1252 superset) since real-world RTF files from Office/WordPad are almost universally Windows-encoded, not UTF-8
-
----
-
-## [1.5.4] — 2026-04-12
-
-### Added
-
-- **`S3Loader`** — load files from Amazon S3 buckets into Documents; supports text, binary fallback, and rich file extraction (PDF, DOCX, XLSX, PPTX, CSV, JSON, HTML) via existing loaders; prefix filtering, extension filtering, `max_files` limit; credential chain (explicit keys, session tokens, or ambient IAM role); async `aload()` via executor; `pip install synapsekit[s3]`; closes #522
-- **`AzureBlobLoader`** — load blobs from Azure Blob Storage containers; supports both connection-string and account URL + credential auth; same extraction chain as S3Loader; prefix filtering, `max_files`; `pip install synapsekit[azure]`; closes #520
-- **`MongoDBLoader`** — load documents from a MongoDB collection as Documents; configurable `text_fields` and `metadata_fields`; optional `query_filter`; projection builder fetches only requested fields; defensive copy of filter dict; sync + async; `pip install synapsekit[mongodb]`; closes #519
-- **`DropboxLoader`** — load files from a Dropbox folder; supports 20+ text/code extensions; pagination via cursor; `limit` stops fetching early; download-error skipping; `pip install synapsekit[dropbox]`; closes #517
-- **`EvalDataset` / `EvalRecord`** — filterable, exportable collection of eval result records; `filter_score(min_score, max_score)` narrows to weak/strong cases; `export()` writes fine-tuning datasets in OpenAI, Anthropic, Together, JSONL, and DPO pair formats; `from_snapshot()` loads from existing EvalCI snapshots
-- **`FineTuner`** — orchestrates fine-tuning jobs against OpenAI and Together AI; injectable adapter pattern for extensibility; `submit()`, `status()`, `wait()` (polls until terminal state with configurable timeout/interval); `FineTuneJob` dataclass tracks id, provider, status, model_id, error
-- **`@eval_case(capture_io=True)`** — opt-in capture of `input`, `output`, and `ideal` fields in eval case results; required for `EvalDataset.export()`
-- **`synapsekit eval` CLI** — `report <snapshot>` summarises scores and weak cases; `export <snapshot> --format openai --output data.jsonl` writes fine-tune dataset; `compare <baseline> <current>` runs regression comparison
-- **`synapsekit finetune` CLI** — `submit <dataset> --provider openai --base-model gpt-4o-mini`; `status <job_id>`; `wait <job_id>` blocks until completion
-
-### Fixed
-
-- **`DropboxLoader` SDK compatibility** — original implementation called `.get()` on Dropbox SDK entry objects (`FileMetadata`, `FolderMetadata`), which are Stone-generated Python classes, not dicts; fixed with `_normalise_entry()` static method that converts SDK objects to canonical dicts via attribute access while passing test-mock dicts through unchanged
 
 ---
 


### PR DESCRIPTION
v1.5.4 was never actually published to PyPI (pyproject.toml was still at 1.5.3 when v1.5.5 was cut). Merges the 1.5.4 section into 1.5.5 so the CHANGELOG matches the actual release history: v1.5.3 → v1.5.5.