### PR TITLE
feat: add SQLiteVecStore backed by sqlite-vec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ pinecone = ["pinecone>=3.0"]
 weaviate = ["weaviate-client>=4.0"]
 milvus = ["pymilvus>=2.4"]
 lancedb = ["lancedb>=0.5"]
+sqlite-vec = ["sqlite-vec>=0.1"]
 ollama = ["ollama>=0.2"]
 lmstudio = ["openai>=1.0"]
 ai21 = ["ai21>=2.0"]
@@ -129,6 +130,7 @@ all = [
     "weaviate-client>=4.0",
     "pymilvus>=2.4",
     "lancedb>=0.5",
+    "sqlite-vec>=0.1",
     "pgvector>=0.2",
     "ollama>=0.2",
     "ai21>=2.0",
@@ -296,6 +298,7 @@ weaviate-client = "weaviate"
 atlassian-python-api = "atlassian"
 gitpython = "git"
 azure-storage-blob = "azure"
+sqlite-vec = "sqlite_vec"
 
 [tool.deptry.per_rule_ignores]
 DEP001 = ["sqlalchemy", "pydantic", "aiohttp", "opentelemetry", "whisper", "botocore", "aiomcache", "nest_asyncio", "huggingface_hub", "serpapi", "weaviate", "uvicorn", "starlette", "tomli"]

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -305,6 +305,7 @@ __all__ = [
     "QdrantVectorStore",
     "PineconeVectorStore",
     "WeaviateVectorStore",
+    "SQLiteVecStore",
     # Retrieval
     "Retriever",
     "AdaptiveRAGRetriever",
@@ -589,6 +590,7 @@ _LAZY_IMPORTS = {
     "QdrantVectorStore": "retrieval.qdrant",
     "PineconeVectorStore": "retrieval.pinecone",
     "WeaviateVectorStore": "retrieval.weaviate",
+    "SQLiteVecStore": "retrieval.sqlite_vec",
     # LLM providers
     "AsyncLRUCache": "llm._cache",
     "DynamoDBCacheBackend": "llm._cache_dynamodb",

--- a/src/synapsekit/retrieval/__init__.py
+++ b/src/synapsekit/retrieval/__init__.py
@@ -44,6 +44,7 @@ __all__ = [
     "QdrantVectorStore",
     "QueryDecompositionRetriever",
     "WeaviateVectorStore",
+    "SQLiteVecStore",
     "Retriever",
     "SelfQueryRetriever",
     "SelfRAGRetriever",
@@ -60,6 +61,7 @@ _BACKENDS = {
     "QdrantVectorStore": ".qdrant",
     "PineconeVectorStore": ".pinecone",
     "WeaviateVectorStore": ".weaviate",
+    "SQLiteVecStore": ".sqlite_vec",
 }
 
 

--- a/src/synapsekit/retrieval/sqlite_vec.py
+++ b/src/synapsekit/retrieval/sqlite_vec.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from contextlib import suppress
+from typing import Any
+
+import numpy as np
+
+from ..embeddings.backend import SynapsekitEmbeddings
+from .base import VectorStore
+
+
+class SQLiteVecStore(VectorStore):
+    """sqlite-vec backed vector store (fully embedded, zero server)."""
+
+    def __init__(
+        self,
+        embedding_backend: SynapsekitEmbeddings,
+        db_path: str = ":memory:",
+        table_name: str = "synapsekit_vec",
+    ) -> None:
+        try:
+            import sqlite_vec
+        except ImportError:
+            raise ImportError("sqlite-vec required: pip install synapsekit[sqlite-vec]") from None
+
+        self._sqlite_vec = sqlite_vec
+        self._embeddings = embedding_backend
+        self._db_path = db_path
+        self._table_name = table_name
+        self._meta_table = f"{table_name}__meta"
+        self._conn = sqlite3.connect(db_path)
+        self._conn.row_factory = sqlite3.Row
+        self._dim: int | None = None
+
+        self._load_extension()
+        self._ensure_meta_table()
+        self._dim = self._read_dim()
+
+    @staticmethod
+    def _q(identifier: str) -> str:
+        return '"' + identifier.replace('"', '""') + '"'
+
+    def _load_extension(self) -> None:
+        if hasattr(self._conn, "enable_load_extension"):
+            self._conn.enable_load_extension(True)
+        try:
+            self._sqlite_vec.load(self._conn)
+        finally:
+            if hasattr(self._conn, "enable_load_extension"):
+                self._conn.enable_load_extension(False)
+
+    def _ensure_meta_table(self) -> None:
+        self._conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {self._q(self._meta_table)} (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                dim INTEGER NOT NULL
+            )
+            """
+        )
+        self._conn.commit()
+
+    def _read_dim(self) -> int | None:
+        row = self._conn.execute(
+            f"SELECT dim FROM {self._q(self._meta_table)} WHERE id = 1"
+        ).fetchone()
+        if row is None:
+            return None
+        return int(row[0])
+
+    def _write_dim(self, dim: int) -> None:
+        self._conn.execute(
+            f"""
+            INSERT INTO {self._q(self._meta_table)} (id, dim)
+            VALUES (1, ?)
+            ON CONFLICT(id) DO UPDATE SET dim = excluded.dim
+            """,
+            (dim,),
+        )
+        self._conn.commit()
+
+    def _table_exists(self) -> bool:
+        row = self._conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE name = ?",
+            (self._table_name,),
+        ).fetchone()
+        return row is not None
+
+    def _ensure_vector_table(self, dim: int) -> None:
+        if self._dim is not None and self._dim != dim:
+            raise ValueError(f"Embedding dimension mismatch: expected {self._dim}, got {dim}")
+
+        if self._table_exists():
+            self._dim = dim
+            self._write_dim(dim)
+            return
+
+        self._conn.execute(
+            f"""
+            CREATE VIRTUAL TABLE {self._q(self._table_name)} USING vec0(
+                embedding float[{dim}],
+                +text text,
+                +metadata text
+            )
+            """
+        )
+        self._conn.commit()
+        self._dim = dim
+        self._write_dim(dim)
+
+    @staticmethod
+    def _serialize_vec(vec: np.ndarray) -> bytes:
+        return np.asarray(vec, dtype=np.float32).tobytes()
+
+    async def add(
+        self,
+        texts: list[str],
+        metadata: list[dict] | None = None,
+    ) -> None:
+        if not texts:
+            return
+
+        meta = metadata or [{} for _ in texts]
+        if len(meta) != len(texts):
+            raise ValueError("metadata must match texts length")
+
+        vecs = await self._embeddings.embed(texts)
+        if vecs.ndim != 2:
+            raise ValueError("embed() must return shape (N, D)")
+
+        self._ensure_vector_table(int(vecs.shape[1]))
+
+        with self._conn:
+            for text, vector, row_meta in zip(texts, vecs, meta, strict=True):
+                self._conn.execute(
+                    f"INSERT INTO {self._q(self._table_name)} (embedding, text, metadata) VALUES (?, ?, ?)",
+                    (self._serialize_vec(vector), text, json.dumps(row_meta)),
+                )
+
+    @staticmethod
+    def _meta_matches(meta: dict[str, Any], metadata_filter: dict[str, Any] | None) -> bool:
+        if not metadata_filter:
+            return True
+        return all(meta.get(k) == v for k, v in metadata_filter.items())
+
+    async def search(
+        self,
+        query: str,
+        top_k: int = 5,
+        metadata_filter: dict | None = None,
+    ) -> list[dict]:
+        if top_k <= 0 or not self._table_exists():
+            return []
+
+        q_vec = await self._embeddings.embed_one(query)
+        candidate_k = top_k if not metadata_filter else max(top_k * 5, top_k)
+
+        rows = self._conn.execute(
+            f"""
+            SELECT rowid, text, metadata, distance
+            FROM {self._q(self._table_name)}
+            WHERE embedding MATCH ?
+            ORDER BY distance
+            LIMIT ?
+            """,
+            (self._serialize_vec(q_vec), candidate_k),
+        ).fetchall()
+
+        out: list[dict] = []
+        for row in rows:
+            if isinstance(row, tuple):
+                _rowid, text_val, metadata_raw, distance_val = row
+            else:
+                text_val = row["text"]
+                metadata_raw = row["metadata"]
+                distance_val = row["distance"]
+
+            metadata_obj = json.loads(metadata_raw) if metadata_raw else {}
+            if not self._meta_matches(metadata_obj, metadata_filter):
+                continue
+            out.append(
+                {
+                    "text": text_val,
+                    "score": float(distance_val),
+                    "metadata": metadata_obj,
+                }
+            )
+            if len(out) >= top_k:
+                break
+        return out
+
+    def save(self, path: str) -> None:
+        if not self._table_exists():
+            raise ValueError("Nothing to save — store is empty.")
+
+        dest = sqlite3.connect(path)
+        try:
+            self._conn.backup(dest)
+        finally:
+            dest.close()
+
+    def load(self, path: str) -> None:
+        if not os.path.exists(path):
+            raise FileNotFoundError(path)
+
+        with suppress(Exception):
+            self._conn.close()
+
+        self._db_path = path
+        self._conn = sqlite3.connect(path)
+        self._conn.row_factory = sqlite3.Row
+        self._load_extension()
+        self._ensure_meta_table()
+        self._dim = self._read_dim()
+
+    def __len__(self) -> int:
+        if not self._table_exists():
+            return 0
+        row = self._conn.execute(f"SELECT COUNT(*) FROM {self._q(self._table_name)}").fetchone()
+        return int(row[0]) if row else 0
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __del__(self) -> None:
+        with suppress(Exception):
+            self.close()

--- a/tests/retrieval/test_sqlite_vec.py
+++ b/tests/retrieval/test_sqlite_vec.py
@@ -1,0 +1,236 @@
+"""Tests for SQLiteVecStore (sqlite-vec backend) with mocked sqlite_vec loader."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+class FakeCursor:
+    def __init__(self, one=None, many=None):
+        self._one = one
+        self._many = many or []
+
+    def fetchone(self):
+        return self._one
+
+    def fetchall(self):
+        return self._many
+
+
+class FakeConnection:
+    def __init__(self, path: str):
+        self.path = path
+        self.row_factory = None
+        self._closed = False
+        self._tables: set[str] = set()
+        self._meta_dim: int | None = None
+        self._rows: list[dict] = []
+        self._next_rowid = 1
+
+    def enable_load_extension(self, _enabled: bool) -> None:
+        return None
+
+    def _extract_table_name(self, sql: str, marker: str) -> str:
+        frag = sql.lower().split(marker, 1)[1].strip().split()[0]
+        return frag.strip('"')
+
+    def execute(self, sql: str, params=()):
+        norm = " ".join(sql.strip().split()).lower()
+
+        if norm.startswith("create table if not exists"):
+            table = self._extract_table_name(norm, "create table if not exists")
+            self._tables.add(table)
+            return FakeCursor()
+
+        if "from sqlite_master" in norm:
+            wanted = params[0]
+            return FakeCursor((1,) if wanted in self._tables else None)
+
+        if norm.startswith("select dim from"):
+            if self._meta_dim is None:
+                return FakeCursor(None)
+            return FakeCursor((self._meta_dim,))
+
+        if norm.startswith("insert into") and "on conflict" in norm:
+            self._meta_dim = int(params[0])
+            return FakeCursor()
+
+        if norm.startswith("create virtual table"):
+            table = self._extract_table_name(norm, "create virtual table")
+            self._tables.add(table)
+            return FakeCursor()
+
+        if norm.startswith("insert into") and "values (?, ?, ?)" in norm:
+            vec, text, metadata = params
+            arr = np.frombuffer(vec, dtype=np.float32)
+            self._rows.append(
+                {
+                    "rowid": self._next_rowid,
+                    "embedding": arr,
+                    "text": text,
+                    "metadata": metadata,
+                }
+            )
+            self._next_rowid += 1
+            return FakeCursor()
+
+        if norm.startswith("select rowid, text, metadata, distance"):
+            query_vec = np.frombuffer(params[0], dtype=np.float32)
+            limit = int(params[1])
+            scored = []
+            for row in self._rows:
+                dist = float(np.linalg.norm(row["embedding"] - query_vec))
+                scored.append((row["rowid"], row["text"], row["metadata"], dist))
+            scored.sort(key=lambda x: x[3])
+            return FakeCursor(many=scored[:limit])
+
+        if norm.startswith("select count(*)"):
+            return FakeCursor((len(self._rows),))
+
+        raise AssertionError(f"Unexpected SQL: {sql}")
+
+    def commit(self) -> None:
+        return None
+
+    def backup(self, dest: FakeConnection) -> None:
+        dest._tables = set(self._tables)
+        dest._meta_dim = self._meta_dim
+        dest._rows = [
+            {
+                "rowid": r["rowid"],
+                "embedding": np.array(r["embedding"], dtype=np.float32),
+                "text": r["text"],
+                "metadata": r["metadata"],
+            }
+            for r in self._rows
+        ]
+        dest._next_rowid = self._next_rowid
+
+    def close(self) -> None:
+        self._closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.commit()
+        return False
+
+
+class FakeSQLiteFactory:
+    def __init__(self):
+        self._connections: dict[str, FakeConnection] = {}
+
+    def connect(self, path: str):
+        key = str(Path(path))
+        if key not in self._connections:
+            self._connections[key] = FakeConnection(key)
+        if path != ":memory:":
+            p = Path(key)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.touch(exist_ok=True)
+        return self._connections[key]
+
+
+def make_mock_embeddings(dim: int = 4):
+    mock = MagicMock()
+
+    def _vec_for(text: str) -> np.ndarray:
+        v = np.zeros(dim, dtype=np.float32)
+        idx = sum(ord(c) for c in text) % dim
+        v[idx] = 1.0
+        return v
+
+    async def embed(texts):
+        return np.array([_vec_for(t) for t in texts], dtype=np.float32)
+
+    async def embed_one(text):
+        return _vec_for(text)
+
+    mock.embed = embed
+    mock.embed_one = embed_one
+    return mock
+
+
+class TestSQLiteVecStore:
+    def test_import_error_without_sqlite_vec(self):
+        with patch.dict("sys.modules", {"sqlite_vec": None}):
+            import synapsekit.retrieval.sqlite_vec as sqlite_vec_mod
+
+            importlib.reload(sqlite_vec_mod)
+            with pytest.raises(ImportError, match="sqlite-vec"):
+                sqlite_vec_mod.SQLiteVecStore(make_mock_embeddings())
+
+    @pytest.mark.asyncio
+    async def test_add_search_and_metadata_filter(self):
+        fake_sqlite = FakeSQLiteFactory()
+        fake_sqlite_vec = MagicMock()
+
+        with patch("sqlite3.connect", side_effect=fake_sqlite.connect), patch.dict(
+            "sys.modules", {"sqlite_vec": fake_sqlite_vec}
+        ):
+            import synapsekit.retrieval.sqlite_vec as sqlite_vec_mod
+
+            importlib.reload(sqlite_vec_mod)
+            store = sqlite_vec_mod.SQLiteVecStore(make_mock_embeddings())
+
+            await store.add(
+                ["alpha", "beta", "gamma"],
+                metadata=[{"src": "a"}, {"src": "b"}, {"src": "a"}],
+            )
+
+            results = await store.search("alpha", top_k=2)
+            assert len(results) == 2
+            assert all("text" in r and "score" in r and "metadata" in r for r in results)
+
+            filtered = await store.search("alpha", top_k=5, metadata_filter={"src": "b"})
+            assert len(filtered) == 1
+            assert filtered[0]["metadata"]["src"] == "b"
+
+            assert len(store) == 3
+
+    @pytest.mark.asyncio
+    async def test_save_and_load_roundtrip(self, tmp_path):
+        fake_sqlite = FakeSQLiteFactory()
+        fake_sqlite_vec = MagicMock()
+
+        with patch("sqlite3.connect", side_effect=fake_sqlite.connect), patch.dict(
+            "sys.modules", {"sqlite_vec": fake_sqlite_vec}
+        ):
+            import synapsekit.retrieval.sqlite_vec as sqlite_vec_mod
+
+            importlib.reload(sqlite_vec_mod)
+
+            store = sqlite_vec_mod.SQLiteVecStore(make_mock_embeddings())
+            await store.add(["persist me"], metadata=[{"id": 1}])
+
+            save_path = str(tmp_path / "sqlite_vec_store.db")
+            store.save(save_path)
+
+            loaded = sqlite_vec_mod.SQLiteVecStore(make_mock_embeddings())
+            loaded.load(save_path)
+
+            results = await loaded.search("persist me", top_k=1)
+            assert len(results) == 1
+            assert results[0]["text"] == "persist me"
+            assert results[0]["metadata"] == {"id": 1}
+
+    def test_save_raises_when_empty(self, tmp_path):
+        fake_sqlite = FakeSQLiteFactory()
+        fake_sqlite_vec = MagicMock()
+
+        with patch("sqlite3.connect", side_effect=fake_sqlite.connect), patch.dict(
+            "sys.modules", {"sqlite_vec": fake_sqlite_vec}
+        ):
+            import synapsekit.retrieval.sqlite_vec as sqlite_vec_mod
+
+            importlib.reload(sqlite_vec_mod)
+            store = sqlite_vec_mod.SQLiteVecStore(make_mock_embeddings())
+
+            with pytest.raises(ValueError, match="empty"):
+                store.save(str(tmp_path / "empty.db"))

--- a/tests/retrieval/test_sqlite_vec.py
+++ b/tests/retrieval/test_sqlite_vec.py
@@ -171,8 +171,9 @@ class TestSQLiteVecStore:
         fake_sqlite = FakeSQLiteFactory()
         fake_sqlite_vec = MagicMock()
 
-        with patch("sqlite3.connect", side_effect=fake_sqlite.connect), patch.dict(
-            "sys.modules", {"sqlite_vec": fake_sqlite_vec}
+        with (
+            patch("sqlite3.connect", side_effect=fake_sqlite.connect),
+            patch.dict("sys.modules", {"sqlite_vec": fake_sqlite_vec}),
         ):
             import synapsekit.retrieval.sqlite_vec as sqlite_vec_mod
 
@@ -199,8 +200,9 @@ class TestSQLiteVecStore:
         fake_sqlite = FakeSQLiteFactory()
         fake_sqlite_vec = MagicMock()
 
-        with patch("sqlite3.connect", side_effect=fake_sqlite.connect), patch.dict(
-            "sys.modules", {"sqlite_vec": fake_sqlite_vec}
+        with (
+            patch("sqlite3.connect", side_effect=fake_sqlite.connect),
+            patch.dict("sys.modules", {"sqlite_vec": fake_sqlite_vec}),
         ):
             import synapsekit.retrieval.sqlite_vec as sqlite_vec_mod
 
@@ -224,8 +226,9 @@ class TestSQLiteVecStore:
         fake_sqlite = FakeSQLiteFactory()
         fake_sqlite_vec = MagicMock()
 
-        with patch("sqlite3.connect", side_effect=fake_sqlite.connect), patch.dict(
-            "sys.modules", {"sqlite_vec": fake_sqlite_vec}
+        with (
+            patch("sqlite3.connect", side_effect=fake_sqlite.connect),
+            patch.dict("sys.modules", {"sqlite_vec": fake_sqlite_vec}),
         ):
             import synapsekit.retrieval.sqlite_vec as sqlite_vec_mod
 


### PR DESCRIPTION
## Summary
- add SQLiteVecStore using sqlite-vec vec0 virtual tables
- implement add(), search(), save(), and load()
- expose SQLiteVecStore through retrieval and package-level lazy exports
- add sqlite-vec optional dependency and deptry module mapping
- add retrieval tests for add/search/filter/save/load flows

## Testing
- python -m ruff check src/synapsekit/retrieval/sqlite_vec.py tests/retrieval/test_sqlite_vec.py
- python -m pytest tests/retrieval/test_sqlite_vec.py tests/retrieval/test_backends.py -q
- python -m pytest tests/retrieval -q

Fixes #129
