### PR TITLE
feat(Loader): Redis Docs Loader

### DIFF
--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -377,6 +377,7 @@ __all__ = [
     "WebLoader",
     "RSSLoader",
     "RTFLoader",
+    "RedisLoader",
     "S3Loader",
     "WikipediaLoader",
     "ExcelLoader",
@@ -632,6 +633,7 @@ _LAZY_IMPORTS = {
     "AzureBlobLoader": "loaders.azure_blob",
     "S3Loader": "loaders.s3",
     "DropboxLoader": "loaders.dropbox",
+    "RedisLoader": "loaders.redis_loader",
 }
 
 

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -38,6 +38,7 @@ __all__ = [
     "PDFLoader",
     "RSSLoader",
     "RTFLoader",
+    "RedisLoader",
     "S3Loader",
     "SQLLoader",
     "SlackLoader",
@@ -92,6 +93,7 @@ _LOADERS = {
     "MongoDBLoader": ".mongodb",
     "DropboxLoader": ".dropbox",
     "EPUBLoader": ".epub",
+    "RedisLoader": ".redis_loader",
 }
 
 

--- a/src/synapsekit/loaders/redis_loader.py
+++ b/src/synapsekit/loaders/redis_loader.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from typing import Any
 
 from .base import Document
 
@@ -61,26 +62,26 @@ class RedisLoader:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self.load)
 
-    def _fetch_text(self, client: object, key: str) -> str:
+    def _fetch_text(self, client: Any, key: str) -> str:
         if self._value_type == "string":
             return self._fetch_string(client, key)
         if self._value_type == "hash":
             return self._fetch_hash(client, key)
         return self._fetch_json(client, key)
 
-    def _fetch_string(self, client: object, key: str) -> str:
+    def _fetch_string(self, client: Any, key: str) -> str:
         value = client.get(key)
         if value is None:
             return ""
         return str(value)
 
-    def _fetch_hash(self, client: object, key: str) -> str:
+    def _fetch_hash(self, client: Any, key: str) -> str:
         data: dict[str, str] = client.hgetall(key)
         if not data:
             return ""
         return " ".join(f"{k}: {v}" for k, v in data.items())
 
-    def _fetch_json(self, client: object, key: str) -> str:
+    def _fetch_json(self, client: Any, key: str) -> str:
         raw = client.get(key)
         if raw is None:
             return ""

--- a/src/synapsekit/loaders/redis_loader.py
+++ b/src/synapsekit/loaders/redis_loader.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+from .base import Document
+
+
+class RedisLoader:
+    """Load documents from Redis keys matching a pattern.
+
+    Supports three value types:
+    - ``"string"`` — plain string values via ``GET``
+    - ``"hash"``   — hash values via ``HGETALL``
+    - ``"json"``   — JSON-encoded strings via ``GET`` + ``json.loads``
+    """
+
+    _SUPPORTED_TYPES = {"string", "hash", "json"}
+
+    def __init__(
+        self,
+        url: str,
+        pattern: str = "*",
+        value_type: str = "string",
+        limit: int | None = None,
+    ) -> None:
+        if not url:
+            raise ValueError("url must be provided")
+        if value_type not in self._SUPPORTED_TYPES:
+            raise ValueError(
+                f"value_type must be one of {self._SUPPORTED_TYPES!r}, got {value_type!r}"
+            )
+
+        self._url = url
+        self._pattern = pattern
+        self._value_type = value_type
+        self._limit = limit
+
+    def load(self) -> list[Document]:
+        try:
+            from redis import Redis
+        except ImportError:
+            raise ImportError("redis required: pip install synapsekit[redis]") from None
+
+        client = Redis.from_url(self._url, decode_responses=True)
+
+        keys: list[str] = client.keys(self._pattern)
+        if self._limit is not None:
+            keys = keys[: self._limit]
+
+        docs: list[Document] = []
+        for key in keys:
+            text = self._fetch_text(client, key)
+            if not text:
+                continue
+            docs.append(Document(text=text, metadata={"source": "redis", "key": key}))
+
+        return docs
+
+    async def aload(self) -> list[Document]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.load)
+
+    def _fetch_text(self, client: object, key: str) -> str:
+        if self._value_type == "string":
+            return self._fetch_string(client, key)
+        if self._value_type == "hash":
+            return self._fetch_hash(client, key)
+        return self._fetch_json(client, key)
+
+    def _fetch_string(self, client: object, key: str) -> str:
+        value = client.get(key)
+        if value is None:
+            return ""
+        return str(value)
+
+    def _fetch_hash(self, client: object, key: str) -> str:
+        data: dict[str, str] = client.hgetall(key)
+        if not data:
+            return ""
+        return " ".join(f"{k}: {v}" for k, v in data.items())
+
+    def _fetch_json(self, client: object, key: str) -> str:
+        raw = client.get(key)
+        if raw is None:
+            return ""
+        try:
+            data = json.loads(raw)
+            return json.dumps(data)
+        except (json.JSONDecodeError, TypeError):
+            return str(raw)

--- a/tests/loaders/test_redis_loader.py
+++ b/tests/loaders/test_redis_loader.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapsekit.loaders import Document
+from synapsekit.loaders.redis_loader import RedisLoader
+
+# ---------------------------------------------------------------------------
+# Initialisation validation
+# ---------------------------------------------------------------------------
+
+
+def test_init_requires_url() -> None:
+    with pytest.raises(ValueError, match="url must be provided"):
+        RedisLoader(url="")
+
+
+def test_init_invalid_value_type() -> None:
+    with pytest.raises(ValueError, match="value_type must be one of"):
+        RedisLoader(url="redis://localhost:6379", value_type="xml")
+
+
+def test_init_defaults() -> None:
+    loader = RedisLoader(url="redis://localhost:6379")
+    assert loader._pattern == "*"
+    assert loader._value_type == "string"
+    assert loader._limit is None
+
+
+# ---------------------------------------------------------------------------
+# Missing dependency
+# ---------------------------------------------------------------------------
+
+
+def test_load_import_error_missing_redis() -> None:
+    with patch.dict("sys.modules", {"redis": None}):
+        loader = RedisLoader(url="redis://localhost:6379")
+        with pytest.raises(ImportError, match="redis required"):
+            loader.load()
+
+
+# ---------------------------------------------------------------------------
+# String value type
+# ---------------------------------------------------------------------------
+
+
+@patch.dict("sys.modules", {"redis": MagicMock()})
+def test_load_string_values() -> None:
+    import sys
+
+    mock_redis_class = sys.modules["redis"].Redis
+    mock_client = MagicMock()
+    mock_redis_class.from_url.return_value = mock_client
+
+    mock_client.keys.return_value = ["key:1", "key:2"]
+    mock_client.get.side_effect = ["hello", "world"]
+
+    loader = RedisLoader(url="redis://localhost:6379", pattern="key:*")
+    docs = loader.load()
+
+    assert len(docs) == 2
+    assert all(isinstance(doc, Document) for doc in docs)
+    assert docs[0].text == "hello"
+    assert docs[1].text == "world"
+    mock_client.keys.assert_called_once_with("key:*")
+
+
+@patch.dict("sys.modules", {"redis": MagicMock()})
+def test_load_string_metadata_correctness() -> None:
+    import sys
+
+    mock_redis_class = sys.modules["redis"].Redis
+    mock_client = MagicMock()
+    mock_redis_class.from_url.return_value = mock_client
+
+    mock_client.keys.return_value = ["doc:42"]
+    mock_client.get.return_value = "some content"
+
+    loader = RedisLoader(url="redis://localhost:6379")
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].metadata["source"] == "redis"
+    assert docs[0].metadata["key"] == "doc:42"
+
+
+# ---------------------------------------------------------------------------
+# Hash value type
+# ---------------------------------------------------------------------------
+
+
+@patch.dict("sys.modules", {"redis": MagicMock()})
+def test_load_hash_values() -> None:
+    import sys
+
+    mock_redis_class = sys.modules["redis"].Redis
+    mock_client = MagicMock()
+    mock_redis_class.from_url.return_value = mock_client
+
+    mock_client.keys.return_value = ["user:1"]
+    mock_client.hgetall.return_value = {"name": "Alice", "role": "admin"}
+
+    loader = RedisLoader(url="redis://localhost:6379", value_type="hash")
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert "name: Alice" in docs[0].text
+    assert "role: admin" in docs[0].text
+
+
+@patch.dict("sys.modules", {"redis": MagicMock()})
+def test_load_hash_empty_hash_is_skipped() -> None:
+    import sys
+
+    mock_redis_class = sys.modules["redis"].Redis
+    mock_client = MagicMock()
+    mock_redis_class.from_url.return_value = mock_client
+
+    mock_client.keys.return_value = ["empty:1"]
+    mock_client.hgetall.return_value = {}
+
+    loader = RedisLoader(url="redis://localhost:6379", value_type="hash")
+    docs = loader.load()
+
+    assert docs == []
+
+
+# ---------------------------------------------------------------------------
+# JSON value type
+# ---------------------------------------------------------------------------
+
+
+@patch.dict("sys.modules", {"redis": MagicMock()})
+def test_load_json_values() -> None:
+    import sys
+
+    mock_redis_class = sys.modules["redis"].Redis
+    mock_client = MagicMock()
+    mock_redis_class.from_url.return_value = mock_client
+
+    payload = {"title": "Redis Rocks", "count": 42}
+    mock_client.keys.return_value = ["item:1"]
+    mock_client.get.return_value = json.dumps(payload)
+
+    loader = RedisLoader(url="redis://localhost:6379", value_type="json")
+    docs = loader.load()
+
+    assert len(docs) == 1
+    parsed = json.loads(docs[0].text)
+    assert parsed["title"] == "Redis Rocks"
+    assert parsed["count"] == 42
+
+
+@patch.dict("sys.modules", {"redis": MagicMock()})
+def test_load_json_invalid_falls_back_to_raw_string() -> None:
+    import sys
+
+    mock_redis_class = sys.modules["redis"].Redis
+    mock_client = MagicMock()
+    mock_redis_class.from_url.return_value = mock_client
+
+    mock_client.keys.return_value = ["bad:1"]
+    mock_client.get.return_value = "not-valid-json{{{"
+
+    loader = RedisLoader(url="redis://localhost:6379", value_type="json")
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].text == "not-valid-json{{{"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@patch.dict("sys.modules", {"redis": MagicMock()})
+def test_load_empty_keys() -> None:
+    import sys
+
+    mock_redis_class = sys.modules["redis"].Redis
+    mock_client = MagicMock()
+    mock_redis_class.from_url.return_value = mock_client
+
+    mock_client.keys.return_value = []
+
+    loader = RedisLoader(url="redis://localhost:6379")
+    docs = loader.load()
+
+    assert docs == []
+
+
+@patch.dict("sys.modules", {"redis": MagicMock()})
+def test_load_skips_none_values() -> None:
+    import sys
+
+    mock_redis_class = sys.modules["redis"].Redis
+    mock_client = MagicMock()
+    mock_redis_class.from_url.return_value = mock_client
+
+    mock_client.keys.return_value = ["missing:1", "present:1"]
+    mock_client.get.side_effect = [None, "valid text"]
+
+    loader = RedisLoader(url="redis://localhost:6379")
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].text == "valid text"
+    assert docs[0].metadata["key"] == "present:1"
+
+
+@patch.dict("sys.modules", {"redis": MagicMock()})
+def test_load_respects_limit() -> None:
+    import sys
+
+    mock_redis_class = sys.modules["redis"].Redis
+    mock_client = MagicMock()
+    mock_redis_class.from_url.return_value = mock_client
+
+    mock_client.keys.return_value = ["k:1", "k:2", "k:3", "k:4", "k:5"]
+    mock_client.get.return_value = "data"
+
+    loader = RedisLoader(url="redis://localhost:6379", limit=2)
+    docs = loader.load()
+
+    assert len(docs) == 2
+
+
+@patch.dict("sys.modules", {"redis": MagicMock()})
+def test_load_uses_decode_responses() -> None:
+    """Verify from_url is called with decode_responses=True."""
+    import sys
+
+    mock_redis_class = sys.modules["redis"].Redis
+    mock_client = MagicMock()
+    mock_redis_class.from_url.return_value = mock_client
+    mock_client.keys.return_value = []
+
+    loader = RedisLoader(url="redis://localhost:6379")
+    loader.load()
+
+    mock_redis_class.from_url.assert_called_once_with(
+        "redis://localhost:6379", decode_responses=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# Async
+# ---------------------------------------------------------------------------
+
+
+@patch.dict("sys.modules", {"redis": MagicMock()})
+def test_aload() -> None:
+    import sys
+
+    mock_redis_class = sys.modules["redis"].Redis
+    mock_client = MagicMock()
+    mock_redis_class.from_url.return_value = mock_client
+
+    mock_client.keys.return_value = ["async:1"]
+    mock_client.get.return_value = "async value"
+
+    loader = RedisLoader(url="redis://localhost:6379")
+    docs = asyncio.run(loader.aload())
+
+    assert len(docs) == 1
+    assert docs[0].text == "async value"

--- a/uv.lock
+++ b/uv.lock
@@ -7553,7 +7553,7 @@ wheels = [
 
 [[package]]
 name = "synapsekit"
-version = "1.5.3"
+version = "1.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Implements `RedisLoader`, a new data loader that fetches values from Redis keys matching a pattern and returns a `list[Document]` with metadata. Supports `string`, `hash`, and `json` value types. Closes #61.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / internal improvement
- [ ] Dependency / tooling update

## Changes

- Added `src/synapsekit/loaders/redis_loader.py` : new `RedisLoader` class with `load()` and `async aload()` methods; initialises the client via `Redis.from_url(url, decode_responses=True)`; lazy-imports `redis` and raises a clear `ImportError` if missing; supports `string` (GET), `hash` (HGETALL → `"k: v"` pairs), and `json` (GET + parse, falls back to raw string on invalid JSON) value types; applies `limit` slicing on matched keys; skips keys with empty or `None` values
- Added `tests/loaders/test_redis_loader.py` : 15 unit tests covering init validation, invalid `value_type`, missing dependency, all three value types, empty hash/key skipping, JSON fallback, `limit`, `decode_responses=True` assertion, and async loading (no real Redis connection required)
- Registered `RedisLoader` in `src/synapsekit/loaders/__init__.py` (`__all__` + `_LOADERS`)
- Registered `RedisLoader` in `src/synapsekit/__init__.py` (`__all__` + `_LAZY_IMPORTS`)

## Testing

- [x] All existing tests pass (`uv run pytest tests/ -q`)
- [x] New tests added for new behaviour
- [x] No API keys or secrets in the code