### PR TITLE
feat(memory): add persistent AgentMemory core + backends (PR1/2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,6 @@ vertex = ["google-cloud-aiplatform>=1.38"]
 cloudflare = ["httpx>=0.27"]
 aleph-alpha = ["aleph-alpha-client>=7.0"]
 llamacpp = ["llama-cpp-python>=0.2"]
-gpt4all = ["gpt4all>=2.0"]
 ernie = ["erniebot>=0.5"]
 minimax = ["httpx>=0.27"]
 serve = ["fastapi>=0.110", "uvicorn[standard]>=0.29"]
@@ -249,7 +248,6 @@ module = [
     "synapsekit.llm.perplexity",
     "synapsekit.llm.cerebras",
     "synapsekit.llm.vertex_ai",
-    "synapsekit.llm.gpt4all",
     "synapsekit.loaders.excel",
     "synapsekit.loaders.pptx",
     "synapsekit.loaders.dropbox",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,10 +86,11 @@ vertex = ["google-cloud-aiplatform>=1.38"]
 cloudflare = ["httpx>=0.27"]
 aleph-alpha = ["aleph-alpha-client>=7.0"]
 llamacpp = ["llama-cpp-python>=0.2"]
+gpt4all = ["gpt4all>=2.0"]
 ernie = ["erniebot>=0.5"]
 minimax = ["httpx>=0.27"]
 serve = ["fastapi>=0.110", "uvicorn[standard]>=0.29"]
-postgres = ["psycopg[binary]>=3.1"]
+postgres = ["psycopg[binary]>=3.1", "asyncpg>=0.29"]
 pgvector = ["psycopg[binary]>=3.1", "pgvector>=0.2"]
 wolfram = ["wolframalpha>=5.0"]
 dynamodb = ["boto3>=1.34"]
@@ -149,6 +150,7 @@ all = [
     "fastapi>=0.110",
     "uvicorn[standard]>=0.29",
     "psycopg[binary]>=3.1",
+    "asyncpg>=0.29",
     "groq>=0.9",
     "llama-cpp-python>=0.2",
     "erniebot>=0.5",
@@ -247,6 +249,7 @@ module = [
     "synapsekit.llm.perplexity",
     "synapsekit.llm.cerebras",
     "synapsekit.llm.vertex_ai",
+    "synapsekit.llm.gpt4all",
     "synapsekit.loaders.excel",
     "synapsekit.loaders.pptx",
     "synapsekit.loaders.dropbox",

--- a/src/synapsekit/memory/__init__.py
+++ b/src/synapsekit/memory/__init__.py
@@ -1,3 +1,11 @@
+from .agent_memory import AgentMemory
+from .backends import (
+    InMemoryMemoryBackend,
+    PostgresMemoryBackend,
+    RedisMemoryBackend,
+    SQLiteMemoryBackend,
+)
+from .base import BaseMemoryBackend, MemoryRecord
 from .buffer import BufferMemory
 from .conversation import ConversationMemory
 from .entity import EntityMemory
@@ -8,6 +16,13 @@ from .summary_buffer import SummaryBufferMemory
 from .token_buffer import TokenBufferMemory
 
 __all__ = [
+    "AgentMemory",
+    "BaseMemoryBackend",
+    "MemoryRecord",
+    "InMemoryMemoryBackend",
+    "SQLiteMemoryBackend",
+    "RedisMemoryBackend",
+    "PostgresMemoryBackend",
     "BufferMemory",
     "ConversationMemory",
     "EntityMemory",

--- a/src/synapsekit/memory/agent_memory.py
+++ b/src/synapsekit/memory/agent_memory.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import hashlib
+import inspect
+import math
+import re
+import uuid
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+from typing import Any
+
+from .backends import (
+    InMemoryMemoryBackend,
+    PostgresMemoryBackend,
+    RedisMemoryBackend,
+    SQLiteMemoryBackend,
+)
+from .base import BaseMemoryBackend, MemoryRecord, MemoryType
+
+EmbedderFn = Callable[[str], list[float] | Awaitable[list[float]]]
+
+
+class AgentMemory:
+    """Persistent agent memory orchestrator with episodic + semantic tiers."""
+
+    def __init__(
+        self,
+        backend: str | BaseMemoryBackend = "memory",
+        *,
+        path: str | None = None,
+        redis_url: str = "redis://localhost:6379",
+        postgres_dsn: str | None = None,
+        embedder: EmbedderFn | None = None,
+        llm: Any | None = None,
+        max_episodes: int = 100,
+        consolidation_window: int = 20,
+    ) -> None:
+        self._backend = self._resolve_backend(
+            backend,
+            path=path,
+            redis_url=redis_url,
+            postgres_dsn=postgres_dsn,
+        )
+        self._embedder = embedder
+        self._llm = llm
+        self._max_episodes = max_episodes
+        self._consolidation_window = consolidation_window
+
+    @staticmethod
+    def _resolve_backend(
+        backend: str | BaseMemoryBackend,
+        *,
+        path: str | None,
+        redis_url: str,
+        postgres_dsn: str | None,
+    ) -> BaseMemoryBackend:
+        if isinstance(backend, BaseMemoryBackend):
+            return backend
+        if backend == "memory":
+            return InMemoryMemoryBackend()
+        if backend == "sqlite":
+            return SQLiteMemoryBackend(path or "agent_memory.db")
+        if backend == "redis":
+            return RedisMemoryBackend(url=redis_url)
+        if backend == "postgres":
+            if not postgres_dsn:
+                raise ValueError("postgres_dsn is required when backend='postgres'")
+            return PostgresMemoryBackend(postgres_dsn)
+        raise ValueError(f"Unknown backend: {backend!r}")
+
+    @staticmethod
+    def _now() -> datetime:
+        return datetime.now(timezone.utc)
+
+    @staticmethod
+    def _default_embed(text: str, dim: int = 128) -> list[float]:
+        tokens = re.findall(r"\w+", text.lower())
+        if not tokens:
+            return [0.0] * dim
+        vec = [0.0] * dim
+        for token in tokens:
+            h = hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest()
+            idx = int.from_bytes(h, byteorder="big") % dim
+            vec[idx] += 1.0
+        norm = math.sqrt(sum(v * v for v in vec))
+        if norm == 0:
+            return vec
+        return [v / norm for v in vec]
+
+    async def _embed_text(self, text: str) -> list[float]:
+        if self._embedder is None:
+            return self._default_embed(text)
+        value = self._embedder(text)
+        if inspect.isawaitable(value):
+            value = await value
+        return [float(x) for x in value]
+
+    @staticmethod
+    def _cosine(a: list[float], b: list[float]) -> float:
+        if not a or not b or len(a) != len(b):
+            return 0.0
+        dot = sum(x * y for x, y in zip(a, b, strict=True))
+        na = math.sqrt(sum(x * x for x in a))
+        nb = math.sqrt(sum(y * y for y in b))
+        if na == 0 or nb == 0:
+            return 0.0
+        return dot / (na * nb)
+
+    async def _store_record(
+        self,
+        *,
+        agent_id: str,
+        content: str,
+        memory_type: MemoryType,
+        ttl_days: int | None,
+        metadata: dict[str, Any] | None,
+        skip_auto_consolidate: bool,
+    ) -> MemoryRecord:
+        now = self._now()
+        record = MemoryRecord(
+            id=str(uuid.uuid4()),
+            agent_id=agent_id,
+            content=content,
+            memory_type=memory_type,
+            embedding=await self._embed_text(content),
+            created_at=now,
+            accessed_at=now,
+            access_count=0,
+            ttl_days=ttl_days,
+            metadata=dict(metadata or {}),
+        )
+        await self._backend.store(record)
+
+        if memory_type == "episodic" and not skip_auto_consolidate:
+            episodic_count = await self._backend.count(agent_id, memory_type="episodic")
+            if episodic_count > self._max_episodes:
+                await self.consolidate(agent_id)
+        return record
+
+    async def store(
+        self,
+        *,
+        agent_id: str,
+        content: str,
+        memory_type: MemoryType = "episodic",
+        ttl_days: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> MemoryRecord:
+        return await self._store_record(
+            agent_id=agent_id,
+            content=content,
+            memory_type=memory_type,
+            ttl_days=ttl_days,
+            metadata=metadata,
+            skip_auto_consolidate=False,
+        )
+
+    async def recall(
+        self,
+        *,
+        agent_id: str,
+        query: str,
+        top_k: int = 5,
+        memory_types: tuple[MemoryType, ...] = ("semantic", "episodic"),
+    ) -> list[MemoryRecord]:
+        if top_k <= 0:
+            return []
+
+        await self._backend.prune_expired()
+
+        records: list[MemoryRecord] = []
+        seen: set[str] = set()
+        for memory_type in memory_types:
+            batch = await self._backend.fetch(agent_id, memory_type=memory_type)
+            for rec in batch:
+                if rec.id in seen:
+                    continue
+                seen.add(rec.id)
+                records.append(rec)
+
+        if not records:
+            return []
+
+        q_emb = await self._embed_text(query)
+        now = self._now()
+
+        def _score(rec: MemoryRecord) -> float:
+            sim = self._cosine(q_emb, rec.embedding)
+            age_days = max((now - rec.created_at).total_seconds() / 86400.0, 0.0)
+            recency = 1.0 / (1.0 + age_days)
+            access = min(rec.access_count, 20) / 20.0
+            semantic_boost = 0.05 if rec.memory_type == "semantic" else 0.0
+            return (0.82 * sim) + (0.12 * recency) + (0.04 * access) + semantic_boost
+
+        ranked = sorted(records, key=_score, reverse=True)[:top_k]
+
+        for rec in ranked:
+            await self._backend.touch(agent_id, rec.id)
+
+        return ranked
+
+    async def _summarize_contents(self, contents: list[str]) -> str:
+        lines = [f"- {c.strip()}" for c in contents if c.strip()]
+        if not lines:
+            return ""
+
+        if self._llm is not None:
+            prompt = (
+                "Consolidate these episodic memories into concise semantic facts. "
+                "Return 3-8 bullet points with stable long-term information only.\n\n"
+                + "\n".join(lines)
+            )
+            try:
+                summary = await self._llm.generate(prompt)
+                if summary and summary.strip():
+                    return summary.strip()
+            except Exception:
+                pass
+
+        # Fallback deterministic summarization
+        unique = list(dict.fromkeys(s[2:] for s in lines))
+        if not unique:
+            return ""
+        return "; ".join(unique[:8])
+
+    async def consolidate(
+        self,
+        agent_id: str,
+        *,
+        limit: int | None = None,
+        delete_consolidated: bool | None = None,
+    ) -> MemoryRecord | None:
+        episodic = await self._backend.fetch(agent_id, memory_type="episodic")
+        if not episodic:
+            return None
+
+        if limit is not None:
+            source = episodic[-limit:]
+        elif len(episodic) > self._max_episodes:
+            overflow = len(episodic) - self._max_episodes
+            source = episodic[:overflow]
+        else:
+            source = episodic[-min(self._consolidation_window, len(episodic)) :]
+
+        if not source:
+            return None
+
+        summary = await self._summarize_contents([r.content for r in source])
+        if not summary.strip():
+            return None
+
+        semantic = await self._store_record(
+            agent_id=agent_id,
+            content=summary,
+            memory_type="semantic",
+            ttl_days=None,
+            metadata={
+                "source": "consolidation",
+                "consolidated_ids": [r.id for r in source],
+            },
+            skip_auto_consolidate=True,
+        )
+
+        should_delete = (
+            delete_consolidated
+            if delete_consolidated is not None
+            else len(episodic) > self._max_episodes
+        )
+        if should_delete:
+            for rec in source:
+                await self._backend.delete(agent_id, rec.id)
+
+        return semantic
+
+    async def delete(self, *, agent_id: str, record_id: str) -> bool:
+        return await self._backend.delete(agent_id, record_id)
+
+    async def clear(self, *, agent_id: str, memory_type: MemoryType | None = None) -> int:
+        return await self._backend.clear(agent_id, memory_type=memory_type)
+
+    async def list(
+        self,
+        *,
+        agent_id: str,
+        memory_type: MemoryType | None = None,
+        include_expired: bool = False,
+    ) -> list[MemoryRecord]:
+        return await self._backend.fetch(
+            agent_id,
+            memory_type=memory_type,
+            include_expired=include_expired,
+        )
+
+    async def count(self, *, agent_id: str, memory_type: MemoryType | None = None) -> int:
+        return await self._backend.count(agent_id, memory_type=memory_type)

--- a/src/synapsekit/memory/agent_memory.py
+++ b/src/synapsekit/memory/agent_memory.py
@@ -212,8 +212,9 @@ class AgentMemory:
             )
             try:
                 summary = await self._llm.generate(prompt)
-                if summary and summary.strip():
-                    return summary.strip()
+                summary_text = str(summary).strip()
+                if summary_text:
+                    return summary_text
             except Exception:
                 pass
 

--- a/src/synapsekit/memory/backends/__init__.py
+++ b/src/synapsekit/memory/backends/__init__.py
@@ -1,0 +1,11 @@
+from .memory import InMemoryMemoryBackend
+from .postgres import PostgresMemoryBackend
+from .redis import RedisMemoryBackend
+from .sqlite import SQLiteMemoryBackend
+
+__all__ = [
+    "InMemoryMemoryBackend",
+    "SQLiteMemoryBackend",
+    "RedisMemoryBackend",
+    "PostgresMemoryBackend",
+]

--- a/src/synapsekit/memory/backends/memory.py
+++ b/src/synapsekit/memory/backends/memory.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from ..base import BaseMemoryBackend, MemoryRecord, MemoryType
+
+
+class InMemoryMemoryBackend(BaseMemoryBackend):
+    """In-process backend for tests/dev."""
+
+    def __init__(self) -> None:
+        self._records: dict[str, dict[str, MemoryRecord]] = {}
+
+    async def store(self, record: MemoryRecord) -> None:
+        self._records.setdefault(record.agent_id, {})[record.id] = record
+
+    async def fetch(
+        self,
+        agent_id: str,
+        memory_type: MemoryType | None = None,
+        *,
+        include_expired: bool = False,
+    ) -> list[MemoryRecord]:
+        bucket = self._records.get(agent_id, {})
+        now = datetime.now(timezone.utc)
+        out: list[MemoryRecord] = []
+        for rec in bucket.values():
+            if memory_type is not None and rec.memory_type != memory_type:
+                continue
+            if not include_expired and rec.is_expired(now):
+                continue
+            out.append(rec)
+        out.sort(key=lambda r: r.created_at)
+        return out
+
+    async def touch(
+        self,
+        agent_id: str,
+        record_id: str,
+        *,
+        accessed_at: datetime | None = None,
+    ) -> None:
+        rec = self._records.get(agent_id, {}).get(record_id)
+        if rec is None:
+            return
+        rec.accessed_at = accessed_at or datetime.now(timezone.utc)
+        rec.access_count += 1
+
+    async def delete(self, agent_id: str, record_id: str) -> bool:
+        bucket = self._records.get(agent_id)
+        if bucket is None:
+            return False
+        return bucket.pop(record_id, None) is not None
+
+    async def clear(self, agent_id: str, memory_type: MemoryType | None = None) -> int:
+        bucket = self._records.get(agent_id)
+        if bucket is None:
+            return 0
+        if memory_type is None:
+            removed = len(bucket)
+            bucket.clear()
+            return removed
+
+        ids = [rid for rid, rec in bucket.items() if rec.memory_type == memory_type]
+        for rid in ids:
+            bucket.pop(rid, None)
+        return len(ids)
+
+    async def count(self, agent_id: str, memory_type: MemoryType | None = None) -> int:
+        bucket = self._records.get(agent_id, {})
+        if memory_type is None:
+            return len(bucket)
+        return sum(1 for rec in bucket.values() if rec.memory_type == memory_type)
+
+    async def prune_expired(self, *, now: datetime | None = None) -> int:
+        now_utc = now or datetime.now(timezone.utc)
+        removed = 0
+        for agent_id, bucket in list(self._records.items()):
+            to_remove = [rid for rid, rec in bucket.items() if rec.is_expired(now_utc)]
+            for rid in to_remove:
+                bucket.pop(rid, None)
+                removed += 1
+            if not bucket:
+                self._records.pop(agent_id, None)
+        return removed

--- a/src/synapsekit/memory/backends/postgres.py
+++ b/src/synapsekit/memory/backends/postgres.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from ..base import BaseMemoryBackend, MemoryRecord, MemoryType
+
+
+class PostgresMemoryBackend(BaseMemoryBackend):
+    """PostgreSQL-backed persistent memory backend via asyncpg."""
+
+    def __init__(self, dsn: str) -> None:
+        self._dsn = dsn
+        self._pool = None
+
+    async def _ensure_pool(self):
+        if self._pool is not None:
+            return self._pool
+        try:
+            import asyncpg
+        except ImportError:
+            raise ImportError("asyncpg required: pip install asyncpg") from None
+
+        self._pool = await asyncpg.create_pool(self._dsn)
+        async with self._pool.acquire() as conn:
+            await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS agent_memory_records (
+                    id TEXT PRIMARY KEY,
+                    agent_id TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    memory_type TEXT NOT NULL,
+                    embedding JSONB NOT NULL,
+                    created_at DOUBLE PRECISION NOT NULL,
+                    accessed_at DOUBLE PRECISION NOT NULL,
+                    access_count INTEGER NOT NULL,
+                    ttl_days INTEGER,
+                    metadata JSONB NOT NULL
+                )
+                """
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_pg_memory_agent_type_created "
+                "ON agent_memory_records(agent_id, memory_type, created_at)"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_pg_memory_agent_created "
+                "ON agent_memory_records(agent_id, created_at)"
+            )
+        return self._pool
+
+    @staticmethod
+    def _to_record(row) -> MemoryRecord:
+        return MemoryRecord(
+            id=row["id"],
+            agent_id=row["agent_id"],
+            content=row["content"],
+            memory_type=row["memory_type"],
+            embedding=list(row["embedding"]),
+            created_at=datetime.fromtimestamp(float(row["created_at"]), tz=timezone.utc),
+            accessed_at=datetime.fromtimestamp(float(row["accessed_at"]), tz=timezone.utc),
+            access_count=int(row["access_count"]),
+            ttl_days=row["ttl_days"],
+            metadata=dict(row["metadata"]),
+        )
+
+    async def store(self, record: MemoryRecord) -> None:
+        pool = await self._ensure_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO agent_memory_records (
+                    id, agent_id, content, memory_type, embedding,
+                    created_at, accessed_at, access_count, ttl_days, metadata
+                ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+                ON CONFLICT (id) DO UPDATE
+                    SET content = EXCLUDED.content,
+                        memory_type = EXCLUDED.memory_type,
+                        embedding = EXCLUDED.embedding,
+                        created_at = EXCLUDED.created_at,
+                        accessed_at = EXCLUDED.accessed_at,
+                        access_count = EXCLUDED.access_count,
+                        ttl_days = EXCLUDED.ttl_days,
+                        metadata = EXCLUDED.metadata
+                """,
+                record.id,
+                record.agent_id,
+                record.content,
+                record.memory_type,
+                json.dumps(record.embedding),
+                record.created_at.timestamp(),
+                record.accessed_at.timestamp(),
+                record.access_count,
+                record.ttl_days,
+                json.dumps(record.metadata),
+            )
+
+    async def fetch(
+        self,
+        agent_id: str,
+        memory_type: MemoryType | None = None,
+        *,
+        include_expired: bool = False,
+    ) -> list[MemoryRecord]:
+        pool = await self._ensure_pool()
+        async with pool.acquire() as conn:
+            if memory_type is None:
+                rows = await conn.fetch(
+                    "SELECT * FROM agent_memory_records WHERE agent_id = $1 ORDER BY created_at ASC",
+                    agent_id,
+                )
+            else:
+                rows = await conn.fetch(
+                    """
+                    SELECT * FROM agent_memory_records
+                    WHERE agent_id = $1 AND memory_type = $2
+                    ORDER BY created_at ASC
+                    """,
+                    agent_id,
+                    memory_type,
+                )
+
+        records = [self._to_record(r) for r in rows]
+        if include_expired:
+            return records
+        now = datetime.now(timezone.utc)
+        return [r for r in records if not r.is_expired(now)]
+
+    async def touch(
+        self,
+        agent_id: str,
+        record_id: str,
+        *,
+        accessed_at: datetime | None = None,
+    ) -> None:
+        pool = await self._ensure_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE agent_memory_records
+                SET accessed_at = $1, access_count = access_count + 1
+                WHERE agent_id = $2 AND id = $3
+                """,
+                (accessed_at or datetime.now(timezone.utc)).timestamp(),
+                agent_id,
+                record_id,
+            )
+
+    async def delete(self, agent_id: str, record_id: str) -> bool:
+        pool = await self._ensure_pool()
+        async with pool.acquire() as conn:
+            result = await conn.execute(
+                "DELETE FROM agent_memory_records WHERE agent_id = $1 AND id = $2",
+                agent_id,
+                record_id,
+            )
+        return result.endswith("1")
+
+    async def clear(self, agent_id: str, memory_type: MemoryType | None = None) -> int:
+        pool = await self._ensure_pool()
+        async with pool.acquire() as conn:
+            if memory_type is None:
+                result = await conn.execute(
+                    "DELETE FROM agent_memory_records WHERE agent_id = $1",
+                    agent_id,
+                )
+            else:
+                result = await conn.execute(
+                    "DELETE FROM agent_memory_records WHERE agent_id = $1 AND memory_type = $2",
+                    agent_id,
+                    memory_type,
+                )
+        return int(result.split()[-1])
+
+    async def count(self, agent_id: str, memory_type: MemoryType | None = None) -> int:
+        pool = await self._ensure_pool()
+        async with pool.acquire() as conn:
+            if memory_type is None:
+                row = await conn.fetchrow(
+                    "SELECT COUNT(*) AS n FROM agent_memory_records WHERE agent_id = $1",
+                    agent_id,
+                )
+            else:
+                row = await conn.fetchrow(
+                    """
+                    SELECT COUNT(*) AS n FROM agent_memory_records
+                    WHERE agent_id = $1 AND memory_type = $2
+                    """,
+                    agent_id,
+                    memory_type,
+                )
+        return int(row["n"]) if row else 0
+
+    async def prune_expired(self, *, now: datetime | None = None) -> int:
+        ts = (now or datetime.now(timezone.utc)).timestamp()
+        pool = await self._ensure_pool()
+        async with pool.acquire() as conn:
+            result = await conn.execute(
+                """
+                DELETE FROM agent_memory_records
+                WHERE ttl_days IS NOT NULL
+                  AND (created_at + (ttl_days * 86400.0)) <= $1
+                """,
+                ts,
+            )
+        return int(result.split()[-1])
+
+    async def close(self) -> None:
+        if self._pool is not None:
+            await self._pool.close()
+            self._pool = None

--- a/src/synapsekit/memory/backends/postgres.py
+++ b/src/synapsekit/memory/backends/postgres.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
+from typing import Any
 
 from ..base import BaseMemoryBackend, MemoryRecord, MemoryType
 
@@ -11,7 +12,7 @@ class PostgresMemoryBackend(BaseMemoryBackend):
 
     def __init__(self, dsn: str) -> None:
         self._dsn = dsn
-        self._pool = None
+        self._pool: Any | None = None
 
     async def _ensure_pool(self):
         if self._pool is not None:
@@ -22,6 +23,7 @@ class PostgresMemoryBackend(BaseMemoryBackend):
             raise ImportError("asyncpg required: pip install asyncpg") from None
 
         self._pool = await asyncpg.create_pool(self._dsn)
+        assert self._pool is not None
         async with self._pool.acquire() as conn:
             await conn.execute(
                 """
@@ -154,7 +156,7 @@ class PostgresMemoryBackend(BaseMemoryBackend):
                 agent_id,
                 record_id,
             )
-        return result.endswith("1")
+        return str(result).endswith("1")
 
     async def clear(self, agent_id: str, memory_type: MemoryType | None = None) -> int:
         pool = await self._ensure_pool()

--- a/src/synapsekit/memory/backends/redis.py
+++ b/src/synapsekit/memory/backends/redis.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from ..base import BaseMemoryBackend, MemoryRecord, MemoryType
+
+
+class RedisMemoryBackend(BaseMemoryBackend):
+    """Redis-backed persistent memory backend."""
+
+    def __init__(
+        self, url: str = "redis://localhost:6379", prefix: str = "synapsekit:agentmem:"
+    ) -> None:
+        try:
+            import redis.asyncio as redis
+        except ImportError:
+            raise ImportError("redis package required: pip install synapsekit[redis]") from None
+
+        self._redis = redis
+        self._client = redis.from_url(url, decode_responses=True)
+        self._prefix = prefix
+
+    def _record_key(self, agent_id: str, record_id: str) -> str:
+        return f"{self._prefix}{agent_id}:record:{record_id}"
+
+    def _index_key(self, agent_id: str) -> str:
+        return f"{self._prefix}{agent_id}:index"
+
+    @staticmethod
+    def _serialize(record: MemoryRecord) -> str:
+        payload = {
+            "id": record.id,
+            "agent_id": record.agent_id,
+            "content": record.content,
+            "memory_type": record.memory_type,
+            "embedding": record.embedding,
+            "created_at": record.created_at.timestamp(),
+            "accessed_at": record.accessed_at.timestamp(),
+            "access_count": record.access_count,
+            "ttl_days": record.ttl_days,
+            "metadata": record.metadata,
+        }
+        return json.dumps(payload)
+
+    @staticmethod
+    def _deserialize(raw: str) -> MemoryRecord:
+        item: dict[str, Any] = json.loads(raw)
+        return MemoryRecord(
+            id=str(item["id"]),
+            agent_id=str(item["agent_id"]),
+            content=str(item["content"]),
+            memory_type=item["memory_type"],
+            embedding=list(item["embedding"]),
+            created_at=datetime.fromtimestamp(float(item["created_at"]), tz=timezone.utc),
+            accessed_at=datetime.fromtimestamp(float(item["accessed_at"]), tz=timezone.utc),
+            access_count=int(item.get("access_count", 0)),
+            ttl_days=item.get("ttl_days"),
+            metadata=dict(item.get("metadata") or {}),
+        )
+
+    async def store(self, record: MemoryRecord) -> None:
+        key = self._record_key(record.agent_id, record.id)
+        index = self._index_key(record.agent_id)
+        pipe = self._client.pipeline()
+        pipe.set(key, self._serialize(record))
+        pipe.zadd(index, {record.id: record.created_at.timestamp()})
+        await pipe.execute()
+
+    async def fetch(
+        self,
+        agent_id: str,
+        memory_type: MemoryType | None = None,
+        *,
+        include_expired: bool = False,
+    ) -> list[MemoryRecord]:
+        ids: list[str] = await self._client.zrange(self._index_key(agent_id), 0, -1)
+        if not ids:
+            return []
+
+        keys = [self._record_key(agent_id, rid) for rid in ids]
+        raw_records = await self._client.mget(keys)
+        now = datetime.now(timezone.utc)
+
+        out: list[MemoryRecord] = []
+        for raw in raw_records:
+            if not raw:
+                continue
+            rec = self._deserialize(raw)
+            if memory_type is not None and rec.memory_type != memory_type:
+                continue
+            if not include_expired and rec.is_expired(now):
+                continue
+            out.append(rec)
+        out.sort(key=lambda r: r.created_at)
+        return out
+
+    async def touch(
+        self,
+        agent_id: str,
+        record_id: str,
+        *,
+        accessed_at: datetime | None = None,
+    ) -> None:
+        key = self._record_key(agent_id, record_id)
+        raw = await self._client.get(key)
+        if not raw:
+            return
+        rec = self._deserialize(raw)
+        rec.accessed_at = accessed_at or datetime.now(timezone.utc)
+        rec.access_count += 1
+        await self._client.set(key, self._serialize(rec))
+
+    async def delete(self, agent_id: str, record_id: str) -> bool:
+        key = self._record_key(agent_id, record_id)
+        index = self._index_key(agent_id)
+        pipe = self._client.pipeline()
+        pipe.delete(key)
+        pipe.zrem(index, record_id)
+        deleted, _ = await pipe.execute()
+        return int(deleted) > 0
+
+    async def clear(self, agent_id: str, memory_type: MemoryType | None = None) -> int:
+        if memory_type is None:
+            ids: list[str] = await self._client.zrange(self._index_key(agent_id), 0, -1)
+            if not ids:
+                return 0
+            keys = [self._record_key(agent_id, rid) for rid in ids]
+            pipe = self._client.pipeline()
+            pipe.delete(*keys)
+            pipe.delete(self._index_key(agent_id))
+            await pipe.execute()
+            return len(ids)
+
+        records = await self.fetch(agent_id, memory_type=memory_type, include_expired=True)
+        if not records:
+            return 0
+        pipe = self._client.pipeline()
+        for rec in records:
+            pipe.delete(self._record_key(agent_id, rec.id))
+            pipe.zrem(self._index_key(agent_id), rec.id)
+        await pipe.execute()
+        return len(records)
+
+    async def count(self, agent_id: str, memory_type: MemoryType | None = None) -> int:
+        if memory_type is None:
+            return int(await self._client.zcard(self._index_key(agent_id)))
+        records = await self.fetch(agent_id, memory_type=memory_type)
+        return len(records)
+
+    async def prune_expired(self, *, now: datetime | None = None) -> int:
+        now_utc = now or datetime.now(timezone.utc)
+        removed = 0
+
+        cursor = 0
+        pattern = f"{self._prefix}*:index"
+        while True:
+            cursor, keys = await self._client.scan(cursor=cursor, match=pattern, count=100)
+            for index_key in keys:
+                agent_id = index_key.split(":")[-2]
+                records = await self.fetch(agent_id, include_expired=True)
+                for rec in records:
+                    if rec.is_expired(now_utc) and await self.delete(agent_id, rec.id):
+                        removed += 1
+            if cursor == 0:
+                break
+        return removed
+
+    async def close(self) -> None:
+        await self._client.aclose()

--- a/src/synapsekit/memory/backends/sqlite.py
+++ b/src/synapsekit/memory/backends/sqlite.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ..base import BaseMemoryBackend, MemoryRecord, MemoryType
+
+
+class SQLiteMemoryBackend(BaseMemoryBackend):
+    """SQLite-backed persistent memory backend."""
+
+    def __init__(self, path: str = "agent_memory.db") -> None:
+        self._path = path
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self._path, check_same_thread=False)
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS agent_memory_records (
+                    id TEXT PRIMARY KEY,
+                    agent_id TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    memory_type TEXT NOT NULL,
+                    embedding TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    accessed_at REAL NOT NULL,
+                    access_count INTEGER NOT NULL,
+                    ttl_days INTEGER,
+                    metadata TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_memory_agent_type_created "
+                "ON agent_memory_records(agent_id, memory_type, created_at)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_memory_agent_created "
+                "ON agent_memory_records(agent_id, created_at)"
+            )
+            conn.commit()
+
+    @staticmethod
+    def _to_ts(dt: datetime) -> float:
+        return dt.timestamp()
+
+    @staticmethod
+    def _from_row(row: tuple) -> MemoryRecord:
+        (
+            rec_id,
+            agent_id,
+            content,
+            memory_type,
+            embedding_json,
+            created_ts,
+            accessed_ts,
+            access_count,
+            ttl_days,
+            metadata_json,
+        ) = row
+        return MemoryRecord(
+            id=rec_id,
+            agent_id=agent_id,
+            content=content,
+            memory_type=memory_type,
+            embedding=list(json.loads(embedding_json)),
+            created_at=datetime.fromtimestamp(created_ts, tz=timezone.utc),
+            accessed_at=datetime.fromtimestamp(accessed_ts, tz=timezone.utc),
+            access_count=int(access_count),
+            ttl_days=None if ttl_days is None else int(ttl_days),
+            metadata=dict(json.loads(metadata_json)),
+        )
+
+    async def store(self, record: MemoryRecord) -> None:
+        def _op() -> None:
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO agent_memory_records (
+                        id, agent_id, content, memory_type, embedding,
+                        created_at, accessed_at, access_count, ttl_days, metadata
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        record.id,
+                        record.agent_id,
+                        record.content,
+                        record.memory_type,
+                        json.dumps(record.embedding),
+                        self._to_ts(record.created_at),
+                        self._to_ts(record.accessed_at),
+                        record.access_count,
+                        record.ttl_days,
+                        json.dumps(record.metadata),
+                    ),
+                )
+                conn.commit()
+
+        await asyncio.to_thread(_op)
+
+    async def fetch(
+        self,
+        agent_id: str,
+        memory_type: MemoryType | None = None,
+        *,
+        include_expired: bool = False,
+    ) -> list[MemoryRecord]:
+        def _op() -> list[MemoryRecord]:
+            with self._connect() as conn:
+                if memory_type is None:
+                    rows = conn.execute(
+                        """
+                        SELECT id, agent_id, content, memory_type, embedding,
+                               created_at, accessed_at, access_count, ttl_days, metadata
+                        FROM agent_memory_records
+                        WHERE agent_id = ?
+                        ORDER BY created_at ASC
+                        """,
+                        (agent_id,),
+                    ).fetchall()
+                else:
+                    rows = conn.execute(
+                        """
+                        SELECT id, agent_id, content, memory_type, embedding,
+                               created_at, accessed_at, access_count, ttl_days, metadata
+                        FROM agent_memory_records
+                        WHERE agent_id = ? AND memory_type = ?
+                        ORDER BY created_at ASC
+                        """,
+                        (agent_id, memory_type),
+                    ).fetchall()
+
+            records = [self._from_row(r) for r in rows]
+            if include_expired:
+                return records
+            now = datetime.now(timezone.utc)
+            return [r for r in records if not r.is_expired(now)]
+
+        return await asyncio.to_thread(_op)
+
+    async def touch(
+        self,
+        agent_id: str,
+        record_id: str,
+        *,
+        accessed_at: datetime | None = None,
+    ) -> None:
+        ts = self._to_ts(accessed_at or datetime.now(timezone.utc))
+
+        def _op() -> None:
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    UPDATE agent_memory_records
+                    SET accessed_at = ?, access_count = access_count + 1
+                    WHERE agent_id = ? AND id = ?
+                    """,
+                    (ts, agent_id, record_id),
+                )
+                conn.commit()
+
+        await asyncio.to_thread(_op)
+
+    async def delete(self, agent_id: str, record_id: str) -> bool:
+        def _op() -> bool:
+            with self._connect() as conn:
+                cur = conn.execute(
+                    "DELETE FROM agent_memory_records WHERE agent_id = ? AND id = ?",
+                    (agent_id, record_id),
+                )
+                conn.commit()
+                return cur.rowcount > 0
+
+        return await asyncio.to_thread(_op)
+
+    async def clear(self, agent_id: str, memory_type: MemoryType | None = None) -> int:
+        def _op() -> int:
+            with self._connect() as conn:
+                if memory_type is None:
+                    cur = conn.execute(
+                        "DELETE FROM agent_memory_records WHERE agent_id = ?",
+                        (agent_id,),
+                    )
+                else:
+                    cur = conn.execute(
+                        "DELETE FROM agent_memory_records WHERE agent_id = ? AND memory_type = ?",
+                        (agent_id, memory_type),
+                    )
+                conn.commit()
+                return int(cur.rowcount)
+
+        return await asyncio.to_thread(_op)
+
+    async def count(self, agent_id: str, memory_type: MemoryType | None = None) -> int:
+        def _op() -> int:
+            with self._connect() as conn:
+                if memory_type is None:
+                    row = conn.execute(
+                        "SELECT COUNT(*) FROM agent_memory_records WHERE agent_id = ?",
+                        (agent_id,),
+                    ).fetchone()
+                else:
+                    row = conn.execute(
+                        "SELECT COUNT(*) FROM agent_memory_records WHERE agent_id = ? AND memory_type = ?",
+                        (agent_id, memory_type),
+                    ).fetchone()
+                return int(row[0]) if row else 0
+
+        return await asyncio.to_thread(_op)
+
+    async def prune_expired(self, *, now: datetime | None = None) -> int:
+        now_ts = (now or datetime.now(timezone.utc)).timestamp()
+
+        def _op() -> int:
+            with self._connect() as conn:
+                cur = conn.execute(
+                    """
+                    DELETE FROM agent_memory_records
+                    WHERE ttl_days IS NOT NULL
+                      AND (created_at + (ttl_days * 86400.0)) <= ?
+                    """,
+                    (now_ts,),
+                )
+                conn.commit()
+                return int(cur.rowcount)
+
+        return await asyncio.to_thread(_op)

--- a/src/synapsekit/memory/base.py
+++ b/src/synapsekit/memory/base.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Literal
+
+MemoryType = Literal["episodic", "semantic"]
+
+
+@dataclass(slots=True)
+class MemoryRecord:
+    id: str
+    agent_id: str
+    content: str
+    memory_type: MemoryType
+    embedding: list[float]
+    created_at: datetime
+    accessed_at: datetime
+    access_count: int = 0
+    ttl_days: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def is_expired(self, now: datetime | None = None) -> bool:
+        if self.ttl_days is None:
+            return False
+        now_utc = now or datetime.now(timezone.utc)
+        return self.created_at + timedelta(days=self.ttl_days) <= now_utc
+
+
+class BaseMemoryBackend(ABC):
+    @abstractmethod
+    async def store(self, record: MemoryRecord) -> None: ...
+
+    @abstractmethod
+    async def fetch(
+        self,
+        agent_id: str,
+        memory_type: MemoryType | None = None,
+        *,
+        include_expired: bool = False,
+    ) -> list[MemoryRecord]: ...
+
+    @abstractmethod
+    async def touch(
+        self,
+        agent_id: str,
+        record_id: str,
+        *,
+        accessed_at: datetime | None = None,
+    ) -> None: ...
+
+    @abstractmethod
+    async def delete(self, agent_id: str, record_id: str) -> bool: ...
+
+    @abstractmethod
+    async def clear(self, agent_id: str, memory_type: MemoryType | None = None) -> int: ...
+
+    @abstractmethod
+    async def count(self, agent_id: str, memory_type: MemoryType | None = None) -> int: ...
+
+    @abstractmethod
+    async def prune_expired(self, *, now: datetime | None = None) -> int: ...

--- a/tests/memory/test_agent_memory_backend_guards.py
+++ b/tests/memory/test_agent_memory_backend_guards.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from synapsekit.memory import AgentMemory
+
+
+def test_postgres_requires_dsn():
+    with pytest.raises(ValueError, match="postgres_dsn"):
+        AgentMemory(backend="postgres")
+
+
+def test_redis_backend_import_error_when_package_missing():
+    with patch.dict("sys.modules", {"redis": None, "redis.asyncio": None}):
+        with pytest.raises(ImportError, match="redis"):
+            AgentMemory(backend="redis")
+
+
+def test_unknown_backend_raises():
+    with pytest.raises(ValueError, match="Unknown backend"):
+        AgentMemory(backend="does-not-exist")

--- a/tests/memory/test_agent_memory_core.py
+++ b/tests/memory/test_agent_memory_core.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+
+from synapsekit.memory import AgentMemory
+
+
+@pytest.mark.asyncio
+async def test_store_and_recall_semantic_relevance():
+    memory = AgentMemory(backend="memory", max_episodes=50)
+
+    await memory.store(
+        agent_id="u1",
+        content="User prefers Python and concise answers",
+        memory_type="semantic",
+    )
+    await memory.store(
+        agent_id="u1",
+        content="User primarily writes Java code",
+        memory_type="semantic",
+    )
+
+    results = await memory.recall(
+        agent_id="u1",
+        query="What language does the user prefer for coding? Python?",
+        top_k=1,
+    )
+
+    assert len(results) == 1
+    assert "python" in results[0].content.lower()
+
+
+@pytest.mark.asyncio
+async def test_agent_id_isolation():
+    memory = AgentMemory(backend="memory")
+
+    await memory.store(agent_id="a", content="A likes Rust", memory_type="semantic")
+    await memory.store(agent_id="b", content="B likes Python", memory_type="semantic")
+
+    results_a = await memory.recall(agent_id="a", query="What does user like?", top_k=5)
+    assert all(r.agent_id == "a" for r in results_a)
+
+
+@pytest.mark.asyncio
+async def test_ttl_expiry_filtered_from_recall():
+    memory = AgentMemory(backend="memory")
+
+    await memory.store(
+        agent_id="u1",
+        content="ephemeral fact",
+        memory_type="episodic",
+        ttl_days=0,
+    )
+
+    results = await memory.recall(agent_id="u1", query="ephemeral", top_k=5)
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_recall_updates_access_stats():
+    memory = AgentMemory(backend="memory")
+
+    rec = await memory.store(
+        agent_id="u1", content="favorite editor is vscode", memory_type="semantic"
+    )
+    assert rec.access_count == 0
+
+    results = await memory.recall(agent_id="u1", query="editor", top_k=1)
+    assert len(results) == 1
+    assert results[0].access_count == 1
+
+
+@pytest.mark.asyncio
+async def test_consolidation_on_overflow_creates_semantic_and_prunes():
+    memory = AgentMemory(backend="memory", max_episodes=2)
+
+    await memory.store(agent_id="u1", content="Episode one", memory_type="episodic")
+    await memory.store(agent_id="u1", content="Episode two", memory_type="episodic")
+    await memory.store(agent_id="u1", content="Episode three", memory_type="episodic")
+
+    episodic_count = await memory.count(agent_id="u1", memory_type="episodic")
+    semantic_count = await memory.count(agent_id="u1", memory_type="semantic")
+
+    assert episodic_count <= 2
+    assert semantic_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_delete_and_clear():
+    memory = AgentMemory(backend="memory")
+
+    r1 = await memory.store(agent_id="u1", content="one", memory_type="episodic")
+    await memory.store(agent_id="u1", content="two", memory_type="semantic")
+
+    deleted = await memory.delete(agent_id="u1", record_id=r1.id)
+    assert deleted
+
+    remaining = await memory.count(agent_id="u1")
+    assert remaining == 1
+
+    cleared = await memory.clear(agent_id="u1")
+    assert cleared == 1
+    assert await memory.count(agent_id="u1") == 0

--- a/tests/memory/test_agent_memory_sqlite_backend.py
+++ b/tests/memory/test_agent_memory_sqlite_backend.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from synapsekit.memory import AgentMemory
+
+
+@pytest.mark.asyncio
+async def test_sqlite_backend_store_recall_and_persist(tmp_path):
+    db = str(tmp_path / "agent_memory.db")
+
+    mem1 = AgentMemory(backend="sqlite", path=db, max_episodes=50)
+    await mem1.store(agent_id="u1", content="User likes Python", memory_type="semantic")
+    await mem1.store(agent_id="u1", content="User works with FastAPI", memory_type="semantic")
+
+    mem2 = AgentMemory(backend="sqlite", path=db, max_episodes=50)
+    results = await mem2.recall(agent_id="u1", query="python preference", top_k=2)
+
+    assert len(results) == 2
+    assert any("python" in r.content.lower() for r in results)
+
+
+@pytest.mark.asyncio
+async def test_sqlite_backend_ttl_and_clear(tmp_path):
+    db = str(tmp_path / "agent_memory_ttl.db")
+    mem = AgentMemory(backend="sqlite", path=db)
+
+    await mem.store(
+        agent_id="u1",
+        content="short lived note",
+        memory_type="episodic",
+        ttl_days=0,
+    )
+    await mem.store(agent_id="u1", content="long lived", memory_type="semantic")
+
+    recalled = await mem.recall(agent_id="u1", query="note", top_k=10)
+    assert all("short lived" not in r.content for r in recalled)
+
+    cleared_sem = await mem.clear(agent_id="u1", memory_type="semantic")
+    assert cleared_sem == 1
+    assert await mem.count(agent_id="u1") == 0


### PR DESCRIPTION
## Summary
This is **PR 1/2** for #506 (persistent agent memory architecture).

### Added persistent memory core
- `MemoryRecord` + backend contract in `src/synapsekit/memory/base.py`
- `AgentMemory` orchestrator in `src/synapsekit/memory/agent_memory.py`
  - `store()`
  - `recall()`
  - `consolidate()`
  - `delete()`
  - `clear()`
  - `list()`
  - `count()`

### Added backend implementations (shared interface)
- `src/synapsekit/memory/backends/memory.py`
- `src/synapsekit/memory/backends/sqlite.py`
- `src/synapsekit/memory/backends/redis.py`
- `src/synapsekit/memory/backends/postgres.py`
- `src/synapsekit/memory/backends/__init__.py`

### Exports / packaging
- updated `src/synapsekit/memory/__init__.py`
- updated `pyproject.toml` (`postgres` extras now include `asyncpg>=0.29`)

### Behavior covered in this PR
- agent_id isolation
- TTL pruning
- access_count + accessed_at updates
- episodic overflow auto-consolidation into semantic memory
- semantic recall ranking with deterministic default embedding fallback

## Tests
- `tests/memory/test_agent_memory_core.py`
- `tests/memory/test_agent_memory_sqlite_backend.py`
- `tests/memory/test_agent_memory_backend_guards.py`

Validation run:
- `python -m ruff check src/synapsekit/memory tests/memory pyproject.toml`
- `python -m ruff format --check src/synapsekit/memory tests/memory`
- `python -m pytest tests/memory tests/agents/test_memory.py -q`

## Follow-up (PR 2)
- integrate persistent `AgentMemory` into `ReActAgent` and `FunctionCallingAgent`
- graph/node integration path
- backward-compatibility bridge for existing `agents.memory.AgentMemory` scratchpad usage
- end-to-end integration examples/tests

Part of #506
