### PR TITLE
fix(memory): preserve conversation history when summarizer fails

### DIFF
--- a/src/synapsekit/memory/summary_buffer.py
+++ b/src/synapsekit/memory/summary_buffer.py
@@ -67,7 +67,6 @@ class SummaryBufferMemory:
         while self._buffer_tokens() > self._max_tokens and len(self._messages) > 2:
             # Take the oldest pair of messages to summarize
             to_summarize = self._messages[:2]
-            self._messages = self._messages[2:]
 
             conversation = "\n".join(
                 f"{m['role'].capitalize()}: {m['content']}" for m in to_summarize
@@ -81,7 +80,13 @@ class SummaryBufferMemory:
                 )
             else:
                 prompt = f"Summarize this conversation exchange concisely:\n\n{conversation}"
-            self._summary = await self._llm.generate(prompt)
+
+            # Await the LLM first; only mutate state after the summary is
+            # successfully computed. If generate() raises, self._summary and
+            # self._messages are left untouched so the caller can retry.
+            new_summary = await self._llm.generate(prompt)
+            self._summary = new_summary
+            self._messages = self._messages[2:]
 
         result = []
         if self._summary:

--- a/tests/test_v062_features.py
+++ b/tests/test_v062_features.py
@@ -462,6 +462,32 @@ def test_summary_buffer_clear():
     assert mem.summary == ""
 
 
+@pytest.mark.asyncio
+async def test_summary_buffer_preserves_history_on_summarizer_failure():
+    """If the summarizer LLM fails, messages must not be silently dropped."""
+    from synapsekit import SummaryBufferMemory
+
+    mock_llm = AsyncMock()
+    mock_llm.generate = AsyncMock(side_effect=RuntimeError("rate limit"))
+
+    mem = SummaryBufferMemory(llm=mock_llm, max_tokens=100, chars_per_token=1)
+    # Fill the buffer above max_tokens so summarization triggers
+    for i in range(20):
+        mem.add("user", f"This is a longer message number {i} with some content")
+        mem.add("assistant", f"This is a reply to message number {i}")
+
+    initial_len = len(mem)
+
+    with pytest.raises(RuntimeError, match="rate limit"):
+        await mem.get_messages()
+
+    # Invariant: on LLM failure, message buffer is unchanged AND summary is unchanged
+    assert len(mem) == initial_len, (
+        f"Messages were silently dropped on LLM failure: {initial_len} -> {len(mem)}"
+    )
+    assert mem.summary == "", "Summary should remain empty when summarizer failed"
+
+
 # ------------------------------------------------------------------ #
 # Human Input Tool
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary

Fix a silent data-loss bug in `SummaryBufferMemory.get_messages()`: if the summarizer LLM raises (rate limit, timeout, transient error), the two oldest messages are permanently dropped from the buffer but never captured in the summary. Reorder the loop to await the LLM *before* mutating state.

Closes #551

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / internal improvement
- [ ] Dependency / tooling update

## Changes

- `src/synapsekit/memory/summary_buffer.py`: in `get_messages()` loop body, compute `new_summary` via `await self._llm.generate(prompt)` into a local variable, then update `self._summary` and `self._messages` atomically after the await succeeds
- `tests/test_v062_features.py`: add `test_summary_buffer_preserves_history_on_summarizer_failure` — discriminating regression test that fails before the fix and passes after

## Testing

- [x] All existing tests pass (`uv run pytest tests/ -q`) — 2042 passed, 49 skipped
- [x] New test added for the regression
- [x] No API keys or secrets in the code

## Documentation

- [ ] Docstrings updated (if public API changed) — no public API change
- [ ] [synapsekit-docs](https://github.com/SynapseKit/synapsekit-docs) updated (if new feature) — no user-facing feature
- [ ] CHANGELOG.md updated — happy to add an entry if preferred; skipped since recent release-cut PRs (e.g. #538) consolidate entries at release time

## Notes for reviewer

Bug exists on current `main` (v1.5.5). See #551 for the full repro. Minimal: `SummaryBufferMemory(llm=failing_llm)` + add >`max_tokens` worth of messages + call `get_messages()` — observe `len(mem)` drop by 2 per LLM exception before the raise propagates. The added test encodes this exact repro.
