### PR TITLE
feat(rag): add multimodal file ingestion for image/audio/video (#510)

### DIFF
--- a/examples/multimodal_rag.py
+++ b/examples/multimodal_rag.py
@@ -1,0 +1,47 @@
+"""Multimodal RAG example: add image/audio/video files to one pipeline.
+
+Prerequisites:
+    pip install synapsekit[openai]
+    ffmpeg (required for video)
+
+Usage:
+    export OPENAI_API_KEY=sk-...
+    python examples/multimodal_rag.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+from synapsekit import RAG
+
+
+async def main() -> None:
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("Please set OPENAI_API_KEY environment variable")
+
+    rag = RAG(model="gpt-4o-mini", api_key=api_key)
+
+    image_path = Path("./data/architecture_diagram.png")
+    audio_path = Path("./data/meeting.mp3")
+    video_path = Path("./data/product_demo.mp4")
+
+    if image_path.exists():
+        await rag.add_async(str(image_path), caption="Authentication architecture diagram")
+
+    if audio_path.exists():
+        await rag.add_async(str(audio_path))
+
+    if video_path.exists():
+        await rag.add_async(str(video_path), frame_interval=30)
+
+    question = "What does the authentication architecture look like?"
+    answer = await rag.ask(question)
+    print(f"Q: {question}\nA: {answer}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/synapsekit/loaders/audio.py
+++ b/src/synapsekit/loaders/audio.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
+from ..text_splitters.sentence import SentenceTextSplitter
 from .base import Document
 
 SUPPORTED_EXTENSIONS = {".mp3", ".wav", ".m4a", ".ogg", ".flac", ".webm"}
 
 
 class AudioLoader:
-    """Load audio files by transcribing them into Documents.
+    """Load audio files by transcribing them into timestamped Documents.
 
     Backends:
 
@@ -30,12 +32,15 @@ class AudioLoader:
         backend: str = "whisper_api",
         language: str | None = None,
         model: str = "whisper-1",
+        chunk_size: int = 6,
+        chunk_overlap: int = 1,
     ) -> None:
         self._path = Path(path)
         self._api_key = api_key
         self._backend = backend
         self._language = language
         self._model = model
+        self._splitter = SentenceTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
 
         if self._path.suffix.lower() not in SUPPORTED_EXTENSIONS:
             raise ValueError(
@@ -44,32 +49,23 @@ class AudioLoader:
             )
 
     def load(self) -> list[Document]:
-        """Synchronously transcribe and return as Documents."""
+        """Synchronously transcribe and return timestamped Documents."""
         if self._backend == "whisper_api":
-            text = self._transcribe_api()
+            result = self._transcribe_api()
         elif self._backend == "whisper_local":
-            text = self._transcribe_local()
+            result = self._transcribe_local()
         else:
             raise ValueError(f"Unknown backend: {self._backend!r}")
 
-        return [
-            Document(
-                text=text,
-                metadata={
-                    "source": str(self._path),
-                    "loader": "AudioLoader",
-                    "backend": self._backend,
-                },
-            )
-        ]
+        return self._to_documents(result)
 
     async def aload(self) -> list[Document]:
-        """Async transcription (wraps sync for API backend)."""
+        """Async transcription (wraps sync transcription in a worker thread)."""
         import asyncio
 
         return await asyncio.to_thread(self.load)
 
-    def _transcribe_api(self) -> str:
+    def _transcribe_api(self) -> dict[str, Any]:
         try:
             import openai
         except ImportError:
@@ -80,13 +76,21 @@ class AudioLoader:
 
         client = openai.OpenAI(api_key=self._api_key)
         with open(self._path, "rb") as audio_file:
-            kwargs: dict = {"model": self._model, "file": audio_file}
+            kwargs: dict[str, Any] = {
+                "model": self._model,
+                "file": audio_file,
+                "response_format": "verbose_json",
+            }
             if self._language:
                 kwargs["language"] = self._language
             transcript = client.audio.transcriptions.create(**kwargs)
-        return str(transcript.text)
 
-    def _transcribe_local(self) -> str:
+        text = str(getattr(transcript, "text", "") or "")
+        raw_segments = getattr(transcript, "segments", None) or []
+        segments = self._normalise_segments(raw_segments)
+        return {"text": text, "segments": segments}
+
+    def _transcribe_local(self) -> dict[str, Any]:
         try:
             import whisper
         except ImportError:
@@ -95,9 +99,76 @@ class AudioLoader:
                 "Install it with: pip install openai-whisper"
             ) from None
 
-        model = whisper.load_model(self._model if self._model != "whisper-1" else "base")
-        kwargs: dict = {}
+        model_name = self._model if self._model != "whisper-1" else "base"
+        model = whisper.load_model(model_name)
+        kwargs: dict[str, Any] = {}
         if self._language:
             kwargs["language"] = self._language
+
         result = model.transcribe(str(self._path), **kwargs)
-        return str(result["text"])
+        text = str(result.get("text", ""))
+        segments = self._normalise_segments(result.get("segments", []))
+        return {"text": text, "segments": segments}
+
+    def _normalise_segments(self, raw_segments: Any) -> list[dict[str, Any]]:
+        normalised: list[dict[str, Any]] = []
+        for seg in raw_segments or []:
+            text = str(self._segment_value(seg, "text", "") or "").strip()
+            if not text:
+                continue
+            start = self._to_float(self._segment_value(seg, "start", None))
+            end = self._to_float(self._segment_value(seg, "end", None))
+            normalised.append({"text": text, "start": start, "end": end})
+        return normalised
+
+    @staticmethod
+    def _segment_value(seg: Any, key: str, default: Any) -> Any:
+        if isinstance(seg, dict):
+            return seg.get(key, default)
+        return getattr(seg, key, default)
+
+    @staticmethod
+    def _to_float(value: Any) -> float | None:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _to_documents(self, transcription: dict[str, Any]) -> list[Document]:
+        base_metadata = {
+            "source": str(self._path),
+            "file": str(self._path),
+            "source_type": "audio",
+            "loader": "AudioLoader",
+            "backend": self._backend,
+        }
+
+        docs: list[Document] = []
+        for seg in transcription.get("segments", []):
+            segment_text = str(seg.get("text", "")).strip()
+            if not segment_text:
+                continue
+            chunks = self._splitter.split(segment_text) or [segment_text]
+            for chunk in chunks:
+                docs.append(
+                    Document(
+                        text=chunk,
+                        metadata={
+                            **base_metadata,
+                            "start_time": seg.get("start"),
+                            "end_time": seg.get("end"),
+                        },
+                    )
+                )
+
+        if docs:
+            return docs
+
+        text = str(transcription.get("text", "") or "").strip()
+        if not text:
+            return []
+
+        chunks = self._splitter.split(text) or [text]
+        return [Document(text=chunk, metadata=dict(base_metadata)) for chunk in chunks]

--- a/src/synapsekit/loaders/image.py
+++ b/src/synapsekit/loaders/image.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import base64
 import mimetypes
 import os
 from pathlib import Path
 from typing import Any
 
+from ..llm.multimodal import ImageContent, MultimodalMessage
 from .base import Document
 
 
@@ -15,71 +15,71 @@ class ImageLoader:
     """Load images as Document objects.
 
     Without an LLM, returns a metadata-only document with ``[Image: <path>]``.
-    With an LLM (any object with an async ``generate`` method), returns a
-    document containing the LLM's description of the image.
+    With an LLM, ``async_load``/``aload`` returns a caption suitable for retrieval.
     """
 
     def __init__(
         self,
         path: str | Path,
         llm: Any = None,
-        prompt: str = "Describe this image in detail.",
+        prompt: str = "Describe this image in detail for retrieval.",
     ) -> None:
         self._path = Path(path)
         self._llm = llm
         self._prompt = prompt
 
     def load(self) -> list[Document]:
-        """Load image synchronously (no LLM description)."""
-        if not self._path.exists():
-            raise FileNotFoundError(f"Image file not found: {self._path}")
-
-        mime, _ = mimetypes.guess_type(str(self._path))
-        if mime is None:
-            mime = "image/png"
-
-        file_size = os.path.getsize(self._path)
-
-        metadata = {
-            "source": str(self._path),
-            "media_type": mime,
-            "file_size": file_size,
-        }
-
-        if self._llm is None:
-            text = f"[Image: {self._path}]"
-            return [Document(text=text, metadata=metadata)]
-
-        # With LLM, still return metadata doc synchronously;
-        # use async_load for actual description.
-        text = f"[Image: {self._path}]"
-        return [Document(text=text, metadata=metadata)]
+        """Load image synchronously (metadata/placeholder only)."""
+        self._validate_file()
+        return [self._placeholder_document()]
 
     async def async_load(self) -> list[Document]:
-        """Load image with optional LLM description."""
+        """Load image with optional multimodal LLM captioning."""
+        self._validate_file()
+
+        metadata = self._base_metadata()
+        if self._llm is None:
+            return [Document(text=f"[Image: {self._path}]", metadata=metadata)]
+
+        image = ImageContent.from_file(self._path)
+        message = MultimodalMessage(text=self._prompt, images=[image])
+
+        provider = getattr(getattr(self._llm, "config", None), "provider", "openai")
+        if provider == "anthropic":
+            messages = message.to_anthropic_messages()
+        else:
+            messages = message.to_openai_messages()
+
+        if hasattr(type(self._llm), "generate_with_messages"):
+            description = await self._llm.generate_with_messages(messages)
+        else:
+            # Backward-compatible fallback for very old/custom LLM wrappers.
+            description = await self._llm.generate(self._prompt)
+
+        metadata["description_prompt"] = self._prompt
+        return [Document(text=str(description).strip(), metadata=metadata)]
+
+    async def aload(self) -> list[Document]:
+        """Alias for loader consistency with other loaders."""
+        return await self.async_load()
+
+    def _validate_file(self) -> None:
         if not self._path.exists():
             raise FileNotFoundError(f"Image file not found: {self._path}")
 
+    def _base_metadata(self) -> dict[str, Any]:
         mime, _ = mimetypes.guess_type(str(self._path))
         if mime is None:
             mime = "image/png"
 
-        file_size = os.path.getsize(self._path)
-
-        metadata = {
+        return {
             "source": str(self._path),
+            "file": str(self._path),
+            "source_type": "image",
             "media_type": mime,
-            "file_size": file_size,
+            "file_size": os.path.getsize(self._path),
+            "loader": "ImageLoader",
         }
 
-        if self._llm is None:
-            text = f"[Image: {self._path}]"
-            return [Document(text=text, metadata=metadata)]
-
-        raw = self._path.read_bytes()
-        b64 = base64.b64encode(raw).decode("ascii")
-        data_uri = f"data:{mime};base64,{b64}"
-
-        description = await self._llm.generate(self._prompt, image_url=data_uri)
-        metadata["description_prompt"] = self._prompt
-        return [Document(text=description, metadata=metadata)]
+    def _placeholder_document(self) -> Document:
+        return Document(text=f"[Image: {self._path}]", metadata=self._base_metadata())

--- a/src/synapsekit/loaders/video.py
+++ b/src/synapsekit/loaders/video.py
@@ -1,27 +1,31 @@
-"""VideoLoader — extract audio from video and transcribe."""
+"""VideoLoader — extract transcript + frame captions from video files."""
 
 from __future__ import annotations
 
 import asyncio
 import tempfile
+from contextlib import suppress
 from pathlib import Path
+from typing import Any
 
+from .._compat import run_sync
 from .audio import AudioLoader
 from .base import Document
+from .image import ImageLoader
 
 SUPPORTED_EXTENSIONS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".m4v"}
 
 
 class VideoLoader:
-    """Load video files by extracting audio and transcribing.
+    """Load video files by extracting transcript chunks and frame-caption chunks.
 
     Requires ``ffmpeg`` to be installed on the system.
-    Delegates transcription to ``AudioLoader``.
+    Audio transcription is delegated to ``AudioLoader``.
 
     Example::
 
-        loader = VideoLoader("lecture.mp4", api_key="sk-...")
-        docs = loader.load()
+        loader = VideoLoader("lecture.mp4", api_key="sk-...", frame_interval=30)
+        docs = await loader.aload()
     """
 
     def __init__(
@@ -31,12 +35,20 @@ class VideoLoader:
         backend: str = "whisper_api",
         language: str | None = None,
         keep_audio: bool = False,
+        llm: Any = None,
+        frame_interval: float | int | None = 30,
+        frame_prompt: str = "Describe this video frame in detail for retrieval.",
+        keep_frames: bool = False,
     ) -> None:
         self._path = Path(path)
         self._api_key = api_key
         self._backend = backend
         self._language = language
         self._keep_audio = keep_audio
+        self._llm = llm
+        self._frame_interval = float(frame_interval) if frame_interval else None
+        self._frame_prompt = frame_prompt
+        self._keep_frames = keep_frames
 
         if self._path.suffix.lower() not in SUPPORTED_EXTENSIONS:
             raise ValueError(
@@ -45,73 +57,110 @@ class VideoLoader:
             )
 
     def load(self) -> list[Document]:
-        """Synchronously extract audio, transcribe, and return Documents."""
+        """Synchronously extract audio/frame content and return Documents."""
         audio_path = self._extract_audio_sync()
+        frame_paths = self._extract_frames_sync()
         try:
-            loader = AudioLoader(
-                path=str(audio_path),
-                api_key=self._api_key,
-                backend=self._backend,
-                language=self._language,
-            )
-            docs = loader.load()
-            # Update metadata
-            for doc in docs:
-                doc.metadata["source"] = str(self._path)
-                doc.metadata["loader"] = "VideoLoader"
-            return docs
+            transcript_docs = self._load_transcript_docs_sync(audio_path)
+            frame_docs = self._frame_documents_sync(frame_paths)
+            return transcript_docs + frame_docs
         finally:
-            if not self._keep_audio and audio_path.exists():
-                audio_path.unlink()
+            self._cleanup_audio_file(audio_path)
+            self._cleanup_frame_files(frame_paths)
 
     async def aload(self) -> list[Document]:
-        """Async: extract audio via ffmpeg subprocess, then transcribe."""
+        """Async: extract audio/frame content and return Documents."""
         audio_path = await self._extract_audio_async()
+        frame_paths = await self._extract_frames_async()
         try:
-            loader = AudioLoader(
-                path=str(audio_path),
-                api_key=self._api_key,
-                backend=self._backend,
-                language=self._language,
-            )
-            docs = await loader.aload()
-            for doc in docs:
-                doc.metadata["source"] = str(self._path)
-                doc.metadata["loader"] = "VideoLoader"
-            return docs
+            transcript_docs = await self._load_transcript_docs_async(audio_path)
+            frame_docs = await self._frame_documents_async(frame_paths)
+            return transcript_docs + frame_docs
         finally:
-            if not self._keep_audio and audio_path.exists():
-                audio_path.unlink()
+            self._cleanup_audio_file(audio_path)
+            self._cleanup_frame_files(frame_paths)
+
+    def _load_transcript_docs_sync(self, audio_path: Path) -> list[Document]:
+        loader = AudioLoader(
+            path=str(audio_path),
+            api_key=self._api_key,
+            backend=self._backend,
+            language=self._language,
+        )
+        docs = loader.load()
+        return [self._decorate_transcript_doc(doc) for doc in docs]
+
+    async def _load_transcript_docs_async(self, audio_path: Path) -> list[Document]:
+        loader = AudioLoader(
+            path=str(audio_path),
+            api_key=self._api_key,
+            backend=self._backend,
+            language=self._language,
+        )
+        docs = await loader.aload()
+        return [self._decorate_transcript_doc(doc) for doc in docs]
+
+    def _decorate_transcript_doc(self, doc: Document) -> Document:
+        timestamp = doc.metadata.get("start_time")
+        doc.metadata = {
+            **doc.metadata,
+            "source": str(self._path),
+            "file": str(self._path),
+            "source_type": "video",
+            "loader": "VideoLoader",
+            "chunk_type": "transcript",
+            "timestamp": self._to_float(timestamp),
+        }
+        return doc
+
+    def _frame_documents_sync(self, frame_paths: list[Path]) -> list[Document]:
+        docs: list[Document] = []
+        for idx, frame_path in enumerate(frame_paths, start=1):
+            loader = ImageLoader(path=frame_path, llm=self._llm, prompt=self._frame_prompt)
+            frame_docs = run_sync(loader.aload())
+            docs.extend(self._decorate_frame_docs(frame_docs, frame_path, idx))
+        return docs
+
+    async def _frame_documents_async(self, frame_paths: list[Path]) -> list[Document]:
+        docs: list[Document] = []
+        for idx, frame_path in enumerate(frame_paths, start=1):
+            loader = ImageLoader(path=frame_path, llm=self._llm, prompt=self._frame_prompt)
+            frame_docs = await loader.aload()
+            docs.extend(self._decorate_frame_docs(frame_docs, frame_path, idx))
+        return docs
+
+    def _decorate_frame_docs(
+        self,
+        docs: list[Document],
+        frame_path: Path,
+        frame_index: int,
+    ) -> list[Document]:
+        timestamp = self._frame_timestamp(frame_index)
+        for doc in docs:
+            doc.metadata = {
+                **doc.metadata,
+                "source": str(self._path),
+                "file": str(self._path),
+                "source_type": "video",
+                "loader": "VideoLoader",
+                "chunk_type": "frame_caption",
+                "timestamp": timestamp,
+                "frame_path": str(frame_path),
+                "frame_index": frame_index,
+            }
+        return docs
+
+    def _frame_timestamp(self, frame_index: int) -> float | None:
+        if not self._frame_interval:
+            return None
+        return (frame_index - 1) * self._frame_interval
 
     def _extract_audio_sync(self) -> Path:
-        """Extract audio using ffmpeg (sync subprocess)."""
+        """Extract mono 16kHz WAV audio using ffmpeg (sync subprocess)."""
         import subprocess
 
         audio_path = self._make_audio_path()
-        subprocess.run(
-            [
-                "ffmpeg",
-                "-i",
-                str(self._path),
-                "-vn",
-                "-acodec",
-                "pcm_s16le",
-                "-ar",
-                "16000",
-                "-ac",
-                "1",
-                "-y",
-                str(audio_path),
-            ],
-            check=True,
-            capture_output=True,
-        )
-        return audio_path
-
-    async def _extract_audio_async(self) -> Path:
-        """Extract audio using ffmpeg (async subprocess)."""
-        audio_path = self._make_audio_path()
-        proc = await asyncio.create_subprocess_exec(
+        cmd = [
             "ffmpeg",
             "-i",
             str(self._path),
@@ -124,13 +173,83 @@ class VideoLoader:
             "1",
             "-y",
             str(audio_path),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
+        ]
+        try:
+            subprocess.run(cmd, check=True, capture_output=True)
+        except FileNotFoundError as e:
+            raise RuntimeError("ffmpeg is required for VideoLoader but was not found.") from e
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr.decode(errors="ignore") if e.stderr else ""
+            raise RuntimeError(f"ffmpeg failed to extract audio: {stderr}") from e
+        return audio_path
+
+    async def _extract_audio_async(self) -> Path:
+        """Extract mono 16kHz WAV audio using ffmpeg (async subprocess)."""
+        audio_path = self._make_audio_path()
+        cmd = [
+            "ffmpeg",
+            "-i",
+            str(self._path),
+            "-vn",
+            "-acodec",
+            "pcm_s16le",
+            "-ar",
+            "16000",
+            "-ac",
+            "1",
+            "-y",
+            str(audio_path),
+        ]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError as e:
+            raise RuntimeError("ffmpeg is required for VideoLoader but was not found.") from e
+
         _, stderr = await proc.communicate()
         if proc.returncode != 0:
-            raise RuntimeError(f"ffmpeg failed: {stderr.decode()}")
+            raise RuntimeError(f"ffmpeg failed to extract audio: {stderr.decode(errors='ignore')}")
         return audio_path
+
+    def _extract_frames_sync(self) -> list[Path]:
+        """Extract frame images with ffmpeg at configured intervals."""
+        if not self._frame_interval or self._frame_interval <= 0:
+            return []
+
+        import subprocess
+
+        frames_dir = Path(tempfile.mkdtemp(prefix="synapsekit_frames_"))
+        frame_pattern = frames_dir / "frame_%06d.jpg"
+        cmd = [
+            "ffmpeg",
+            "-i",
+            str(self._path),
+            "-vf",
+            f"fps=1/{self._frame_interval}",
+            "-q:v",
+            "2",
+            "-y",
+            str(frame_pattern),
+        ]
+
+        try:
+            subprocess.run(cmd, check=True, capture_output=True)
+        except FileNotFoundError as e:
+            self._remove_dir_if_exists(frames_dir)
+            raise RuntimeError("ffmpeg is required for VideoLoader but was not found.") from e
+        except subprocess.CalledProcessError as e:
+            self._remove_dir_if_exists(frames_dir)
+            stderr = e.stderr.decode(errors="ignore") if e.stderr else ""
+            raise RuntimeError(f"ffmpeg failed to extract frames: {stderr}") from e
+
+        return sorted(frames_dir.glob("frame_*.jpg"))
+
+    async def _extract_frames_async(self) -> list[Path]:
+        """Extract frames asynchronously by offloading sync extraction."""
+        return await asyncio.to_thread(self._extract_frames_sync)
 
     def _make_audio_path(self) -> Path:
         """Create a temp path for the extracted audio file."""
@@ -138,6 +257,38 @@ class VideoLoader:
         if self._keep_audio:
             return self._path.with_suffix(suffix)
         with tempfile.NamedTemporaryFile(
-            suffix=suffix, prefix="synapsekit_audio_", delete=False
+            suffix=suffix,
+            prefix="synapsekit_audio_",
+            delete=False,
         ) as fd:
             return Path(fd.name)
+
+    def _cleanup_audio_file(self, audio_path: Path) -> None:
+        if self._keep_audio:
+            return
+        if audio_path.exists():
+            audio_path.unlink()
+
+    def _cleanup_frame_files(self, frame_paths: list[Path]) -> None:
+        if self._keep_frames or not frame_paths:
+            return
+
+        parent = frame_paths[0].parent
+        for frame_path in frame_paths:
+            if frame_path.exists():
+                frame_path.unlink()
+        self._remove_dir_if_exists(parent)
+
+    @staticmethod
+    def _remove_dir_if_exists(path: Path) -> None:
+        with suppress(OSError):
+            path.rmdir()
+
+    @staticmethod
+    def _to_float(value: Any) -> float | None:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None

--- a/src/synapsekit/rag/facade.py
+++ b/src/synapsekit/rag/facade.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
+from pathlib import Path
 
 from .._compat import run_sync
 from ..embeddings.backend import SynapsekitEmbeddings
@@ -13,6 +14,20 @@ from ..observability.tracer import TokenTracer
 from ..retrieval.retriever import Retriever
 from ..retrieval.vectorstore import InMemoryVectorStore
 from .pipeline import RAGConfig, RAGPipeline
+
+IMAGE_EXTENSIONS = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
+    ".bmp",
+    ".tiff",
+    ".tif",
+    ".heic",
+    ".heif",
+    ".svg",
+}
 
 
 def _make_llm(
@@ -221,12 +236,16 @@ class RAG:
     # Document ingestion
     # ------------------------------------------------------------------ #
 
-    def add(self, text: str, metadata: dict | None = None) -> None:
-        """Sync: chunk and embed text into the vectorstore."""
-        run_sync(self._pipeline.add(text, metadata))
+    def add(self, text: str, metadata: dict | None = None, **kwargs) -> None:
+        """Sync: add raw text, or auto-detect multimodal file paths."""
+        run_sync(self.add_async(text, metadata=metadata, **kwargs))
 
-    async def add_async(self, text: str, metadata: dict | None = None) -> None:
-        """Async: chunk and embed text into the vectorstore."""
+    async def add_async(self, text: str, metadata: dict | None = None, **kwargs) -> None:
+        """Async: add raw text, or auto-detect multimodal file paths."""
+        docs = await self._load_multimodal_documents(text, metadata=metadata, **kwargs)
+        if docs is not None:
+            await self._pipeline.add_documents(docs)
+            return
         await self._pipeline.add(text, metadata)
 
     def add_documents(self, docs: list[Document]) -> None:
@@ -236,6 +255,66 @@ class RAG:
     async def add_documents_async(self, docs: list[Document]) -> None:
         """Async: chunk and embed a list of Documents into the vectorstore."""
         await self._pipeline.add_documents(docs)
+
+    async def _load_multimodal_documents(
+        self,
+        text: str,
+        metadata: dict | None = None,
+        **kwargs,
+    ) -> list[Document] | None:
+        path = Path(text)
+        if not path.exists() or not path.is_file():
+            return None
+
+        from ..loaders.audio import SUPPORTED_EXTENSIONS as AUDIO_EXTENSIONS
+        from ..loaders.audio import AudioLoader
+        from ..loaders.image import ImageLoader
+        from ..loaders.video import SUPPORTED_EXTENSIONS as VIDEO_EXTENSIONS
+        from ..loaders.video import VideoLoader
+
+        suffix = path.suffix.lower()
+        llm = self._pipeline.config.llm
+
+        if suffix in IMAGE_EXTENSIONS:
+            prompt = kwargs.get("caption") or kwargs.get("prompt")
+            image_loader = ImageLoader(
+                path=path,
+                llm=llm,
+                prompt=prompt or "Describe this image in detail for retrieval.",
+            )
+            docs = await image_loader.aload()
+        elif suffix in AUDIO_EXTENSIONS:
+            audio_loader = AudioLoader(
+                path=str(path),
+                api_key=kwargs.get("audio_api_key", llm.config.api_key),
+                backend=kwargs.get("audio_backend", "whisper_api"),
+                language=kwargs.get("language"),
+                model=kwargs.get("audio_model", "whisper-1"),
+            )
+            docs = await audio_loader.aload()
+        elif suffix in VIDEO_EXTENSIONS:
+            video_loader = VideoLoader(
+                path=str(path),
+                api_key=kwargs.get("audio_api_key", llm.config.api_key),
+                backend=kwargs.get("audio_backend", "whisper_api"),
+                language=kwargs.get("language"),
+                keep_audio=bool(kwargs.get("keep_audio", False)),
+                llm=llm,
+                frame_interval=kwargs.get("frame_interval", 30),
+                frame_prompt=kwargs.get(
+                    "frame_prompt",
+                    "Describe this video frame in detail for retrieval.",
+                ),
+                keep_frames=bool(kwargs.get("keep_frames", False)),
+            )
+            docs = await video_loader.aload()
+        else:
+            return None
+
+        if metadata:
+            for doc in docs:
+                doc.metadata = {**doc.metadata, **metadata}
+        return docs
 
     # ------------------------------------------------------------------ #
     # Querying

--- a/tests/loaders/test_audio_video_loaders.py
+++ b/tests/loaders/test_audio_video_loaders.py
@@ -1,13 +1,14 @@
-"""Tests for AudioLoader and VideoLoader (v1.3.0)."""
+"""Tests for AudioLoader and VideoLoader."""
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from synapsekit.loaders.audio import SUPPORTED_EXTENSIONS as AUDIO_EXTENSIONS
 from synapsekit.loaders.audio import AudioLoader
+from synapsekit.loaders.base import Document
 from synapsekit.loaders.video import SUPPORTED_EXTENSIONS as VIDEO_EXTENSIONS
 from synapsekit.loaders.video import VideoLoader
 
@@ -26,18 +27,27 @@ class TestAudioLoader:
         with pytest.raises(ValueError, match="Unsupported audio format"):
             AudioLoader(str(bad_file))
 
-    def test_load_whisper_api(self, tmp_path):
+    def test_load_whisper_api_segmented(self, tmp_path):
         audio_file = tmp_path / "test.mp3"
         audio_file.write_bytes(b"fake audio data")
 
         loader = AudioLoader(str(audio_file), api_key="sk-test", backend="whisper_api")
-        with patch.object(loader, "_transcribe_api", return_value="Hello world transcription"):
+        fake_transcript = {
+            "text": "Hello world transcription.",
+            "segments": [
+                {"text": "Hello world.", "start": 0.0, "end": 1.2},
+                {"text": "Second sentence.", "start": 1.2, "end": 2.1},
+            ],
+        }
+        with patch.object(loader, "_transcribe_api", return_value=fake_transcript):
             docs = loader.load()
 
-        assert len(docs) == 1
-        assert docs[0].text == "Hello world transcription"
+        assert len(docs) == 2
         assert docs[0].metadata["loader"] == "AudioLoader"
         assert docs[0].metadata["source"] == str(audio_file)
+        assert docs[0].metadata["source_type"] == "audio"
+        assert docs[0].metadata["start_time"] == 0.0
+        assert docs[0].metadata["end_time"] == 1.2
 
     def test_unknown_backend_raises(self, tmp_path):
         audio_file = tmp_path / "test.mp3"
@@ -51,17 +61,19 @@ class TestAudioLoader:
         audio_file.write_bytes(b"fake audio data")
 
         loader = AudioLoader(str(audio_file), api_key="sk-test")
-        with patch.object(loader, "_transcribe_api", return_value="Async transcription"):
+        with patch.object(
+            loader, "_transcribe_api", return_value={"text": "Async", "segments": []}
+        ):
             docs = await loader.aload()
 
         assert len(docs) == 1
-        assert docs[0].text == "Async transcription"
+        assert docs[0].text == "Async"
 
     def test_metadata_includes_backend(self, tmp_path):
         audio_file = tmp_path / "test.mp3"
         audio_file.write_bytes(b"data")
         loader = AudioLoader(str(audio_file), backend="whisper_api")
-        with patch.object(loader, "_transcribe_api", return_value="text"):
+        with patch.object(loader, "_transcribe_api", return_value={"text": "text", "segments": []}):
             docs = loader.load()
         assert docs[0].metadata["backend"] == "whisper_api"
 
@@ -69,7 +81,9 @@ class TestAudioLoader:
         audio_file = tmp_path / "test.mp3"
         audio_file.write_bytes(b"data")
         loader = AudioLoader(str(audio_file), backend="whisper_local")
-        with patch.object(loader, "_transcribe_local", return_value="local text"):
+        with patch.object(
+            loader, "_transcribe_local", return_value={"text": "local text", "segments": []}
+        ):
             docs = loader.load()
         assert docs[0].text == "local text"
         assert docs[0].metadata["backend"] == "whisper_local"
@@ -88,22 +102,41 @@ class TestVideoLoader:
         with pytest.raises(ValueError, match="Unsupported video format"):
             VideoLoader(str(bad_file))
 
-    def test_load_delegates_to_audio_loader(self, tmp_path):
+    def test_load_includes_transcript_and_frames(self, tmp_path):
         video_file = tmp_path / "test.mp4"
         video_file.write_bytes(b"fake video")
 
         audio_file = tmp_path / "extracted.wav"
         audio_file.write_bytes(b"fake audio")
 
-        loader = VideoLoader(str(video_file), api_key="sk-test")
-        with patch.object(loader, "_extract_audio_sync", return_value=audio_file):
-            with patch.object(AudioLoader, "_transcribe_api", return_value="Video transcription"):
-                docs = loader.load()
+        frame1 = tmp_path / "frame_000001.jpg"
+        frame1.write_bytes(b"frame1")
+        frame2 = tmp_path / "frame_000002.jpg"
+        frame2.write_bytes(b"frame2")
 
-        assert len(docs) == 1
+        loader = VideoLoader(str(video_file), api_key="sk-test", frame_interval=30)
+
+        transcript_doc = Document(
+            text="Video transcription",
+            metadata={"start_time": 5.0, "end_time": 9.5, "source_type": "audio"},
+        )
+        frame_doc = Document(text="A UI screen", metadata={"source_type": "image"})
+
+        with patch.object(loader, "_extract_audio_sync", return_value=audio_file):
+            with patch.object(loader, "_extract_frames_sync", return_value=[frame1, frame2]):
+                with patch.object(
+                    loader, "_load_transcript_docs_sync", return_value=[transcript_doc]
+                ):
+                    with patch.object(
+                        loader,
+                        "_frame_documents_sync",
+                        return_value=[frame_doc],
+                    ):
+                        docs = loader.load()
+
+        assert len(docs) == 2
         assert docs[0].text == "Video transcription"
-        assert docs[0].metadata["loader"] == "VideoLoader"
-        assert docs[0].metadata["source"] == str(video_file)
+        assert docs[1].text == "A UI screen"
 
     def test_keep_audio_flag(self, tmp_path):
         video_file = tmp_path / "test.mp4"
@@ -119,9 +152,21 @@ class TestVideoLoader:
         audio_file.write_bytes(b"fake audio")
 
         loader = VideoLoader(str(video_file), api_key="sk-test")
+        transcript_doc = Document(text="Async video", metadata={"start_time": 0.0})
+
         with patch.object(loader, "_extract_audio_async", return_value=audio_file):
-            with patch.object(AudioLoader, "_transcribe_api", return_value="Async video"):
-                docs = await loader.aload()
+            with patch.object(loader, "_extract_frames_async", return_value=[]):
+                with patch.object(
+                    loader,
+                    "_load_transcript_docs_async",
+                    new=AsyncMock(return_value=[transcript_doc]),
+                ):
+                    with patch.object(
+                        loader,
+                        "_frame_documents_async",
+                        new=AsyncMock(return_value=[]),
+                    ):
+                        docs = await loader.aload()
 
         assert len(docs) == 1
         assert docs[0].text == "Async video"
@@ -130,6 +175,5 @@ class TestVideoLoader:
         """`.webm` is valid for both audio and video."""
         webm_file = tmp_path / "test.webm"
         webm_file.write_bytes(b"data")
-        # Should be valid for both
         assert ".webm" in AUDIO_EXTENSIONS
         assert ".webm" in VIDEO_EXTENSIONS

--- a/tests/rag/test_facade.py
+++ b/tests/rag/test_facade.py
@@ -7,17 +7,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from synapsekit import RAG
+from synapsekit.loaders.base import Document
 from synapsekit.memory.conversation import ConversationMemory
 from synapsekit.observability.tracer import TokenTracer
 
 
 def _patch_rag(rag: RAG, tokens=("Answer", " here")):
     """Replace the pipeline's LLM and retriever with mocks."""
-    # Patch retriever
     rag._pipeline.config.retriever.retrieve = AsyncMock(return_value=["context"])
     rag._pipeline.config.retriever._store.add = AsyncMock()
 
-    # Patch LLM stream
     async def mock_stream(messages, **kw):
         for t in tokens:
             yield t
@@ -26,7 +25,6 @@ def _patch_rag(rag: RAG, tokens=("Answer", " here")):
     rag._pipeline.config.llm._input_tokens = 5
     rag._pipeline.config.llm._output_tokens = 3
 
-    # Patch splitter
     mock_splitter = MagicMock()
     mock_splitter.split = MagicMock(return_value=["chunk"])
     rag._pipeline._splitter = mock_splitter
@@ -59,6 +57,68 @@ class TestRAGFacade:
         _patch_rag(rag)
         await rag.add_async("Some document text.")
         rag._pipeline._splitter.split.assert_called_once()
+
+    def test_add_sync_autodetects_image_file(self, tmp_path):
+        image_file = tmp_path / "diagram.png"
+        image_file.write_bytes(b"png")
+
+        rag = RAG(model="gpt-4o-mini", api_key="sk-test")
+        _patch_rag(rag)
+
+        with patch(
+            "synapsekit.loaders.image.ImageLoader.aload",
+            new=AsyncMock(
+                return_value=[Document(text="caption", metadata={"source_type": "image"})]
+            ),
+        ):
+            rag.add(str(image_file))
+
+        rag._pipeline._splitter.split.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_add_async_autodetects_audio_file(self, tmp_path):
+        audio_file = tmp_path / "meeting.mp3"
+        audio_file.write_bytes(b"audio")
+
+        rag = RAG(model="gpt-4o-mini", api_key="sk-test")
+        _patch_rag(rag)
+
+        with patch(
+            "synapsekit.loaders.audio.AudioLoader.aload",
+            new=AsyncMock(
+                return_value=[Document(text="transcript", metadata={"source_type": "audio"})]
+            ),
+        ):
+            await rag.add_async(str(audio_file))
+
+        rag._pipeline._splitter.split.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_add_async_existing_non_multimodal_path_falls_back_to_text(self, tmp_path):
+        text_file = tmp_path / "notes.txt"
+        text_file.write_text("hello", encoding="utf-8")
+
+        rag = RAG(model="gpt-4o-mini", api_key="sk-test")
+        rag._pipeline.add = AsyncMock()
+
+        await rag.add_async(str(text_file))
+
+        rag._pipeline.add.assert_awaited_once_with(str(text_file), None)
+
+    def test_add_image_caption_kw_passed_to_loader(self, tmp_path):
+        image_file = tmp_path / "diagram.png"
+        image_file.write_bytes(b"png")
+
+        rag = RAG(model="gpt-4o-mini", api_key="sk-test")
+        _patch_rag(rag)
+
+        with patch("synapsekit.loaders.image.ImageLoader") as mock_loader_cls:
+            mock_loader = mock_loader_cls.return_value
+            mock_loader.aload = AsyncMock(return_value=[Document(text="caption", metadata={})])
+
+            rag.add(str(image_file), caption="Login flow from Q4 review")
+
+            assert mock_loader_cls.call_args.kwargs["prompt"] == "Login flow from Q4 review"
 
     @pytest.mark.asyncio
     async def test_ask_returns_string(self):


### PR DESCRIPTION
## Summary
- add multimodal ingestion auto-detection to `RAG.add` / `RAG.add_async` for image, audio, and video file paths
- upgrade `ImageLoader` for robust multimodal captioning via provider-aware message formatting
- extend `AudioLoader` to produce segmented, timestamped chunk documents with modality metadata
- extend `VideoLoader` to emit both transcript chunks and frame-caption chunks with timestamp/chunk metadata
- add `examples/multimodal_rag.py` and update loader/facade tests

## Why
Implements issue #510 by making multimodal assets ingestible in the same pipeline API used for text (`rag.add(...)`).

## Metadata added
- `source_type` (`image` / `audio` / `video`)
- `file`, `source`, loader/backend markers
- audio: `start_time`, `end_time`
- video: `chunk_type` (`transcript` / `frame_caption`), `timestamp`, `frame_index`, `frame_path`

## Validation
- `python -m ruff check src/ tests/`
- `python -m ruff format --check src/ tests/`
- `PYTHONPATH=src python -m pytest tests/loaders/test_audio_video_loaders.py tests/rag/test_facade.py tests/test_v100_features.py -q`

All targeted checks above pass locally.

Closes #510
