### PR TITLE
feat(loaders): add DynamoDBLoader

### DIFF
--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -159,6 +159,7 @@ from .loaders.config import ConfigLoader
 from .loaders.confluence import ConfluenceLoader
 from .loaders.csv import CSVLoader
 from .loaders.directory import DirectoryLoader
+from .loaders.dynamodb import DynamoDBLoader
 from .loaders.email import EmailLoader
 from .loaders.epub import EPUBLoader
 from .loaders.gcs import GCSLoader
@@ -370,6 +371,7 @@ __all__ = [
     "LaTeXLoader",
     "MarkdownLoader",
     "MongoDBLoader",
+    "DynamoDBLoader",
     "OneDriveLoader",
     "SQLLoader",
     "SupabaseLoader",

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     "DiscordLoader",
     "DocxLoader",
     "Document",
+    "DynamoDBLoader",
     "DropboxLoader",
     "EPUBLoader",
     "EmailLoader",
@@ -90,6 +91,7 @@ _LOADERS = {
     "WikipediaLoader": ".wikipedia",
     "ConfluenceLoader": ".confluence",
     "MongoDBLoader": ".mongodb",
+    "DynamoDBLoader": ".dynamodb",
     "DropboxLoader": ".dropbox",
     "EPUBLoader": ".epub",
 }

--- a/src/synapsekit/loaders/dynamodb.py
+++ b/src/synapsekit/loaders/dynamodb.py
@@ -1,0 +1,207 @@
+"""DynamoDBLoader — load items from AWS DynamoDB tables as Documents."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from decimal import Decimal
+from typing import Any, Literal
+
+from .base import Document
+
+
+class DynamoDBLoader:
+    """Load items from a DynamoDB table into Documents.
+
+    This loader supports both scan and query operations and converts each
+    DynamoDB item into a Document.
+
+    Prerequisites:
+        - boto3
+
+    Example::
+
+        loader = DynamoDBLoader(
+            table_name="my-table",
+            operation="scan",
+            text_attributes=["title", "content"],
+        )
+        docs = loader.load()
+
+    Args:
+        table_name: DynamoDB table name.
+        operation: Either "scan" or "query".
+        scan_kwargs: Extra kwargs forwarded to Table.scan().
+        query_kwargs: Extra kwargs forwarded to Table.query().
+        text_attributes: Item attributes to concatenate into Document.text.
+        metadata_attributes: Item attributes to include in metadata.
+        region_name: AWS region (default "us-east-1").
+        aws_access_key_id/aws_secret_access_key/aws_session_token: Optional explicit credentials.
+        max_items: Optional cap on number of items converted.
+    """
+
+    def __init__(
+        self,
+        table_name: str,
+        *,
+        operation: Literal["scan", "query"] = "scan",
+        scan_kwargs: dict[str, Any] | None = None,
+        query_kwargs: dict[str, Any] | None = None,
+        text_attributes: list[str] | None = None,
+        metadata_attributes: list[str] | None = None,
+        region_name: str = "us-east-1",
+        aws_access_key_id: str | None = None,
+        aws_secret_access_key: str | None = None,
+        aws_session_token: str | None = None,
+        max_items: int | None = None,
+    ) -> None:
+        if not table_name:
+            raise ValueError("table_name must be provided")
+
+        if operation not in {"scan", "query"}:
+            raise ValueError("operation must be 'scan' or 'query'")
+
+        self._table_name = table_name
+        self._operation: Literal["scan", "query"] = operation
+        self._scan_kwargs = dict(scan_kwargs or {})
+        self._query_kwargs = dict(query_kwargs or {})
+        self._text_attributes = list(text_attributes) if text_attributes else None
+        self._metadata_attributes = list(metadata_attributes) if metadata_attributes else None
+
+        self._region_name = region_name
+        self._aws_access_key_id = aws_access_key_id
+        self._aws_secret_access_key = aws_secret_access_key
+        self._aws_session_token = aws_session_token
+
+        self._max_items = max_items
+
+    def load(self) -> list[Document]:
+        try:
+            import boto3
+        except ImportError:
+            raise ImportError("boto3 required: pip install synapsekit[dynamodb]") from None
+
+        table = self._get_table(boto3)
+
+        items = self._fetch_items(table)
+        docs: list[Document] = []
+        for idx, item in enumerate(items):
+            if self._max_items is not None and idx >= self._max_items:
+                break
+
+            normalized = _normalize_item(item)
+            text = self._build_text(normalized)
+            metadata = self._build_metadata(normalized, idx)
+            docs.append(Document(text=text, metadata=metadata))
+
+        return docs
+
+    async def aload(self) -> list[Document]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.load)
+
+    def _get_table(self, boto3_module: Any) -> Any:
+        kwargs: dict[str, Any] = {"region_name": self._region_name}
+        if self._aws_access_key_id:
+            kwargs["aws_access_key_id"] = self._aws_access_key_id
+        if self._aws_secret_access_key:
+            kwargs["aws_secret_access_key"] = self._aws_secret_access_key
+        if self._aws_session_token:
+            kwargs["aws_session_token"] = self._aws_session_token
+
+        resource = boto3_module.resource("dynamodb", **kwargs)
+        return resource.Table(self._table_name)
+
+    def _fetch_items(self, table: Any) -> list[dict[str, Any]]:
+        if self._operation == "query" and not self._query_kwargs:
+            raise ValueError("query_kwargs must be provided when operation='query'")
+
+        op_name = self._operation
+        base_kwargs = dict(self._query_kwargs if op_name == "query" else self._scan_kwargs)
+
+        items: list[dict[str, Any]] = []
+        start_key: dict[str, Any] | None = None
+
+        while True:
+            kwargs = dict(base_kwargs)
+            if start_key is not None:
+                kwargs["ExclusiveStartKey"] = start_key
+
+            response = table.query(**kwargs) if op_name == "query" else table.scan(**kwargs)
+            page_items = response.get("Items", []) or []
+            items.extend(page_items)
+
+            start_key = response.get("LastEvaluatedKey")
+            if not start_key:
+                break
+
+            if self._max_items is not None and len(items) >= self._max_items:
+                break
+
+        return items
+
+    def _build_text(self, item: dict[str, Any]) -> str:
+        if self._text_attributes:
+            parts: list[str] = []
+            for attr in self._text_attributes:
+                value = item.get(attr)
+                parts.append(_stringify_value(value))
+            return "\n".join(parts)
+
+        # Default: show all key/value pairs (stable order for tests/debuggability).
+        return "\n".join(f"{k}: {_stringify_value(v)}" for k, v in sorted(item.items()))
+
+    def _build_metadata(self, item: dict[str, Any], idx: int) -> dict[str, Any]:
+        metadata: dict[str, Any] = {
+            "source": "dynamodb",
+            "table": self._table_name,
+            "row": idx,
+            "operation": self._operation,
+        }
+
+        if self._metadata_attributes:
+            for attr in self._metadata_attributes:
+                if attr in item:
+                    metadata[attr] = item[attr]
+        else:
+            metadata.update(item)
+
+        return metadata
+
+
+def _normalize_item(item: dict[str, Any]) -> dict[str, Any]:
+    return {k: _normalize_value(v) for k, v in item.items()}
+
+
+def _normalize_value(value: Any) -> Any:
+    # DynamoDB uses Decimal for numbers.
+    if isinstance(value, Decimal):
+        if value % 1 == 0:
+            return int(value)
+        return float(value)
+
+    if isinstance(value, bytes):
+        # Make bytes readable/serializable.
+        return value.decode("utf-8", errors="replace")
+
+    if isinstance(value, set):
+        return sorted(_normalize_value(v) for v in value)
+
+    if isinstance(value, list):
+        return [_normalize_value(v) for v in value]
+
+    if isinstance(value, dict):
+        return {k: _normalize_value(v) for k, v in value.items()}
+
+    return value
+
+
+def _stringify_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, (dict, list)):
+        try:
+            return json.dumps(value, ensure_ascii=False, default=str)
+        except Exception:
+            return str(value)
+    return str(value)

--- a/tests/loaders/test_dynamodb_loader.py
+++ b/tests/loaders/test_dynamodb_loader.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import asyncio
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapsekit.loaders import Document
+from synapsekit.loaders.dynamodb import DynamoDBLoader
+
+
+def test_init_requires_table_name() -> None:
+    with pytest.raises(ValueError, match="table_name must be provided"):
+        DynamoDBLoader(table_name="")
+
+
+def test_init_rejects_invalid_operation() -> None:
+    with pytest.raises(ValueError, match="operation must be 'scan' or 'query'"):
+        DynamoDBLoader(table_name="t", operation="nope")  # type: ignore[arg-type]
+
+
+def test_load_missing_boto3_import_error() -> None:
+    with patch.dict("sys.modules", {"boto3": None}):
+        loader = DynamoDBLoader(table_name="tbl")
+        with pytest.raises(ImportError, match=r"synapsekit\[dynamodb\]"):
+            loader.load()
+
+
+@patch.dict("sys.modules", {"boto3": MagicMock()})
+def test_scan_loads_items_and_builds_documents() -> None:
+    import sys
+
+    mock_boto3 = sys.modules["boto3"]
+
+    mock_table = MagicMock()
+    mock_table.scan.return_value = {
+        "Items": [
+            {"pk": "1", "title": "Hello", "count": Decimal("2")},
+            {"pk": "2", "title": "World", "count": Decimal("2.5")},
+        ]
+    }
+
+    mock_resource = MagicMock()
+    mock_resource.Table.return_value = mock_table
+    mock_boto3.resource.return_value = mock_resource
+
+    loader = DynamoDBLoader(table_name="my-table", text_attributes=["title"])
+    docs = loader.load()
+
+    assert len(docs) == 2
+    assert all(isinstance(d, Document) for d in docs)
+
+    assert docs[0].text == "Hello"
+    assert docs[0].metadata["source"] == "dynamodb"
+    assert docs[0].metadata["table"] == "my-table"
+    assert docs[0].metadata["operation"] == "scan"
+    assert docs[0].metadata["row"] == 0
+
+    # Decimal normalization
+    assert docs[0].metadata["count"] == 2
+    assert docs[1].metadata["count"] == 2.5
+
+    mock_boto3.resource.assert_called_once_with("dynamodb", region_name="us-east-1")
+    mock_resource.Table.assert_called_once_with("my-table")
+    mock_table.scan.assert_called_once()
+
+
+@patch.dict("sys.modules", {"boto3": MagicMock()})
+def test_scan_paginates_with_last_evaluated_key() -> None:
+    import sys
+
+    mock_boto3 = sys.modules["boto3"]
+
+    mock_table = MagicMock()
+    mock_table.scan.side_effect = [
+        {"Items": [{"pk": "1", "text": "a"}], "LastEvaluatedKey": {"pk": "1"}},
+        {"Items": [{"pk": "2", "text": "b"}]},
+    ]
+
+    mock_resource = MagicMock()
+    mock_resource.Table.return_value = mock_table
+    mock_boto3.resource.return_value = mock_resource
+
+    loader = DynamoDBLoader(table_name="tbl", scan_kwargs={"Limit": 1}, text_attributes=["text"])
+    docs = loader.load()
+
+    assert [d.text for d in docs] == ["a", "b"]
+
+    first_call_kwargs = mock_table.scan.call_args_list[0].kwargs
+    second_call_kwargs = mock_table.scan.call_args_list[1].kwargs
+    assert first_call_kwargs == {"Limit": 1}
+    assert second_call_kwargs == {"Limit": 1, "ExclusiveStartKey": {"pk": "1"}}
+
+
+@patch.dict("sys.modules", {"boto3": MagicMock()})
+def test_query_requires_query_kwargs() -> None:
+    import sys
+
+    mock_boto3 = sys.modules["boto3"]
+    mock_resource = MagicMock()
+    mock_resource.Table.return_value = MagicMock()
+    mock_boto3.resource.return_value = mock_resource
+
+    loader = DynamoDBLoader(table_name="tbl", operation="query")
+    with pytest.raises(ValueError, match="query_kwargs must be provided"):
+        loader.load()
+
+
+@patch.dict("sys.modules", {"boto3": MagicMock()})
+def test_query_uses_table_query_and_respects_text_and_metadata_fields() -> None:
+    import sys
+
+    mock_boto3 = sys.modules["boto3"]
+
+    mock_table = MagicMock()
+    mock_table.query.return_value = {
+        "Items": [
+            {
+                "pk": "u#1",
+                "sk": "doc#1",
+                "title": "T",
+                "body": {"k": [1, 2]},
+                "extra": "ignore",
+            }
+        ]
+    }
+
+    mock_resource = MagicMock()
+    mock_resource.Table.return_value = mock_table
+    mock_boto3.resource.return_value = mock_resource
+
+    loader = DynamoDBLoader(
+        table_name="tbl",
+        operation="query",
+        query_kwargs={"KeyConditionExpression": "pk = :pk"},
+        text_attributes=["title", "body", "missing"],
+        metadata_attributes=["pk", "sk"],
+    )
+
+    docs = loader.load()
+    assert len(docs) == 1
+
+    assert docs[0].text == 'T\n{"k": [1, 2]}\n'
+    assert docs[0].metadata["pk"] == "u#1"
+    assert docs[0].metadata["sk"] == "doc#1"
+    assert "extra" not in docs[0].metadata
+
+    mock_table.query.assert_called_once_with(KeyConditionExpression="pk = :pk")
+
+
+@patch.dict("sys.modules", {"boto3": MagicMock()})
+def test_aload_runs() -> None:
+    import sys
+
+    mock_boto3 = sys.modules["boto3"]
+
+    mock_table = MagicMock()
+    mock_table.scan.return_value = {"Items": [{"pk": "1", "text": "hi"}]}
+
+    mock_resource = MagicMock()
+    mock_resource.Table.return_value = mock_table
+    mock_boto3.resource.return_value = mock_resource
+
+    loader = DynamoDBLoader(table_name="tbl", text_attributes=["text"])
+    docs = asyncio.run(loader.aload())
+
+    assert len(docs) == 1
+    assert docs[0].text == "hi"


### PR DESCRIPTION
Closes #94.

Adds `DynamoDBLoader` to load items from AWS DynamoDB tables via `boto3` (optional dependency).

Highlights:
- Supports `scan` and `query` (+ pagination via `LastEvaluatedKey`)
- `text_attributes` to build document text
- `metadata_attributes` to control metadata
- Async `aload()` wrapper
- Tests mock `boto3` (no AWS access required)

Local tests:
- `python -m pytest tests/loaders/test_dynamodb_loader.py`
- `python -m pytest tests/loaders`
