### PR TITLE
fix(rag): preserve memory state when stream consumer disconnects

### DIFF
--- a/src/synapsekit/rag/pipeline.py
+++ b/src/synapsekit/rag/pipeline.py
@@ -102,21 +102,30 @@ class RAGPipeline:
         t0 = tracer.start_timer() if tracer else 0.0
 
         answer_parts: list[str] = []
-        async for token in self.config.llm.stream_with_messages(messages):
-            answer_parts.append(token)
-            yield token
+        try:
+            async for token in self.config.llm.stream_with_messages(messages):
+                answer_parts.append(token)
+                yield token
+        finally:
+            # Commit the turn to memory + tracer only if at least one token
+            # was delivered to the consumer. This preserves the user query
+            # and partial answer when the consumer disconnects early (client
+            # HTTP drop, upstream exception, explicit break) — the finally
+            # runs even when GeneratorExit is raised at the yield point.
+            # The answer_parts guard prevents recording a "ghost turn" when
+            # the LLM call failed before streaming began.
+            if answer_parts:
+                answer = "".join(answer_parts)
+                self.config.memory.add("user", query)
+                self.config.memory.add("assistant", answer)
 
-        answer = "".join(answer_parts)
-        self.config.memory.add("user", query)
-        self.config.memory.add("assistant", answer)
-
-        if tracer:
-            used = self.config.llm.tokens_used
-            tracer.record(
-                input_tokens=used["input"],
-                output_tokens=used["output"],
-                latency_ms=tracer.elapsed_ms(t0),
-            )
+                if tracer:
+                    used = self.config.llm.tokens_used
+                    tracer.record(
+                        input_tokens=used["input"],
+                        output_tokens=used["output"],
+                        latency_ms=tracer.elapsed_ms(t0),
+                    )
 
     async def ask(self, query: str, top_k: int | None = None) -> str:
         return "".join([t async for t in self.stream(query, top_k=top_k)])

--- a/tests/rag/test_pipeline.py
+++ b/tests/rag/test_pipeline.py
@@ -91,6 +91,80 @@ class TestRAGPipeline:
         assert len(tokens) > 0  # LLM still responds
 
     @pytest.mark.asyncio
+    async def test_stream_commits_memory_on_consumer_disconnect(self, pipeline):
+        """Consumer breaks after 1 token and explicitly closes the generator —
+        simulates a streaming-HTTP client disconnect, which causes the ASGI
+        server (starlette/anyio) to call aclose() on the response generator.
+        Memory must still reflect the query and the partial answer the
+        consumer saw. Fails before the fix."""
+        seen = []
+        gen = pipeline.stream("Partial question?")
+        try:
+            async for token in gen:
+                seen.append(token)
+                break  # simulate consumer stopping iteration
+        finally:
+            await gen.aclose()  # simulate ASGI-level disconnect cleanup
+
+        assert seen == ["Hello"]
+        messages = pipeline.config.memory.get_messages()
+        contents = [m["content"] for m in messages]
+        assert "Partial question?" in contents
+        assert "Hello" in contents  # partial answer preserved
+
+    @pytest.mark.asyncio
+    async def test_stream_no_memory_commit_on_pre_stream_failure(self):
+        """If the LLM fails before yielding any token, memory should not
+        record a ghost turn with an empty assistant response."""
+        llm = MagicMock()
+        llm.tokens_used = {"input": 0, "output": 0}
+
+        async def failing_stream(messages, **kw):
+            raise RuntimeError("auth error")
+            yield  # unreachable; marks this as an async generator
+
+        llm.stream_with_messages = failing_stream
+
+        retriever = make_mock_retriever()
+        memory = ConversationMemory()
+        pipeline = RAGPipeline(RAGConfig(llm=llm, retriever=retriever, memory=memory))
+
+        with pytest.raises(RuntimeError, match="auth error"):
+            async for _ in pipeline.stream("Never streams."):
+                pass
+
+        assert len(memory) == 0, "No memory should be recorded when no tokens were emitted"
+
+    @pytest.mark.asyncio
+    async def test_stream_commits_partial_answer_on_mid_stream_llm_failure(self):
+        """If the LLM yields some tokens then raises mid-stream (e.g. transient
+        network error), memory must capture the partial answer the consumer
+        already saw, not silently drop it."""
+        llm = MagicMock()
+        llm.tokens_used = {"input": 10, "output": 5}
+
+        async def partial_failure_stream(messages, **kw):
+            yield "Partial "
+            yield "answer"
+            raise RuntimeError("connection reset")
+
+        llm.stream_with_messages = partial_failure_stream
+
+        retriever = make_mock_retriever()
+        memory = ConversationMemory()
+        pipeline = RAGPipeline(RAGConfig(llm=llm, retriever=retriever, memory=memory))
+
+        seen = []
+        with pytest.raises(RuntimeError, match="connection reset"):
+            async for token in pipeline.stream("Mid-stream failure?"):
+                seen.append(token)
+
+        assert seen == ["Partial ", "answer"]
+        contents = [m["content"] for m in memory.get_messages()]
+        assert "Mid-stream failure?" in contents
+        assert "Partial answer" in contents  # partial answer preserved despite LLM error
+
+    @pytest.mark.asyncio
     async def test_add_chunks_text(self):
         llm = make_mock_llm()
         retriever = make_mock_retriever()


### PR DESCRIPTION
## Summary

Fix silent data loss in `RAGPipeline.stream()`: if the consumer exits the async generator early (client disconnect, upstream exception, explicit `break`), or if the LLM raises mid-stream, the memory-update and tracer-record calls after the loop never execute, even though tokens have already been delivered to the consumer. Wrap the loop in `try/finally` and commit state when at least one token was emitted.

Closes #553

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / internal improvement
- [ ] Dependency / tooling update

## Changes

- `src/synapsekit/rag/pipeline.py`: wrap the `async for token` loop in `try/finally`; commit `memory.add(user/assistant)` and `tracer.record(...)` from `finally` when `answer_parts` is non-empty, so early-disconnect consumers (and mid-stream LLM failures) preserve the conversation turn they saw
- `tests/rag/test_pipeline.py`: add three regression tests — `test_stream_commits_memory_on_consumer_disconnect`, `test_stream_no_memory_commit_on_pre_stream_failure`, `test_stream_commits_partial_answer_on_mid_stream_llm_failure`

## Testing

- [x] All existing tests pass (`uv run pytest tests/ -q`) — 2044 passed, 49 skipped
- [x] New tests added for the regression
- [x] No API keys or secrets in the code

## Documentation

- [ ] Docstrings updated (if public API changed) — no public API change
- [ ] [synapsekit-docs](https://github.com/SynapseKit/synapsekit-docs) updated (if new feature) — no user-facing feature
- [ ] CHANGELOG.md updated — happy to add if preferred; skipped since release-cut PRs (e.g. #538) consolidate entries at release time

## Notes for reviewer

Sibling fix to #552 (PR A, `fix(memory): preserve conversation history when summarizer fails`) — same bug class, different subsystem. Discriminating repro is described in the linked issue.

**One minor behavior change worth flagging:** the `if answer_parts:` guard in `finally` also suppresses the memory+tracer write when a stream completes normally with zero tokens emitted (pathological case — LLM returns empty response). Old code would record `("assistant", "")` and a zero-token tracer call in that case; new code skips. Happy to split memory and tracer guards if you'd prefer to preserve the exact old tracer behavior for zero-token-success streams, but recording an empty assistant turn seemed of questionable value.

The disconnect test explicitly calls `gen.aclose()` in a `finally` around the `async for` — this accurately simulates what starlette/ASGI does when a streaming-HTTP client disconnects, which was the motivating scenario for this fix.
