### PR TITLE
feat(Loader): Added Parquet docs loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ confluence = ["atlassian-python-api>=3.0", "beautifulsoup4>=4.12"]
 dropbox = ["dropbox>=12.0"]
 rtf = ["striprtf>=0.0.26"]
 epub = ["ebooklib>=0.18"]
+parquet = ["pyarrow>=14.0"]
 all = [
     "openai>=1.0",
     "anthropic>=0.25",
@@ -175,6 +176,7 @@ dev = [
     "pre-commit>=3.7",
     "pydantic>=2.12.5",
     "httpx>=0.27",
+    "pyarrow>=23.0.1",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -381,6 +381,7 @@ __all__ = [
     "WikipediaLoader",
     "ExcelLoader",
     "PowerPointLoader",
+    "ParquetLoader",
     # Parsers
     "JSONParser",
     "PydanticParser",
@@ -632,6 +633,7 @@ _LAZY_IMPORTS = {
     "AzureBlobLoader": "loaders.azure_blob",
     "S3Loader": "loaders.s3",
     "DropboxLoader": "loaders.dropbox",
+    "ParquetLoader": "loaders.parquet",
 }
 
 

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -36,6 +36,7 @@ __all__ = [
     "NotionLoader",
     "OneDriveLoader",
     "PDFLoader",
+    "ParquetLoader",
     "RSSLoader",
     "RTFLoader",
     "S3Loader",
@@ -92,6 +93,7 @@ _LOADERS = {
     "MongoDBLoader": ".mongodb",
     "DropboxLoader": ".dropbox",
     "EPUBLoader": ".epub",
+    "ParquetLoader": ".parquet",
 }
 
 

--- a/src/synapsekit/loaders/parquet.py
+++ b/src/synapsekit/loaders/parquet.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from .base import Document
+
+
+class ParquetLoader:
+    """Load documents from an Apache Parquet file.
+
+    Each row in the file becomes a :class:`Document`. Text is assembled
+    from the columns listed in ``text_fields`` (in order), or from every
+    column when ``text_fields`` is ``None``.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        text_fields: list[str] | None = None,
+        limit: int | None = None,
+    ) -> None:
+        if not path:
+            raise ValueError("path must be provided")
+
+        self._path = path
+        self._text_fields = text_fields
+        self._limit = limit
+
+    def load(self) -> list[Document]:
+        if not Path(self._path).exists():
+            raise FileNotFoundError(f"Parquet file not found: {self._path!r}")
+
+        try:
+            import pyarrow.parquet as pq
+        except ImportError:
+            raise ImportError("pyarrow required: pip install synapsekit[parquet]") from None
+
+        table = pq.read_table(self._path)
+        rows: list[dict[str, Any]] = table.to_pylist()
+
+        if self._limit is not None:
+            rows = rows[: self._limit]
+
+        docs: list[Document] = []
+        for idx, row in enumerate(rows):
+            text = self._build_text(row)
+            if not text:
+                continue
+            docs.append(
+                Document(
+                    text=text,
+                    metadata={"source": self._path, "row": idx},
+                )
+            )
+
+        return docs
+
+    async def aload(self) -> list[Document]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.load)
+
+    def _build_text(self, row: dict[str, Any]) -> str:
+        if self._text_fields:
+            return " ".join(
+                str(row[field])
+                for field in self._text_fields
+                if row.get(field) is not None and row.get(field) != ""
+            )
+        return " ".join(str(v) for v in row.values() if v is not None and v != "")

--- a/src/synapsekit/loaders/parquet.py
+++ b/src/synapsekit/loaders/parquet.py
@@ -40,6 +40,9 @@ class ParquetLoader:
         table = pq.read_table(self._path)
         rows: list[dict[str, Any]] = table.to_pylist()
 
+        if not rows:
+            return []
+
         if self._limit is not None:
             rows = rows[: self._limit]
 
@@ -62,10 +65,11 @@ class ParquetLoader:
         return await loop.run_in_executor(None, self.load)
 
     def _build_text(self, row: dict[str, Any]) -> str:
-        if self._text_fields:
-            return " ".join(
-                str(row[field])
-                for field in self._text_fields
-                if row.get(field) is not None and row.get(field) != ""
-            )
+        if self._text_fields is not None:
+            parts = []
+            for field in self._text_fields:
+                val = row.get(field)
+                if val not in (None, ""):
+                    parts.append(str(row.get(field, "")))
+            return " ".join(parts)
         return " ".join(str(v) for v in row.values() if v is not None and v != "")

--- a/tests/loaders/test_parquet_loader.py
+++ b/tests/loaders/test_parquet_loader.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from synapsekit.loaders import Document
+from synapsekit.loaders.parquet import ParquetLoader
+
+# ---------------------------------------------------------------------------
+# Helpers — write real Parquet bytes using pyarrow (dev dependency)
+# ---------------------------------------------------------------------------
+
+
+def _write_parquet(rows: list[dict], path: str) -> None:
+    """Write a list of dicts to a real Parquet file via pyarrow."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    if not rows:
+        table = pa.table({})
+    else:
+        keys = list(rows[0].keys())
+        columns = {k: [r.get(k) for r in rows] for k in keys}
+        table = pa.table(columns)
+    pq.write_table(table, path)
+
+
+# ---------------------------------------------------------------------------
+# Initialisation validation
+# ---------------------------------------------------------------------------
+
+
+def test_init_requires_path() -> None:
+    with pytest.raises(ValueError, match="path must be provided"):
+        ParquetLoader(path="")
+
+
+def test_init_defaults() -> None:
+    loader = ParquetLoader(path="/tmp/dummy.parquet")
+    assert loader._text_fields is None
+    assert loader._limit is None
+
+
+# ---------------------------------------------------------------------------
+# Missing dependency
+# ---------------------------------------------------------------------------
+
+
+def test_load_import_error_missing_pyarrow() -> None:
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        existing_path = f.name
+    try:
+        with patch.dict("sys.modules", {"pyarrow": None, "pyarrow.parquet": None}):
+            loader = ParquetLoader(path=existing_path)
+            with pytest.raises(ImportError, match="pyarrow required"):
+                loader.load()
+    finally:
+        os.unlink(existing_path)
+
+
+# ---------------------------------------------------------------------------
+# Missing file
+# ---------------------------------------------------------------------------
+
+
+def test_load_raises_file_not_found() -> None:
+    loader = ParquetLoader(path="/nonexistent/path/data.parquet")
+    with pytest.raises(FileNotFoundError, match="Parquet file not found"):
+        loader.load()
+
+
+# ---------------------------------------------------------------------------
+# Normal load — real Parquet files (pyarrow is a dev transitive dep)
+# ---------------------------------------------------------------------------
+
+
+def test_load_returns_documents() -> None:
+    pytest.importorskip("pyarrow")
+
+    rows = [
+        {"title": "First Doc", "content": "Hello world"},
+        {"title": "Second Doc", "content": "Parquet rocks"},
+    ]
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        path = f.name
+
+    try:
+        _write_parquet(rows, path)
+        loader = ParquetLoader(path=path)
+        docs = loader.load()
+    finally:
+        os.unlink(path)
+
+    assert len(docs) == 2
+    assert all(isinstance(doc, Document) for doc in docs)
+    assert "First Doc" in docs[0].text
+    assert "Hello world" in docs[0].text
+
+
+def test_load_metadata_correctness() -> None:
+    pytest.importorskip("pyarrow")
+
+    rows = [{"content": "Test row"}]
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        path = f.name
+
+    try:
+        _write_parquet(rows, path)
+        loader = ParquetLoader(path=path)
+        docs = loader.load()
+    finally:
+        os.unlink(path)
+
+    assert len(docs) == 1
+    assert docs[0].metadata["source"] == path
+    assert docs[0].metadata["row"] == 0
+
+
+def test_load_text_fields() -> None:
+    pytest.importorskip("pyarrow")
+
+    rows = [{"title": "My Title", "body": "My Body", "author": "Alice"}]
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        path = f.name
+
+    try:
+        _write_parquet(rows, path)
+        loader = ParquetLoader(path=path, text_fields=["title", "body"])
+        docs = loader.load()
+    finally:
+        os.unlink(path)
+
+    assert len(docs) == 1
+    assert docs[0].text == "My Title My Body"
+    assert "Alice" not in docs[0].text
+
+
+def test_load_respects_limit() -> None:
+    pytest.importorskip("pyarrow")
+
+    rows = [{"content": f"Row {i}"} for i in range(10)]
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        path = f.name
+
+    try:
+        _write_parquet(rows, path)
+        loader = ParquetLoader(path=path, limit=3)
+        docs = loader.load()
+    finally:
+        os.unlink(path)
+
+    assert len(docs) == 3
+
+
+def test_load_skips_empty_rows() -> None:
+    pytest.importorskip("pyarrow")
+
+    rows = [
+        {"content": ""},
+        {"content": "Valid content"},
+        {"content": None},
+    ]
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        path = f.name
+
+    try:
+        _write_parquet(rows, path)
+        loader = ParquetLoader(path=path, text_fields=["content"])
+        docs = loader.load()
+    finally:
+        os.unlink(path)
+
+    assert len(docs) == 1
+    assert docs[0].text == "Valid content"
+
+
+def test_load_missing_text_field_is_skipped() -> None:
+    pytest.importorskip("pyarrow")
+
+    rows = [{"title": "Present", "body": None}]
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        path = f.name
+
+    try:
+        _write_parquet(rows, path)
+        loader = ParquetLoader(path=path, text_fields=["title", "body"])
+        docs = loader.load()
+    finally:
+        os.unlink(path)
+
+    assert len(docs) == 1
+    assert docs[0].text == "Present"
+    assert "None" not in docs[0].text
+
+
+def test_load_all_columns_when_no_text_fields() -> None:
+    pytest.importorskip("pyarrow")
+
+    rows = [{"a": "foo", "b": "bar", "c": "baz"}]
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        path = f.name
+
+    try:
+        _write_parquet(rows, path)
+        loader = ParquetLoader(path=path)
+        docs = loader.load()
+    finally:
+        os.unlink(path)
+
+    assert len(docs) == 1
+    assert "foo" in docs[0].text
+    assert "bar" in docs[0].text
+    assert "baz" in docs[0].text
+
+
+def test_load_mixed_types() -> None:
+    pytest.importorskip("pyarrow")
+
+    rows = [{"name": "Alice", "score": 42, "active": True}]
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        path = f.name
+
+    try:
+        _write_parquet(rows, path)
+        loader = ParquetLoader(path=path)
+        docs = loader.load()
+    finally:
+        os.unlink(path)
+
+    assert len(docs) == 1
+    assert "Alice" in docs[0].text
+    assert "42" in docs[0].text
+
+
+# ---------------------------------------------------------------------------
+# Async
+# ---------------------------------------------------------------------------
+
+
+def test_aload() -> None:
+    pytest.importorskip("pyarrow")
+
+    rows = [{"content": "Async parquet test"}]
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        path = f.name
+
+    try:
+        _write_parquet(rows, path)
+        loader = ParquetLoader(path=path)
+        docs = asyncio.run(loader.aload())
+    finally:
+        os.unlink(path)
+
+    assert len(docs) == 1
+    assert docs[0].text == "Async parquet test"

--- a/uv.lock
+++ b/uv.lock
@@ -7553,7 +7553,7 @@ wheels = [
 
 [[package]]
 name = "synapsekit"
-version = "1.5.3"
+version = "1.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -7752,6 +7752,9 @@ ollama = [
 openai = [
     { name = "openai" },
 ]
+parquet = [
+    { name = "pyarrow" },
+]
 pdf = [
     { name = "pypdf" },
 ]
@@ -7841,6 +7844,7 @@ dev = [
     { name = "httpx" },
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -7943,6 +7947,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], marker = "extra == 'all'", specifier = ">=3.1" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'pgvector'", specifier = ">=3.1" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1" },
+    { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=14.0" },
     { name = "pymilvus", marker = "extra == 'all'", specifier = ">=2.4" },
     { name = "pymilvus", marker = "extra == 'milvus'", specifier = ">=2.4" },
     { name = "pymongo", marker = "extra == 'all'", specifier = ">=4.0" },
@@ -7980,7 +7985,7 @@ requires-dist = [
     { name = "youtube-search-python", marker = "extra == 'all'", specifier = ">=1.6" },
     { name = "youtube-search-python", marker = "extra == 'youtube'", specifier = ">=1.6" },
 ]
-provides-extras = ["openai", "anthropic", "semantic", "colbert", "pdf", "wikipedia", "arxiv", "html", "web", "chroma", "faiss", "qdrant", "pinecone", "weaviate", "milvus", "lancedb", "ollama", "lmstudio", "ai21", "cohere", "mistral", "gemini", "bedrock", "gcal-tool", "aws-lambda", "rss", "groq", "audio", "video", "excel", "pptx", "docx", "yaml", "teams", "http", "search", "huggingface", "google-search", "tavily", "youtube", "mcp", "redis", "memcached", "vertex", "cloudflare", "aleph-alpha", "llamacpp", "ernie", "minimax", "serve", "postgres", "pgvector", "wolfram", "dynamodb", "discord", "gcs", "gdrive", "git", "gsheets", "jira", "sql", "mongodb", "azure", "s3", "onedrive", "slack", "supabase", "notion", "confluence", "dropbox", "rtf", "epub", "all"]
+provides-extras = ["openai", "anthropic", "semantic", "colbert", "pdf", "wikipedia", "arxiv", "html", "web", "chroma", "faiss", "qdrant", "pinecone", "weaviate", "milvus", "lancedb", "ollama", "lmstudio", "ai21", "cohere", "mistral", "gemini", "bedrock", "gcal-tool", "aws-lambda", "rss", "groq", "audio", "video", "excel", "pptx", "docx", "yaml", "teams", "http", "search", "huggingface", "google-search", "tavily", "youtube", "mcp", "redis", "memcached", "vertex", "cloudflare", "aleph-alpha", "llamacpp", "ernie", "minimax", "serve", "postgres", "pgvector", "wolfram", "dynamodb", "discord", "gcs", "gdrive", "git", "gsheets", "jira", "sql", "mongodb", "azure", "s3", "onedrive", "slack", "supabase", "notion", "confluence", "dropbox", "rtf", "epub", "parquet", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -7989,6 +7994,7 @@ dev = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "mypy", specifier = ">=1.11" },
     { name = "pre-commit", specifier = ">=3.7" },
+    { name = "pyarrow", specifier = ">=23.0.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },


### PR DESCRIPTION
## Summary

Implements `ParquetLoader`, a new data loader that reads Apache Parquet files from disk and returns a `list[Document]`, one per row. Text is assembled from specified columns or all columns when none are specified. 

Closes #68.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / internal improvement
- [ ] Dependency / tooling update

## Changes

- Added `src/synapsekit/loaders/parquet.py` : new `ParquetLoader` class with `load()` and `async aload()` methods; validates file existence before attempting the lazy import; lazy-imports `pyarrow.parquet` and raises a clear `ImportError` if missing; supports `text_fields` (join specified columns in order) and falls back to all non-empty column values when unset; applies `limit` slicing on rows; skips rows where the assembled text is empty; safely handles `None` values and mixed column types
- Added `tests/loaders/test_parquet_loader.py` : 13 tests using real Parquet files written via a `_write_parquet` helper (no mocking needed for file I/O); tests are gated with `pytest.importorskip("pyarrow")` for graceful degradation; covers init validation, `FileNotFoundError`, missing dependency, document output, `text_fields`, `limit`, empty/`None` skipping, all-columns mode, mixed types, and `aload`
- Registered `ParquetLoader` in `src/synapsekit/loaders/__init__.py` (`__all__` + `_LOADERS`)
- Registered `ParquetLoader` in `src/synapsekit/__init__.py` (`__all__` + `_LAZY_IMPORTS`)
- Added `parquet = ["pyarrow>=14.0"]` optional dependency to `pyproject.toml`

## Testing

- [x] All existing tests pass (`uv run pytest tests/ -q`)
- [x] New tests added for new behaviour
- [x] No API keys or secrets in the code