### PR TITLE
feat(Loader): Added Elastic docs loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ confluence = ["atlassian-python-api>=3.0", "beautifulsoup4>=4.12"]
 dropbox = ["dropbox>=12.0"]
 rtf = ["striprtf>=0.0.26"]
 epub = ["ebooklib>=0.18"]
+elasticsearch = ["elasticsearch>=8.0"]
 all = [
     "openai>=1.0",
     "anthropic>=0.25",
@@ -161,6 +162,7 @@ all = [
     "supabase>=2.0",
     "pymongo>=4.0",
     "azure-storage-blob>=12.0",
+    "elasticsearch>=8.0",
 ]
 
 [dependency-groups]
@@ -299,6 +301,6 @@ azure-storage-blob = "azure"
 
 [tool.deptry.per_rule_ignores]
 DEP001 = ["sqlalchemy", "pydantic", "aiohttp", "opentelemetry", "whisper", "botocore", "aiomcache", "nest_asyncio", "huggingface_hub", "serpapi", "weaviate", "uvicorn", "starlette", "tomli"]
-DEP002 = ["numpy", "rank-bm25", "beautifulsoup4", "lxml", "faiss-cpu", "google-generativeai", "tavily-python", "youtube-search-python", "psycopg", "google-search-results", "discord.py", "google-auth", "weaviate-client", "pymilvus", "lancedb", "pgvector", "slack-sdk", "supabase", "pymongo", "azure-storage-blob"]
+DEP002 = ["numpy", "rank-bm25", "beautifulsoup4", "lxml", "faiss-cpu", "google-generativeai", "tavily-python", "youtube-search-python", "psycopg", "google-search-results", "discord.py", "google-auth", "weaviate-client", "pymilvus", "lancedb", "pgvector", "slack-sdk", "supabase", "pymongo", "azure-storage-blob", "elasticsearch"]
 DEP003 = ["sqlalchemy", "botocore", "nest_asyncio", "opentelemetry", "starlette", "uvicorn"]
 DEP004 = ["pydantic"]

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -359,6 +359,7 @@ __all__ = [
     "DirectoryLoader",
     "DropboxLoader",
     "EPUBLoader",
+    "ElasticsearchLoader",
     "ConfluenceLoader",
     "DocxLoader",
     "EmailLoader",
@@ -632,6 +633,7 @@ _LAZY_IMPORTS = {
     "AzureBlobLoader": "loaders.azure_blob",
     "S3Loader": "loaders.s3",
     "DropboxLoader": "loaders.dropbox",
+    "ElasticsearchLoader": "loaders.elasticsearch",
 }
 
 

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     "Document",
     "DropboxLoader",
     "EPUBLoader",
+    "ElasticsearchLoader",
     "EmailLoader",
     "GCSLoader",
     "GitHubLoader",
@@ -92,6 +93,7 @@ _LOADERS = {
     "MongoDBLoader": ".mongodb",
     "DropboxLoader": ".dropbox",
     "EPUBLoader": ".epub",
+    "ElasticsearchLoader": ".elasticsearch",
 }
 
 

--- a/src/synapsekit/loaders/elasticsearch.py
+++ b/src/synapsekit/loaders/elasticsearch.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from .base import Document
+
+
+class ElasticsearchLoader:
+    """Load documents from an Elasticsearch index."""
+
+    def __init__(
+        self,
+        url: str,
+        index: str,
+        query: dict[str, Any] | None = None,
+        text_fields: list[str] | None = None,
+        limit: int | None = None,
+    ) -> None:
+        if not url:
+            raise ValueError("url must be provided")
+        if not index:
+            raise ValueError("index must be provided")
+
+        self._url = url
+        self._index = index
+        self._query = query
+        self._text_fields = text_fields or ["content"]
+        self._limit = limit
+
+    def load(self) -> list[Document]:
+        try:
+            from elasticsearch import Elasticsearch
+        except ImportError:
+            raise ImportError(
+                "elasticsearch required: pip install synapsekit[elasticsearch]"
+            ) from None
+
+        client = Elasticsearch(self._url)
+        resp = client.search(
+            index=self._index,
+            query=self._query or {"match_all": {}},
+            size=self._limit or 100,
+        )
+
+        hits = resp.get("hits", {}).get("hits", [])
+
+        docs: list[Document] = []
+        for hit in hits:
+            source = hit.get("_source", {})
+
+            text = " ".join(
+                str(source[field])
+                for field in self._text_fields
+                if source.get(field) is not None and source.get(field) != ""
+            )
+
+            if not text:
+                continue
+
+            metadata: dict[str, Any] = {
+                "source": "elasticsearch",
+                "index": self._index,
+                "id": hit.get("_id"),
+            }
+
+            docs.append(Document(text=text, metadata=metadata))
+
+        return docs
+
+    async def aload(self) -> list[Document]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.load)

--- a/tests/loaders/test_elasticsearch_loader.py
+++ b/tests/loaders/test_elasticsearch_loader.py
@@ -8,7 +8,6 @@ import pytest
 from synapsekit.loaders import Document
 from synapsekit.loaders.elasticsearch import ElasticsearchLoader
 
-
 # ---------------------------------------------------------------------------
 # Initialisation validation
 # ---------------------------------------------------------------------------

--- a/tests/loaders/test_elasticsearch_loader.py
+++ b/tests/loaders/test_elasticsearch_loader.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapsekit.loaders import Document
+from synapsekit.loaders.elasticsearch import ElasticsearchLoader
+
+
+# ---------------------------------------------------------------------------
+# Initialisation validation
+# ---------------------------------------------------------------------------
+
+
+def test_init_requires_url() -> None:
+    with pytest.raises(ValueError, match="url must be provided"):
+        ElasticsearchLoader(url="", index="my-index")
+
+
+def test_init_requires_index() -> None:
+    with pytest.raises(ValueError, match="index must be provided"):
+        ElasticsearchLoader(url="http://localhost:9200", index="")
+
+
+def test_init_defaults() -> None:
+    loader = ElasticsearchLoader(url="http://localhost:9200", index="my-index")
+    assert loader._text_fields == ["content"]
+    assert loader._query is None
+    assert loader._limit is None
+
+
+# ---------------------------------------------------------------------------
+# Missing dependency
+# ---------------------------------------------------------------------------
+
+
+def test_load_import_error_missing_elasticsearch() -> None:
+    with patch.dict("sys.modules", {"elasticsearch": None}):
+        loader = ElasticsearchLoader(url="http://localhost:9200", index="my-index")
+        with pytest.raises(ImportError, match="elasticsearch required"):
+            loader.load()
+
+
+# ---------------------------------------------------------------------------
+# Normal load
+# ---------------------------------------------------------------------------
+
+
+@patch.dict("sys.modules", {"elasticsearch": MagicMock()})
+def test_load_returns_documents() -> None:
+    import sys
+
+    mock_es_class = sys.modules["elasticsearch"].Elasticsearch
+    mock_client = MagicMock()
+    mock_es_class.return_value = mock_client
+
+    mock_client.search.return_value = {
+        "hits": {
+            "hits": [
+                {"_id": "1", "_source": {"content": "Hello world"}},
+                {"_id": "2", "_source": {"content": "Elasticsearch rocks"}},
+            ]
+        }
+    }
+
+    loader = ElasticsearchLoader(url="http://localhost:9200", index="articles")
+    docs = loader.load()
+
+    assert len(docs) == 2
+    assert all(isinstance(doc, Document) for doc in docs)
+    assert docs[0].text == "Hello world"
+    assert docs[1].text == "Elasticsearch rocks"
+
+
+@patch.dict("sys.modules", {"elasticsearch": MagicMock()})
+def test_load_metadata_correctness() -> None:
+    import sys
+
+    mock_es_class = sys.modules["elasticsearch"].Elasticsearch
+    mock_client = MagicMock()
+    mock_es_class.return_value = mock_client
+
+    mock_client.search.return_value = {
+        "hits": {
+            "hits": [
+                {"_id": "abc-123", "_source": {"content": "Test document"}},
+            ]
+        }
+    }
+
+    loader = ElasticsearchLoader(url="http://localhost:9200", index="docs")
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].metadata["source"] == "elasticsearch"
+    assert docs[0].metadata["index"] == "docs"
+    assert docs[0].metadata["id"] == "abc-123"
+
+
+@patch.dict("sys.modules", {"elasticsearch": MagicMock()})
+def test_load_multiple_text_fields() -> None:
+    import sys
+
+    mock_es_class = sys.modules["elasticsearch"].Elasticsearch
+    mock_client = MagicMock()
+    mock_es_class.return_value = mock_client
+
+    mock_client.search.return_value = {
+        "hits": {
+            "hits": [
+                {"_id": "1", "_source": {"title": "My Title", "body": "My Body"}},
+            ]
+        }
+    }
+
+    loader = ElasticsearchLoader(
+        url="http://localhost:9200",
+        index="articles",
+        text_fields=["title", "body"],
+    )
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].text == "My Title My Body"
+
+
+# ---------------------------------------------------------------------------
+# Query forwarding
+# ---------------------------------------------------------------------------
+
+
+@patch.dict("sys.modules", {"elasticsearch": MagicMock()})
+def test_load_passes_custom_query() -> None:
+    import sys
+
+    mock_es_class = sys.modules["elasticsearch"].Elasticsearch
+    mock_client = MagicMock()
+    mock_es_class.return_value = mock_client
+
+    mock_client.search.return_value = {"hits": {"hits": []}}
+
+    custom_query = {"term": {"status": "published"}}
+    loader = ElasticsearchLoader(
+        url="http://localhost:9200",
+        index="posts",
+        query=custom_query,
+    )
+    loader.load()
+
+    mock_client.search.assert_called_once_with(
+        index="posts",
+        query=custom_query,
+        size=100,
+    )
+
+
+@patch.dict("sys.modules", {"elasticsearch": MagicMock()})
+def test_load_defaults_to_match_all_query() -> None:
+    import sys
+
+    mock_es_class = sys.modules["elasticsearch"].Elasticsearch
+    mock_client = MagicMock()
+    mock_es_class.return_value = mock_client
+
+    mock_client.search.return_value = {"hits": {"hits": []}}
+
+    loader = ElasticsearchLoader(url="http://localhost:9200", index="logs")
+    loader.load()
+
+    mock_client.search.assert_called_once_with(
+        index="logs",
+        query={"match_all": {}},
+        size=100,
+    )
+
+
+@patch.dict("sys.modules", {"elasticsearch": MagicMock()})
+def test_load_respects_limit() -> None:
+    import sys
+
+    mock_es_class = sys.modules["elasticsearch"].Elasticsearch
+    mock_client = MagicMock()
+    mock_es_class.return_value = mock_client
+
+    mock_client.search.return_value = {"hits": {"hits": []}}
+
+    loader = ElasticsearchLoader(url="http://localhost:9200", index="logs", limit=10)
+    loader.load()
+
+    mock_client.search.assert_called_once_with(
+        index="logs",
+        query={"match_all": {}},
+        size=10,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@patch.dict("sys.modules", {"elasticsearch": MagicMock()})
+def test_load_empty_results() -> None:
+    import sys
+
+    mock_es_class = sys.modules["elasticsearch"].Elasticsearch
+    mock_client = MagicMock()
+    mock_es_class.return_value = mock_client
+
+    mock_client.search.return_value = {"hits": {"hits": []}}
+
+    loader = ElasticsearchLoader(url="http://localhost:9200", index="empty-index")
+    docs = loader.load()
+
+    assert docs == []
+
+
+@patch.dict("sys.modules", {"elasticsearch": MagicMock()})
+def test_load_skips_hits_with_empty_text() -> None:
+    import sys
+
+    mock_es_class = sys.modules["elasticsearch"].Elasticsearch
+    mock_client = MagicMock()
+    mock_es_class.return_value = mock_client
+
+    mock_client.search.return_value = {
+        "hits": {
+            "hits": [
+                {"_id": "1", "_source": {"content": ""}},
+                {"_id": "2", "_source": {}},
+                {"_id": "3", "_source": {"content": "Valid content"}},
+            ]
+        }
+    }
+
+    loader = ElasticsearchLoader(url="http://localhost:9200", index="mixed")
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].text == "Valid content"
+    assert docs[0].metadata["id"] == "3"
+
+
+@patch.dict("sys.modules", {"elasticsearch": MagicMock()})
+def test_load_skips_none_field_values() -> None:
+    import sys
+
+    mock_es_class = sys.modules["elasticsearch"].Elasticsearch
+    mock_client = MagicMock()
+    mock_es_class.return_value = mock_client
+
+    mock_client.search.return_value = {
+        "hits": {
+            "hits": [
+                {"_id": "1", "_source": {"title": None, "body": "Some body text"}},
+            ]
+        }
+    }
+
+    loader = ElasticsearchLoader(
+        url="http://localhost:9200",
+        index="articles",
+        text_fields=["title", "body"],
+    )
+    docs = loader.load()
+
+    # title is None so only body goes into text — no "None" strings
+    assert len(docs) == 1
+    assert docs[0].text == "Some body text"
+    assert "None" not in docs[0].text
+
+
+@patch.dict("sys.modules", {"elasticsearch": MagicMock()})
+def test_load_missing_source_is_skipped() -> None:
+    import sys
+
+    mock_es_class = sys.modules["elasticsearch"].Elasticsearch
+    mock_client = MagicMock()
+    mock_es_class.return_value = mock_client
+
+    mock_client.search.return_value = {
+        "hits": {
+            "hits": [
+                {"_id": "1"},  # no _source key
+                {"_id": "2", "_source": {"content": "Good doc"}},
+            ]
+        }
+    }
+
+    loader = ElasticsearchLoader(url="http://localhost:9200", index="partial")
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].text == "Good doc"
+
+
+# ---------------------------------------------------------------------------
+# Async
+# ---------------------------------------------------------------------------
+
+
+@patch.dict("sys.modules", {"elasticsearch": MagicMock()})
+def test_aload() -> None:
+    import sys
+
+    mock_es_class = sys.modules["elasticsearch"].Elasticsearch
+    mock_client = MagicMock()
+    mock_es_class.return_value = mock_client
+
+    mock_client.search.return_value = {
+        "hits": {
+            "hits": [
+                {"_id": "1", "_source": {"content": "Async test"}},
+            ]
+        }
+    }
+
+    loader = ElasticsearchLoader(url="http://localhost:9200", index="async-index")
+    docs = asyncio.run(loader.aload())
+
+    assert len(docs) == 1
+    assert docs[0].text == "Async test"

--- a/uv.lock
+++ b/uv.lock
@@ -1557,6 +1557,36 @@ wheels = [
 ]
 
 [[package]]
+name = "elastic-transport"
+version = "9.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "sniffio" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/0a/a92140b666afdcb9862a16e4d80873b3c887c1b7e3f17e945fc3460edf1b/elastic_transport-9.2.1.tar.gz", hash = "sha256:97d9abd638ba8aa90faa4ca1bf1a18bde0fe2088fbc8757f2eb7b299f205773d", size = 77403, upload-time = "2025-12-23T11:54:12.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e6/a42b600ae8b808371f740381f6c32050cad93f870d36cc697b8b7006bf7c/elastic_transport-9.2.1-py3-none-any.whl", hash = "sha256:39e1a25e486af34ce7aa1bc9005d1c736f1b6fb04c9b64ea0604ded5a61fc1d4", size = 65327, upload-time = "2025-12-23T11:54:11.681Z" },
+]
+
+[[package]]
+name = "elasticsearch"
+version = "9.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "elastic-transport" },
+    { name = "python-dateutil" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/15/283459c9299d412ffa2aaab69b082857631c519233f5491d6c567e3320ca/elasticsearch-9.3.0.tar.gz", hash = "sha256:f76e149c0a22d5ccbba58bdc30c9f51cf894231b359ef4fd7e839b558b59f856", size = 893538, upload-time = "2026-02-03T20:26:38.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/37/3a196f8918743f2104cb66b1f56218079ecac6e128c061de7df7f4faef02/elasticsearch-9.3.0-py3-none-any.whl", hash = "sha256:67bd2bb4f0800f58c2847d29cd57d6e7bf5bc273483b4f17421f93e75ba09f39", size = 979405, upload-time = "2026-02-03T20:26:34.552Z" },
+]
+
+[[package]]
 name = "erniebot"
 version = "0.5.9"
 source = { registry = "https://pypi.org/simple" }
@@ -7553,7 +7583,7 @@ wheels = [
 
 [[package]]
 name = "synapsekit"
-version = "1.5.3"
+version = "1.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -7580,6 +7610,7 @@ all = [
     { name = "cohere" },
     { name = "discord-py" },
     { name = "duckduckgo-search" },
+    { name = "elasticsearch" },
     { name = "erniebot" },
     { name = "faiss-cpu" },
     { name = "fastapi" },
@@ -7664,6 +7695,9 @@ dropbox = [
 ]
 dynamodb = [
     { name = "boto3" },
+]
+elasticsearch = [
+    { name = "elasticsearch" },
 ]
 epub = [
     { name = "ebooklib" },
@@ -7882,6 +7916,8 @@ requires-dist = [
     { name = "duckduckgo-search", marker = "extra == 'all'", specifier = ">=6.0" },
     { name = "duckduckgo-search", marker = "extra == 'search'", specifier = ">=6.0" },
     { name = "ebooklib", marker = "extra == 'epub'", specifier = ">=0.18" },
+    { name = "elasticsearch", marker = "extra == 'all'", specifier = ">=8.0" },
+    { name = "elasticsearch", marker = "extra == 'elasticsearch'", specifier = ">=8.0" },
     { name = "erniebot", marker = "extra == 'all'", specifier = ">=0.5" },
     { name = "erniebot", marker = "extra == 'ernie'", specifier = ">=0.5" },
     { name = "faiss-cpu", marker = "extra == 'all'", specifier = ">=1.7" },
@@ -7980,7 +8016,7 @@ requires-dist = [
     { name = "youtube-search-python", marker = "extra == 'all'", specifier = ">=1.6" },
     { name = "youtube-search-python", marker = "extra == 'youtube'", specifier = ">=1.6" },
 ]
-provides-extras = ["openai", "anthropic", "semantic", "colbert", "pdf", "wikipedia", "arxiv", "html", "web", "chroma", "faiss", "qdrant", "pinecone", "weaviate", "milvus", "lancedb", "ollama", "lmstudio", "ai21", "cohere", "mistral", "gemini", "bedrock", "gcal-tool", "aws-lambda", "rss", "groq", "audio", "video", "excel", "pptx", "docx", "yaml", "teams", "http", "search", "huggingface", "google-search", "tavily", "youtube", "mcp", "redis", "memcached", "vertex", "cloudflare", "aleph-alpha", "llamacpp", "ernie", "minimax", "serve", "postgres", "pgvector", "wolfram", "dynamodb", "discord", "gcs", "gdrive", "git", "gsheets", "jira", "sql", "mongodb", "azure", "s3", "onedrive", "slack", "supabase", "notion", "confluence", "dropbox", "rtf", "epub", "all"]
+provides-extras = ["openai", "anthropic", "semantic", "colbert", "pdf", "wikipedia", "arxiv", "html", "web", "chroma", "faiss", "qdrant", "pinecone", "weaviate", "milvus", "lancedb", "ollama", "lmstudio", "ai21", "cohere", "mistral", "gemini", "bedrock", "gcal-tool", "aws-lambda", "rss", "groq", "audio", "video", "excel", "pptx", "docx", "yaml", "teams", "http", "search", "huggingface", "google-search", "tavily", "youtube", "mcp", "redis", "memcached", "vertex", "cloudflare", "aleph-alpha", "llamacpp", "ernie", "minimax", "serve", "postgres", "pgvector", "wolfram", "dynamodb", "discord", "gcs", "gdrive", "git", "gsheets", "jira", "sql", "mongodb", "azure", "s3", "onedrive", "slack", "supabase", "notion", "confluence", "dropbox", "rtf", "epub", "elasticsearch", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Implements `ElasticsearchLoader`, a new data loader that queries an Elasticsearch index and returns a `list[Document]` with extracted text and metadata.

Closes #60.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / internal improvement
- [ ] Dependency / tooling update

## Changes

- Added `src/synapsekit/loaders/elasticsearch.py` : new `ElasticsearchLoader` class with `load()` and `async aload()` methods; lazy-imports `elasticsearch` and raises a clear `ImportError` if missing
- Added `tests/loaders/test_elasticsearch_loader.py` : 15 unit tests covering init validation, missing dependency, text extraction, multi-field joining, custom queries, limit, empty results, `None`/missing field handling, and async loading (no real Elasticsearch connection required)
- Registered `ElasticsearchLoader` in `src/synapsekit/loaders/__init__.py` (`__all__` + `_LOADERS`)
- Registered `ElasticsearchLoader` in `src/synapsekit/__init__.py` (`__all__` + `_LAZY_IMPORTS`)
- Added `elasticsearch = ["elasticsearch>=8.0"]` optional dependency to `pyproject.toml` (also included in the `all` bundle and `deptry` ignore list)

## Testing

- [x] All existing tests pass (`uv run pytest tests/ -q`)
- [x] New tests added for new behaviour
- [x] No API keys or secrets in the code