### PR TITLE
feat(agents): integrate persistent memory into agents and graph path

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -57,6 +57,16 @@ Configure response caching, automatic retries, and cost tracking with budget lim
 python examples/caching_retries.py
 ```
 
+### 6. `agent_memory.py` — Persistent Memory in Agents
+Shows PR2-style memory integration:
+- auto-recall injected into each turn
+- episodic memory stored after each run
+- `AgentExecutor` wiring with `PersistentAgentMemory`
+
+```bash
+python examples/agent_memory.py
+```
+
 ## General Pattern
 
 All examples follow this pattern:

--- a/examples/agent_memory.py
+++ b/examples/agent_memory.py
@@ -1,0 +1,57 @@
+"""Persistent memory integration for agents.
+
+Run:
+    python examples/agent_memory.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+
+from synapsekit import AgentConfig, AgentExecutor, PersistentAgentMemory
+
+
+class DemoLLM:
+    """Tiny demo LLM that inspects injected memory text."""
+
+    async def generate_with_messages(self, messages: list[dict]) -> str:
+        system_prompt = str(messages[0].get("content", ""))
+        if "prefers tea" in system_prompt.lower():
+            return "Thought: I now know the final answer.\nFinal Answer: You prefer tea."
+        return "Thought: I now know the final answer.\nFinal Answer: I don't know yet."
+
+    async def stream_with_messages(self, messages: list[dict]) -> AsyncGenerator[str]:
+        text = await self.generate_with_messages(messages)
+        for token in text.split(" "):
+            yield token + " "
+
+
+async def main() -> None:
+    memory = PersistentAgentMemory(backend="memory")
+    await memory.store(
+        agent_id="demo-user",
+        memory_type="semantic",
+        content="User prefers tea in the evening.",
+    )
+
+    executor = AgentExecutor(
+        AgentConfig(
+            llm=DemoLLM(),
+            tools=[],
+            agent_type="react",
+            memory=memory,
+            agent_id="demo-user",
+            memory_top_k=3,
+        )
+    )
+
+    answer = await executor.run("What drink do I usually prefer?")
+    print("Answer:", answer)
+
+    episodic_count = await memory.count(agent_id="demo-user", memory_type="episodic")
+    print("Episodic memories stored:", episodic_count)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -21,6 +21,7 @@ from .agents import (
     AgentConfig,
     AgentExecutor,
     AgentMemory,
+    AgentScratchpad,
     AgentStep,
     ArxivSearchTool,
     BaseTool,
@@ -184,6 +185,7 @@ from .loaders.tsv import TSVLoader
 from .loaders.web import WebLoader
 from .loaders.wikipedia import WikipediaLoader
 from .mcp import MCPClient, MCPServer, MCPToolAdapter
+from .memory import AgentMemory as PersistentAgentMemory
 from .memory.buffer import BufferMemory
 from .memory.conversation import ConversationMemory
 from .memory.entity import EntityMemory
@@ -335,6 +337,7 @@ __all__ = [
     "BudgetExceededError",
     "CircuitState",
     # Memory / observability
+    "PersistentAgentMemory",
     "BufferMemory",
     "ConversationMemory",
     "EntityMemory",
@@ -395,6 +398,7 @@ __all__ = [
     "ToolResult",
     "ToolRegistry",
     "AgentMemory",
+    "AgentScratchpad",
     "AgentStep",
     "ReActAgent",
     "FunctionCallingAgent",

--- a/src/synapsekit/agents/__init__.py
+++ b/src/synapsekit/agents/__init__.py
@@ -8,7 +8,7 @@ from .guardrails import (
     PIIDetector,
     TopicRestrictor,
 )
-from .memory import AgentMemory, AgentStep
+from .memory import AgentMemory, AgentScratchpad, AgentStep
 from .multi import (
     Crew,
     CrewAgent,
@@ -89,6 +89,7 @@ __all__ = [
     "ToolResult",
     "ToolRegistry",
     "AgentMemory",
+    "AgentScratchpad",
     "AgentStep",
     # Agents
     "ReActAgent",

--- a/src/synapsekit/agents/executor.py
+++ b/src/synapsekit/agents/executor.py
@@ -6,9 +6,10 @@ from typing import Literal
 
 from .._compat import run_sync
 from ..llm.base import BaseLLM
+from ..memory.agent_memory import AgentMemory as PersistentAgentMemory
 from .base import BaseTool
 from .function_calling import FunctionCallingAgent
-from .memory import AgentMemory
+from .memory import AgentScratchpad
 from .react import ReActAgent
 
 
@@ -20,6 +21,9 @@ class AgentConfig:
     max_iterations: int = 10
     system_prompt: str = "You are a helpful AI assistant."
     verbose: bool = False
+    memory: PersistentAgentMemory | None = None
+    agent_id: str = "default"
+    memory_top_k: int = 5
 
 
 class AgentExecutor:
@@ -43,21 +47,27 @@ class AgentExecutor:
         self._agent = self._build_agent()
 
     def _build_agent(self) -> ReActAgent | FunctionCallingAgent:
-        memory = AgentMemory(max_steps=self.config.max_iterations)
+        scratchpad = AgentScratchpad(max_steps=self.config.max_iterations)
         if self.config.agent_type == "react":
             return ReActAgent(
                 llm=self.config.llm,
                 tools=self.config.tools,
                 max_iterations=self.config.max_iterations,
-                memory=memory,
+                memory=self.config.memory,
+                scratchpad=scratchpad,
+                agent_id=self.config.agent_id,
+                memory_top_k=self.config.memory_top_k,
             )
         elif self.config.agent_type == "function_calling":
             return FunctionCallingAgent(
                 llm=self.config.llm,
                 tools=self.config.tools,
                 max_iterations=self.config.max_iterations,
-                memory=memory,
+                memory=self.config.memory,
+                scratchpad=scratchpad,
                 system_prompt=self.config.system_prompt,
+                agent_id=self.config.agent_id,
+                memory_top_k=self.config.memory_top_k,
             )
         else:
             raise ValueError(
@@ -79,5 +89,9 @@ class AgentExecutor:
         return run_sync(self.run(query))
 
     @property
-    def memory(self) -> AgentMemory:
+    def memory(self) -> AgentScratchpad:
         return self._agent.memory
+
+    @property
+    def persistent_memory(self) -> PersistentAgentMemory | None:
+        return getattr(self._agent, "persistent_memory", None)

--- a/src/synapsekit/agents/function_calling.py
+++ b/src/synapsekit/agents/function_calling.py
@@ -5,34 +5,43 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from ..llm.base import BaseLLM
+from ..memory.agent_memory import AgentMemory as PersistentAgentMemory
 from .base import BaseTool
-from .memory import AgentMemory, AgentStep
+from .memory import AgentScratchpad, AgentStep
 from .registry import ToolRegistry
 
 
 class FunctionCallingAgent:
-    """
-    Agent that uses native LLM function-calling (OpenAI tool_calls / Anthropic tool_use).
-
-    Falls back gracefully: if the LLM doesn't support call_with_tools(),
-    raises RuntimeError with a suggestion to use ReActAgent instead.
-    """
+    """Function-calling agent with optional persistent memory integration."""
 
     def __init__(
         self,
         llm: BaseLLM,
         tools: list[BaseTool],
         max_iterations: int = 10,
-        memory: AgentMemory | None = None,
+        memory: PersistentAgentMemory | AgentScratchpad | None = None,
         system_prompt: str = "You are a helpful AI assistant.",
+        *,
+        agent_id: str = "default",
+        memory_top_k: int = 5,
+        scratchpad: AgentScratchpad | None = None,
     ) -> None:
         if max_iterations < 1:
             raise ValueError("max_iterations must be >= 1")
         self._llm = llm
         self._registry = ToolRegistry(tools)
         self._max_iterations = max_iterations
-        self._memory = memory or AgentMemory(max_steps=max_iterations)
         self._system_prompt = system_prompt
+        self._agent_id = agent_id
+        self._memory_top_k = memory_top_k
+
+        self._persistent_memory: PersistentAgentMemory | None = None
+        if isinstance(memory, AgentScratchpad):
+            self._scratchpad = memory
+        else:
+            self._scratchpad = scratchpad or AgentScratchpad(max_steps=max_iterations)
+            if memory is not None:
+                self._persistent_memory = memory
 
     def __repr__(self) -> str:
         llm = type(self._llm).__name__
@@ -40,7 +49,6 @@ class FunctionCallingAgent:
         return f"FunctionCallingAgent(llm={llm!r}, tools={tools}, max_iterations={self._max_iterations})"
 
     def _check_support(self) -> None:
-        # Check if the provider has overridden _call_with_tools_impl (not just the base NotImplementedError)
         method = getattr(type(self._llm), "_call_with_tools_impl", None)
         if method is getattr(BaseLLM, "_call_with_tools_impl", None):
             raise RuntimeError(
@@ -48,13 +56,51 @@ class FunctionCallingAgent:
                 "Use ReActAgent instead, or switch to OpenAILLM / AnthropicLLM / GeminiLLM / MistralLLM."
             )
 
+    async def _build_system_prompt(self, query: str) -> str:
+        if self._persistent_memory is None:
+            return self._system_prompt
+        records = await self._persistent_memory.recall(
+            agent_id=self._agent_id,
+            query=query,
+            top_k=self._memory_top_k,
+        )
+        if not records:
+            return self._system_prompt
+
+        lines = []
+        for rec in records:
+            memory_type = getattr(rec, "memory_type", "semantic")
+            content = getattr(rec, "content", "")
+            if content:
+                lines.append(f"- [{memory_type}] {content}")
+        if not lines:
+            return self._system_prompt
+
+        return (
+            f"{self._system_prompt}\n\n"
+            "Relevant persistent memories (use when helpful and factual):\n"
+            + "\n".join(lines)
+        )
+
+    async def _store_episode(self, query: str, answer: str) -> None:
+        if self._persistent_memory is None:
+            return
+        await self._persistent_memory.store(
+            agent_id=self._agent_id,
+            content=f"User query: {query}\nAgent answer: {answer}",
+            memory_type="episodic",
+            metadata={
+                "tool_count": len(self._scratchpad.steps),
+                "tools": [step.action for step in self._scratchpad.steps],
+            },
+        )
+
     async def run(self, query: str) -> str:
-        """Run the function-calling loop and return the final answer."""
         self._check_support()
-        self._memory.clear()
+        self._scratchpad.clear()
 
         messages: list[dict] = [
-            {"role": "system", "content": self._system_prompt},
+            {"role": "system", "content": await self._build_system_prompt(query)},
             {"role": "user", "content": query},
         ]
 
@@ -66,11 +112,11 @@ class FunctionCallingAgent:
             tool_calls = result.get("tool_calls")
             content = result.get("content")
 
-            # No tool calls → final answer
             if not tool_calls:
-                return content or ""
+                final_answer = content or ""
+                await self._store_episode(query, final_answer)
+                return final_answer
 
-            # Append assistant message with tool_calls
             messages.append(
                 {
                     "role": "assistant",
@@ -89,7 +135,6 @@ class FunctionCallingAgent:
                 }
             )
 
-            # Execute each tool and append observations
             for tc in tool_calls:
                 try:
                     tool = self._registry.get(tc["name"])
@@ -108,7 +153,7 @@ class FunctionCallingAgent:
                     }
                 )
 
-                self._memory.add_step(
+                self._scratchpad.add_step(
                     AgentStep(
                         thought="",
                         action=tc["name"],
@@ -117,20 +162,17 @@ class FunctionCallingAgent:
                     )
                 )
 
-        return "I was unable to complete the task within the allowed number of steps."
+        fallback = "I was unable to complete the task within the allowed number of steps."
+        await self._store_episode(query, fallback)
+        return fallback
 
     async def stream(self, query: str) -> AsyncGenerator[str]:
-        """Stream the final answer (intermediate tool calls run silently)."""
         answer = await self.run(query)
         for word in answer.split(" "):
             yield word + " "
 
     async def stream_steps(self, query: str) -> AsyncGenerator:
-        """Stream step-by-step events for function-calling agent.
-
-        Yields ``StepEvent`` instances (``ActionEvent``, ``ObservationEvent``,
-        ``TokenEvent``, ``FinalAnswerEvent``, ``ErrorEvent``).
-        """
+        """Stream step-by-step events for function-calling agent."""
         from .step_events import (
             ActionEvent,
             ErrorEvent,
@@ -140,10 +182,10 @@ class FunctionCallingAgent:
         )
 
         self._check_support()
-        self._memory.clear()
+        self._scratchpad.clear()
 
         messages: list[dict] = [
-            {"role": "system", "content": self._system_prompt},
+            {"role": "system", "content": await self._build_system_prompt(query)},
             {"role": "user", "content": query},
         ]
 
@@ -155,15 +197,14 @@ class FunctionCallingAgent:
             tool_calls = result.get("tool_calls")
             content = result.get("content")
 
-            # No tool calls → final answer
             if not tool_calls:
                 answer = content or ""
+                await self._store_episode(query, answer)
                 for token in answer.split(" "):
                     yield TokenEvent(token=token + " ")
                 yield FinalAnswerEvent(answer=answer)
                 return
 
-            # Append assistant message with tool_calls
             messages.append(
                 {
                     "role": "assistant",
@@ -182,7 +223,6 @@ class FunctionCallingAgent:
                 }
             )
 
-            # Execute each tool
             for tc in tool_calls:
                 yield ActionEvent(tool=tc["name"], tool_input=tc["arguments"])
 
@@ -203,7 +243,7 @@ class FunctionCallingAgent:
                 )
                 yield ObservationEvent(observation=observation, tool=tc["name"])
 
-                self._memory.add_step(
+                self._scratchpad.add_step(
                     AgentStep(
                         thought="",
                         action=tc["name"],
@@ -212,10 +252,14 @@ class FunctionCallingAgent:
                     )
                 )
 
-        yield FinalAnswerEvent(
-            answer="I was unable to complete the task within the allowed number of steps."
-        )
+        fallback = "I was unable to complete the task within the allowed number of steps."
+        await self._store_episode(query, fallback)
+        yield FinalAnswerEvent(answer=fallback)
 
     @property
-    def memory(self) -> AgentMemory:
-        return self._memory
+    def memory(self) -> AgentScratchpad:
+        return self._scratchpad
+
+    @property
+    def persistent_memory(self) -> PersistentAgentMemory | None:
+        return self._persistent_memory

--- a/src/synapsekit/agents/memory.py
+++ b/src/synapsekit/agents/memory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 
 
@@ -13,7 +14,7 @@ class AgentStep:
     observation: str
 
 
-class AgentMemory:
+class AgentScratchpad:
     """Scratchpad that records agent steps for the current run."""
 
     def __init__(self, max_steps: int = 20) -> None:
@@ -45,3 +46,17 @@ class AgentMemory:
 
     def __len__(self) -> int:
         return len(self._steps)
+
+
+class AgentMemory(AgentScratchpad):
+    """Backward-compatible alias for AgentScratchpad (deprecated)."""
+
+    def __init__(self, max_steps: int = 20) -> None:
+        warnings.warn(
+            "synapsekit.agents.memory.AgentMemory is deprecated; "
+            "use AgentScratchpad for step scratchpad, and synapsekit.memory.AgentMemory "
+            "for persistent memory.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(max_steps=max_steps)

--- a/src/synapsekit/agents/react.py
+++ b/src/synapsekit/agents/react.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import re
 from collections.abc import AsyncGenerator
+from typing import Any
 
 from ..llm.base import BaseLLM
+from ..memory.agent_memory import AgentMemory as PersistentAgentMemory
 from .base import BaseTool
-from .memory import AgentMemory, AgentStep
+from .memory import AgentScratchpad, AgentStep
 from .registry import ToolRegistry
 
 _REACT_SYSTEM = """\
@@ -59,67 +61,118 @@ def _parse_final_answer(text: str) -> str | None:
 
 
 class ReActAgent:
-    """
-    Reasoning + Acting agent.
-
-    Loops: Thought → Action → Observation → repeat until Final Answer.
-    Works with any BaseLLM — no native function-calling required.
-    """
+    """Reasoning + Acting agent with optional persistent memory integration."""
 
     def __init__(
         self,
         llm: BaseLLM,
         tools: list[BaseTool],
         max_iterations: int = 10,
-        memory: AgentMemory | None = None,
+        memory: PersistentAgentMemory | AgentScratchpad | None = None,
+        *,
+        agent_id: str = "default",
+        memory_top_k: int = 5,
+        scratchpad: AgentScratchpad | None = None,
     ) -> None:
         if max_iterations < 1:
             raise ValueError("max_iterations must be >= 1")
         self._llm = llm
         self._registry = ToolRegistry(tools)
         self._max_iterations = max_iterations
-        self._memory = memory or AgentMemory(max_steps=max_iterations)
+        self._agent_id = agent_id
+        self._memory_top_k = memory_top_k
+
+        self._persistent_memory: PersistentAgentMemory | None = None
+        if isinstance(memory, AgentScratchpad):
+            self._scratchpad = memory
+        else:
+            self._scratchpad = scratchpad or AgentScratchpad(max_steps=max_iterations)
+            if memory is not None:
+                self._persistent_memory = memory
 
     def __repr__(self) -> str:
         llm = type(self._llm).__name__
         tools = len(self._registry.schemas())
         return f"ReActAgent(llm={llm!r}, tools={tools}, max_iterations={self._max_iterations})"
 
-    def _build_system_prompt(self) -> str:
-        return _REACT_SYSTEM.format(tools=self._registry.describe())
+    @staticmethod
+    def _format_recalled_memories(records: list[Any]) -> str:
+        if not records:
+            return ""
+        lines = []
+        for rec in records:
+            memory_type = getattr(rec, "memory_type", "semantic")
+            content = getattr(rec, "content", "")
+            if content:
+                lines.append(f"- [{memory_type}] {content}")
+        return "\n".join(lines)
 
-    def _build_messages(self, query: str) -> list[dict]:
-        scratchpad = self._memory.format_scratchpad()
+    async def _recall_context(self, query: str) -> str:
+        if self._persistent_memory is None:
+            return ""
+        records = await self._persistent_memory.recall(
+            agent_id=self._agent_id,
+            query=query,
+            top_k=self._memory_top_k,
+        )
+        return self._format_recalled_memories(records)
+
+    async def _store_episode(self, query: str, answer: str) -> None:
+        if self._persistent_memory is None:
+            return
+        tool_names = [step.action for step in self._scratchpad.steps]
+        await self._persistent_memory.store(
+            agent_id=self._agent_id,
+            content=f"User query: {query}\nAgent answer: {answer}",
+            memory_type="episodic",
+            metadata={
+                "tool_count": len(tool_names),
+                "tools": tool_names,
+            },
+        )
+
+    def _build_system_prompt(self, memory_context: str = "") -> str:
+        prompt = _REACT_SYSTEM.format(tools=self._registry.describe())
+        if not memory_context:
+            return prompt
+        return (
+            f"{prompt}\n\n"
+            "Relevant persistent memories (use when helpful and factual):\n"
+            f"{memory_context}"
+        )
+
+    def _build_messages(self, query: str, memory_context: str = "") -> list[dict]:
+        scratchpad = self._scratchpad.format_scratchpad()
         user_content = f"Question: {query}"
         if scratchpad:
             user_content += f"\n\n{scratchpad}"
         return [
-            {"role": "system", "content": self._build_system_prompt()},
+            {"role": "system", "content": self._build_system_prompt(memory_context)},
             {"role": "user", "content": user_content},
         ]
 
     async def run(self, query: str) -> str:
         """Run the ReAct loop and return the final answer."""
-        self._memory.clear()
+        self._scratchpad.clear()
+        memory_context = await self._recall_context(query)
 
         for _ in range(self._max_iterations):
-            messages = self._build_messages(query)
+            messages = self._build_messages(query, memory_context)
             response = await self._llm.generate_with_messages(messages)
 
-            # Check for final answer first
             final = _parse_final_answer(response)
             if final is not None:
+                await self._store_episode(query, final)
                 return final
 
-            # Parse action
             action_name, action_input = _parse_action(response)
             thought = _parse_thought(response)
 
             if not action_name:
-                # LLM didn't follow format — treat whole response as final answer
-                return response.strip()
+                final_answer = response.strip()
+                await self._store_episode(query, final_answer)
+                return final_answer
 
-            # Execute tool
             try:
                 tool = self._registry.get(action_name)
                 result = await tool.run(input=action_input)
@@ -129,7 +182,7 @@ class ReActAgent:
             except Exception as e:
                 observation = f"Tool error: {e}"
 
-            self._memory.add_step(
+            self._scratchpad.add_step(
                 AgentStep(
                     thought=thought,
                     action=action_name,
@@ -138,23 +191,17 @@ class ReActAgent:
                 )
             )
 
-        return "I was unable to find the answer within the allowed number of steps."
+        fallback = "I was unable to find the answer within the allowed number of steps."
+        await self._store_episode(query, fallback)
+        return fallback
 
     async def stream(self, query: str) -> AsyncGenerator[str]:
-        """
-        Stream the final answer. Intermediate tool calls run silently.
-        Yields the final answer string (may be multi-token on last LLM call).
-        """
         answer = await self.run(query)
         for word in answer.split(" "):
             yield word + " "
 
     async def stream_steps(self, query: str) -> AsyncGenerator:
-        """Stream step-by-step events including thoughts, actions, and tokens.
-
-        Yields ``StepEvent`` instances (``ThoughtEvent``, ``ActionEvent``,
-        ``ObservationEvent``, ``TokenEvent``, ``FinalAnswerEvent``, ``ErrorEvent``).
-        """
+        """Stream step-by-step events including thoughts, actions, and tokens."""
         from .step_events import (
             ActionEvent,
             ErrorEvent,
@@ -164,24 +211,23 @@ class ReActAgent:
             TokenEvent,
         )
 
-        self._memory.clear()
+        self._scratchpad.clear()
+        memory_context = await self._recall_context(query)
 
         for _ in range(self._max_iterations):
-            messages = self._build_messages(query)
+            messages = self._build_messages(query, memory_context)
 
-            # Stream tokens live
             full_response = ""
             async for token in self._llm.stream_with_messages(messages):
                 yield TokenEvent(token=token)
                 full_response += token
 
-            # Check for final answer
             final = _parse_final_answer(full_response)
             if final is not None:
+                await self._store_episode(query, final)
                 yield FinalAnswerEvent(answer=final)
                 return
 
-            # Parse action
             action_name, action_input = _parse_action(full_response)
             thought = _parse_thought(full_response)
 
@@ -189,12 +235,13 @@ class ReActAgent:
                 yield ThoughtEvent(thought=thought)
 
             if not action_name:
-                yield FinalAnswerEvent(answer=full_response.strip())
+                final_answer = full_response.strip()
+                await self._store_episode(query, final_answer)
+                yield FinalAnswerEvent(answer=final_answer)
                 return
 
             yield ActionEvent(tool=action_name, tool_input=action_input)
 
-            # Execute tool
             try:
                 tool = self._registry.get(action_name)
                 result = await tool.run(input=action_input)
@@ -205,7 +252,7 @@ class ReActAgent:
 
             yield ObservationEvent(observation=observation, tool=action_name)
 
-            self._memory.add_step(
+            self._scratchpad.add_step(
                 AgentStep(
                     thought=thought,
                     action=action_name,
@@ -214,10 +261,14 @@ class ReActAgent:
                 )
             )
 
-        yield FinalAnswerEvent(
-            answer="I was unable to find the answer within the allowed number of steps."
-        )
+        fallback = "I was unable to find the answer within the allowed number of steps."
+        await self._store_episode(query, fallback)
+        yield FinalAnswerEvent(answer=fallback)
 
     @property
-    def memory(self) -> AgentMemory:
-        return self._memory
+    def memory(self) -> AgentScratchpad:
+        return self._scratchpad
+
+    @property
+    def persistent_memory(self) -> PersistentAgentMemory | None:
+        return self._persistent_memory

--- a/src/synapsekit/graph/node.py
+++ b/src/synapsekit/graph/node.py
@@ -14,10 +14,53 @@ class Node:
     fn: NodeFn
 
 
-def agent_node(executor: Any, input_key: str = "input", output_key: str = "output") -> NodeFn:
-    """Wrap an AgentExecutor as a NodeFn."""
+def agent_node(
+    executor: Any,
+    input_key: str = "input",
+    output_key: str = "output",
+    *,
+    memory_key: str | None = None,
+    agent_id_key: str | None = None,
+    memory_top_k_key: str | None = None,
+) -> NodeFn:
+    """Wrap an AgentExecutor as a NodeFn.
+
+    Optional state wiring for memory-aware agents:
+    - ``memory_key``: state key containing persistent ``AgentMemory`` instance
+    - ``agent_id_key``: state key containing per-run agent/user id
+    - ``memory_top_k_key``: state key overriding recall top-k
+
+    When provided, these values are applied to ``executor.config`` before each run.
+    """
+
+    def _configure_executor_from_state(state: dict[str, Any]) -> None:
+        config = getattr(executor, "config", None)
+        if config is None:
+            return
+
+        changed = False
+
+        if memory_key and memory_key in state and getattr(config, "memory", None) is not state[memory_key]:
+            config.memory = state[memory_key]
+            changed = True
+
+        if agent_id_key and agent_id_key in state:
+            agent_id = state[agent_id_key]
+            if agent_id is not None and getattr(config, "agent_id", None) != str(agent_id):
+                config.agent_id = str(agent_id)
+                changed = True
+
+        if memory_top_k_key and memory_top_k_key in state:
+            top_k = int(state[memory_top_k_key])
+            if getattr(config, "memory_top_k", None) != top_k:
+                config.memory_top_k = top_k
+                changed = True
+
+        if changed and hasattr(executor, "_build_agent"):
+            executor._agent = executor._build_agent()
 
     async def _fn(state: dict[str, Any]) -> dict[str, Any]:
+        _configure_executor_from_state(state)
         result = await executor.run(state[input_key])
         return {output_key: result}
 

--- a/tests/agents/test_executor.py
+++ b/tests/agents/test_executor.py
@@ -9,6 +9,7 @@ import pytest
 from synapsekit.agents.executor import AgentConfig, AgentExecutor
 from synapsekit.agents.registry import ToolRegistry
 from synapsekit.agents.tools.calculator import CalculatorTool
+from synapsekit.memory import AgentMemory as PersistentAgentMemory
 
 # ------------------------------------------------------------------ #
 # ToolRegistry
@@ -99,6 +100,24 @@ class TestAgentExecutorReAct:
         executor = AgentExecutor(AgentConfig(llm=llm, tools=[], agent_type="react"))
         await executor.run("test")
         assert executor.memory is not None
+
+    @pytest.mark.asyncio
+    async def test_persistent_memory_accessible(self):
+        llm = self._make_react_llm("done")
+        persistent = PersistentAgentMemory(backend="memory")
+        executor = AgentExecutor(
+            AgentConfig(
+                llm=llm,
+                tools=[],
+                agent_type="react",
+                memory=persistent,
+                agent_id="u1",
+            )
+        )
+
+        await executor.run("test")
+        assert executor.persistent_memory is persistent
+        assert await persistent.count(agent_id="u1", memory_type="episodic") == 1
 
 
 # ------------------------------------------------------------------ #

--- a/tests/agents/test_function_calling.py
+++ b/tests/agents/test_function_calling.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -46,6 +47,12 @@ def make_no_fc_llm():
             yield "x"
 
     return _NoFCLLM(LLMConfig(model="test", api_key="test", provider="test"))
+
+
+@dataclass
+class _MemoryRecord:
+    content: str
+    memory_type: str = "semantic"
 
 
 # ------------------------------------------------------------------ #
@@ -153,3 +160,41 @@ class TestFunctionCallingAgent:
         result = await agent.run("compute both")
         assert result == "Results: 3 and 7."
         assert len(agent.memory) == 2
+
+    @pytest.mark.asyncio
+    async def test_persistent_memory_recalled_and_injected(self):
+        persistent = MagicMock()
+        persistent.recall = AsyncMock(return_value=[_MemoryRecord(content="Use metric units")])
+        persistent.store = AsyncMock()
+
+        responses = [{"content": "Done", "tool_calls": None}]
+        llm = make_fc_llm(responses)
+        agent = FunctionCallingAgent(llm=llm, tools=[], memory=persistent, agent_id="u1")
+
+        result = await agent.run("How should I format output?")
+        assert result == "Done"
+
+        persistent.recall.assert_awaited_once_with(
+            agent_id="u1", query="How should I format output?", top_k=5
+        )
+        messages = llm.call_with_tools.call_args.args[0]
+        assert "Relevant persistent memories" in messages[0]["content"]
+        assert "Use metric units" in messages[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_persistent_memory_stores_episodic_run(self):
+        persistent = MagicMock()
+        persistent.recall = AsyncMock(return_value=[])
+        persistent.store = AsyncMock()
+
+        responses = [{"content": "final", "tool_calls": None}]
+        llm = make_fc_llm(responses)
+        agent = FunctionCallingAgent(llm=llm, tools=[], memory=persistent, agent_id="u2")
+
+        await agent.run("question")
+        persistent.store.assert_awaited_once()
+        payload = persistent.store.await_args.kwargs
+        assert payload["agent_id"] == "u2"
+        assert payload["memory_type"] == "episodic"
+        assert "question" in payload["content"]
+        assert "final" in payload["content"]

--- a/tests/agents/test_memory.py
+++ b/tests/agents/test_memory.py
@@ -1,18 +1,20 @@
-"""Tests for AgentMemory."""
+"""Tests for agent scratchpad memory."""
 
 from __future__ import annotations
 
-from synapsekit.agents.memory import AgentMemory, AgentStep
+import pytest
+
+from synapsekit.agents.memory import AgentMemory, AgentScratchpad, AgentStep
 
 
-class TestAgentMemory:
+class TestAgentScratchpad:
     def test_empty_on_init(self):
-        mem = AgentMemory()
+        mem = AgentScratchpad()
         assert len(mem) == 0
         assert mem.steps == []
 
     def test_add_step(self):
-        mem = AgentMemory()
+        mem = AgentScratchpad()
         step = AgentStep(
             thought="Let me calculate",
             action="calculator",
@@ -24,7 +26,7 @@ class TestAgentMemory:
         assert mem.steps[0].observation == "4"
 
     def test_multiple_steps(self):
-        mem = AgentMemory()
+        mem = AgentScratchpad()
         for i in range(3):
             mem.add_step(
                 AgentStep(
@@ -37,7 +39,7 @@ class TestAgentMemory:
         assert len(mem) == 3
 
     def test_format_scratchpad(self):
-        mem = AgentMemory()
+        mem = AgentScratchpad()
         mem.add_step(
             AgentStep(
                 thought="I need to add",
@@ -53,25 +55,33 @@ class TestAgentMemory:
         assert "Observation: 2" in scratchpad
 
     def test_format_scratchpad_empty(self):
-        mem = AgentMemory()
+        mem = AgentScratchpad()
         assert mem.format_scratchpad() == ""
 
     def test_is_full(self):
-        mem = AgentMemory(max_steps=2)
+        mem = AgentScratchpad(max_steps=2)
         assert not mem.is_full()
         mem.add_step(AgentStep("t", "a", "i", "o"))
         mem.add_step(AgentStep("t", "a", "i", "o"))
         assert mem.is_full()
 
     def test_clear(self):
-        mem = AgentMemory()
+        mem = AgentScratchpad()
         mem.add_step(AgentStep("t", "a", "i", "o"))
         mem.clear()
         assert len(mem) == 0
 
     def test_steps_returns_copy(self):
-        mem = AgentMemory()
+        mem = AgentScratchpad()
         mem.add_step(AgentStep("t", "a", "i", "o"))
         steps = mem.steps
         steps.clear()
         assert len(mem) == 1  # original unaffected
+
+
+class TestAgentMemoryCompatibility:
+    def test_agent_memory_alias_warns(self):
+        with pytest.deprecated_call(match="AgentMemory is deprecated"):
+            mem = AgentMemory()
+        mem.add_step(AgentStep("t", "a", "i", "o"))
+        assert len(mem) == 1

--- a/tests/agents/test_react.py
+++ b/tests/agents/test_react.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -41,6 +42,12 @@ def make_mock_llm(responses):
     llm = MagicMock()
     llm.generate_with_messages = AsyncMock(side_effect=responses)
     return llm
+
+
+@dataclass
+class _MemoryRecord:
+    content: str
+    memory_type: str = "semantic"
 
 
 # ------------------------------------------------------------------ #
@@ -175,3 +182,41 @@ class TestReActAgent:
         agent = ReActAgent(llm=llm, tools=[])
         result = await agent.run("What is 42?")
         assert "42" in result
+
+    @pytest.mark.asyncio
+    async def test_persistent_memory_recalled_and_injected(self):
+        persistent = MagicMock()
+        persistent.recall = AsyncMock(
+            return_value=[_MemoryRecord(content="User prefers concise answers")]
+        )
+        persistent.store = AsyncMock()
+
+        llm = make_mock_llm(["Thought: done\nFinal Answer: acknowledged"])
+        agent = ReActAgent(llm=llm, tools=[], memory=persistent, agent_id="user-123")
+
+        result = await agent.run("How should I answer?")
+        assert result == "acknowledged"
+
+        persistent.recall.assert_awaited_once_with(
+            agent_id="user-123", query="How should I answer?", top_k=5
+        )
+        messages = llm.generate_with_messages.call_args.args[0]
+        assert "Relevant persistent memories" in messages[0]["content"]
+        assert "User prefers concise answers" in messages[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_persistent_memory_stores_episodic_run(self):
+        persistent = MagicMock()
+        persistent.recall = AsyncMock(return_value=[])
+        persistent.store = AsyncMock()
+
+        llm = make_mock_llm(["Thought: done\nFinal Answer: Paris"])
+        agent = ReActAgent(llm=llm, tools=[], memory=persistent, agent_id="u1")
+
+        await agent.run("capital?")
+        persistent.store.assert_awaited_once()
+        payload = persistent.store.await_args.kwargs
+        assert payload["agent_id"] == "u1"
+        assert payload["memory_type"] == "episodic"
+        assert "capital?" in payload["content"]
+        assert "Paris" in payload["content"]

--- a/tests/graph/test_node.py
+++ b/tests/graph/test_node.py
@@ -1,0 +1,70 @@
+"""Tests for graph node helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from synapsekit.agents.executor import AgentConfig, AgentExecutor
+from synapsekit.graph.node import agent_node
+from synapsekit.memory import AgentMemory as PersistentAgentMemory
+
+
+@pytest.mark.asyncio
+async def test_agent_node_basic_wrapper():
+    class _Executor:
+        async def run(self, query: str) -> str:
+            return f"answer:{query}"
+
+    fn = agent_node(_Executor(), input_key="q", output_key="a")
+    result = await fn({"q": "hello"})
+    assert result == {"a": "answer:hello"}
+
+
+@pytest.mark.asyncio
+async def test_agent_node_memory_wiring_into_executor_config():
+    llm = MagicMock()
+    llm.generate_with_messages = AsyncMock(return_value="Thought: done\nFinal Answer: ok")
+
+    executor = AgentExecutor(
+        AgentConfig(
+            llm=llm,
+            tools=[],
+            agent_type="react",
+        )
+    )
+
+    persistent = PersistentAgentMemory(backend="memory")
+    await persistent.store(
+        agent_id="alice",
+        content="Alice prefers tea over coffee",
+        memory_type="semantic",
+    )
+
+    fn = agent_node(
+        executor,
+        input_key="q",
+        output_key="a",
+        memory_key="memory",
+        agent_id_key="agent_id",
+        memory_top_k_key="top_k",
+    )
+
+    result = await fn(
+        {
+            "q": "What drink should I suggest?",
+            "memory": persistent,
+            "agent_id": "alice",
+            "top_k": 3,
+        }
+    )
+    assert result == {"a": "ok"}
+
+    assert executor.config.memory is persistent
+    assert executor.config.agent_id == "alice"
+    assert executor.config.memory_top_k == 3
+
+    messages = llm.generate_with_messages.call_args.args[0]
+    assert "Relevant persistent memories" in messages[0]["content"]
+    assert "Alice prefers tea over coffee" in messages[0]["content"]


### PR DESCRIPTION
## Summary
- integrate persistent memory into `ReActAgent` and `FunctionCallingAgent`
- auto-inject recalled memories per turn and store episodic run memories
- add compatibility deprecation path: `agents.AgentMemory` -> `AgentScratchpad`
- extend `graph.agent_node` with optional state wiring for memory (`memory_key`, `agent_id_key`, `memory_top_k_key`)
- add `examples/agent_memory.py` and docs entry
- add end-to-end integration tests for agent + graph memory wiring

## Validation
- `python -m ruff check src tests examples`
- `python -m pytest tests/agents tests/graph tests/test_v061_features.py -q`

## Notes
- This is PR2 of the #506 split and is intentionally based on `feat/memory-pr1-issue-506`.
- Delivered as a single commit on this branch.
