### PR TITLE
chore: update README and banner for v1.5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/synapsekit?color=22c55e&label=pypi&logo=pypi&logoColor=white)](https://pypi.org/project/synapsekit/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-22c55e?logo=python&logoColor=white)](https://www.python.org/)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-22c55e)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-1752%20passing-22c55e?logo=pytest&logoColor=white)]()
+[![Tests](https://img.shields.io/badge/tests-2041%20passing-22c55e?logo=pytest&logoColor=white)]()
 [![Downloads](https://img.shields.io/pypi/dm/synapsekit?color=22c55e&logo=pypi&logoColor=white)](https://pypistats.org/packages/synapsekit)
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/synapsekit?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/synapsekit)
 [![Docs](https://img.shields.io/badge/docs-online-22c55e?logo=readthedocs&logoColor=white)](https://synapsekit.github.io/synapsekit-docs/)
@@ -24,7 +24,7 @@ Async-native RAG, Agents, and Graph workflows — no magic, no SaaS, no bloat.
 
 > *"LangChain for people who hate LangChain."*
 
-SynapseKit is the minimal, async-first Python framework for LLM applications. 30 providers · 46 tools · 33 loaders · 9 vector stores. Every abstraction is plain Python you can read, debug, and extend. No hidden chains. No global state. No lock-in.
+SynapseKit is the minimal, async-first Python framework for LLM applications. 31 providers · 48 tools · 43 loaders · 9 vector stores. Every abstraction is plain Python you can read, debug, and extend. No hidden chains. No global state. No lock-in.
 
 ---
 
@@ -48,7 +48,7 @@ Token-level streaming is the default,<br/>not an afterthought.<br/>Works across 
 <tr>
 <td align="center" width="33%">
 <h3>🔌 One interface</h3>
-30 LLM providers and 9 vector stores<br/>behind the same API.<br/>Swap without rewriting.
+31 LLM providers and 9 vector stores<br/>behind the same API.<br/>Swap without rewriting.
 </td>
 <td align="center" width="33%">
 <h3>🧩 Composable</h3>
@@ -77,7 +77,7 @@ No hidden chains.<br/>Every step is plain Python<br/>you can read and override.
 | Cost tracking | **✅ Built-in** | ❌ LangSmith (SaaS) | ❌ No |
 | Evaluation | **✅ CLI + GitHub Action** | ❌ LangSmith (SaaS) | ✅ Built-in |
 | Graph workflows | **✅ Built-in** | ✅ LangGraph (separate pkg) | ❌ No |
-| LLM providers | **30** | 38+ | 20+ |
+| LLM providers | **31** | 38+ | 20+ |
 | Stack traces | **Your code** | Framework internals | Framework internals |
 
 </div>
@@ -112,7 +112,7 @@ Retrieval-augmented generation with streaming, BM25 reranking, conversation memo
 <td width="50%">
 
 **🤖 Agents**<br/>
-ReAct loop (any LLM) and native function calling (OpenAI / Anthropic / Gemini / Mistral). 43 built-in tools including calculator, Python REPL, web search, SQL, HTTP, shell, Twilio, arxiv, pubmed, wolfram, wikipedia, and more. Fully extensible.
+ReAct loop (any LLM) and native function calling (OpenAI / Anthropic / Gemini / Mistral). 48 built-in tools including calculator, Python REPL, code interpreter, web search, SQL, HTTP, shell, Twilio, arxiv, pubmed, wolfram, wikipedia, and more. Fully extensible.
 
 </td>
 </tr>
@@ -126,7 +126,7 @@ DAG-based async pipelines. Nodes run in waves — parallel nodes execute concurr
 <td width="50%">
 
 **🧠 LLM Providers**<br/>
-OpenAI, Anthropic, Ollama, Gemini, Cohere, Mistral, Bedrock, Azure OpenAI, Groq, DeepSeek, OpenRouter, Together, Fireworks, Cerebras, Cloudflare, Moonshot, Perplexity, Vertex AI, Zhipu, AI21 Labs, Databricks, Baidu ERNIE, llama.cpp, Minimax, Aleph Alpha, Hugging Face, SambaNova — all behind one interface. Auto-detected from the model name. Swap without rewriting.
+OpenAI, Anthropic, Ollama, Gemini, Cohere, Mistral, Bedrock, Azure OpenAI, Groq, DeepSeek, OpenRouter, Together, Fireworks, Cerebras, Cloudflare, Moonshot, Perplexity, Vertex AI, Zhipu, AI21 Labs, Databricks, Baidu ERNIE, llama.cpp, LM Studio, Minimax, Aleph Alpha, Hugging Face, SambaNova, xAI, NovitaAI, Writer — all behind one interface. Auto-detected from the model name. Swap without rewriting.
 
 </td>
 </tr>
@@ -194,7 +194,7 @@ Everything you need to get started and go deep is in the docs.
 | 🗂 [RAG](https://synapsekit.github.io/synapsekit-docs/docs/rag/pipeline) | Pipelines, loaders, retrieval, vector stores |
 | 🤖 [Agents](https://synapsekit.github.io/synapsekit-docs/docs/agents/overview) | ReAct, function calling, tools, executor |
 | 🔀 [Graph Workflows](https://synapsekit.github.io/synapsekit-docs/docs/graph/overview) | DAG pipelines, conditional routing, parallel execution |
-| 🧠 [LLM Providers](https://synapsekit.github.io/synapsekit-docs/docs/llms/overview) | All 30 providers with examples |
+| 🧠 [LLM Providers](https://synapsekit.github.io/synapsekit-docs/docs/llms/overview) | All 31 providers with examples |
 | 🧪 [EvalCI](https://synapsekit.github.io/synapsekit-docs/docs/evalci/overview) | LLM quality gates on every PR — GitHub Action |
 | 📖 [API Reference](https://synapsekit.github.io/synapsekit-docs/docs/api/llm) | Full class and method reference |
 

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -34,13 +34,13 @@
 
   <!-- Stat pills -->
   <rect x="132" y="159" width="90"  height="22" rx="11" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1.5"/>
-  <text x="177" y="174" font-family="'SF Mono','Fira Code','Consolas',monospace" font-size="10" fill="#15803d" text-anchor="middle">30 providers</text>
+  <text x="177" y="174" font-family="'SF Mono','Fira Code','Consolas',monospace" font-size="10" fill="#15803d" text-anchor="middle">31 providers</text>
 
   <rect x="230" y="159" width="68"  height="22" rx="11" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1.5"/>
-  <text x="264" y="174" font-family="'SF Mono','Fira Code','Consolas',monospace" font-size="10" fill="#15803d" text-anchor="middle">46 tools</text>
+  <text x="264" y="174" font-family="'SF Mono','Fira Code','Consolas',monospace" font-size="10" fill="#15803d" text-anchor="middle">48 tools</text>
 
   <rect x="306" y="159" width="76"  height="22" rx="11" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1.5"/>
-  <text x="344" y="174" font-family="'SF Mono','Fira Code','Consolas',monospace" font-size="10" fill="#15803d" text-anchor="middle">33 loaders</text>
+  <text x="344" y="174" font-family="'SF Mono','Fira Code','Consolas',monospace" font-size="10" fill="#15803d" text-anchor="middle">43 loaders</text>
 
   <rect x="390" y="159" width="100" height="22" rx="11" fill="#f1f5f9" stroke="#e2e8f0" stroke-width="1.5"/>
   <text x="440" y="174" font-family="'SF Mono','Fira Code','Consolas',monospace" font-size="10" fill="#64748b" text-anchor="middle">9 vector stores</text>


### PR DESCRIPTION
- README: 31 providers, 48 tools, 43 loaders, 2041 tests badge, full LLM list updated
- Banner (assets/): 31 providers, 48 tools, 43 loaders