### PR TITLE
feat(Loader): Added sitemap loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,8 @@ dev = [
     "pydantic>=2.12.5",
     "httpx>=0.27",
     "pyarrow>=23.0.1",
+    "lxml>=6.0.2",
+    "beautifulsoup4>=4.14.3",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -385,6 +385,7 @@ __all__ = [
     "RTFLoader",
     "RedisLoader",
     "S3Loader",
+    "SitemapLoader",
     "WikipediaLoader",
     "ExcelLoader",
     "PowerPointLoader",
@@ -646,6 +647,7 @@ _LAZY_IMPORTS = {
     "ParquetLoader": "loaders.parquet",
     "RedisLoader": "loaders.redis_loader",
     "ElasticsearchLoader": "loaders.elasticsearch",
+    "SitemapLoader": "loaders.sitemap",
 }
 
 

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -43,6 +43,7 @@ __all__ = [
     "RTFLoader",
     "RedisLoader",
     "S3Loader",
+    "SitemapLoader",
     "SQLLoader",
     "SlackLoader",
     "StringLoader",
@@ -100,6 +101,7 @@ _LOADERS = {
     "ParquetLoader": ".parquet",
     "RedisLoader": ".redis_loader",
     "ElasticsearchLoader": ".elasticsearch",
+    "SitemapLoader": ".sitemap",
 }
 
 

--- a/src/synapsekit/loaders/sitemap.py
+++ b/src/synapsekit/loaders/sitemap.py
@@ -85,9 +85,7 @@ class SitemapLoader:
             raise ValueError("url must be provided")
         parsed = urlparse(url)
         if parsed.scheme not in ("http", "https"):
-            raise ValueError(
-                f"URL scheme {parsed.scheme!r} is not allowed; use http or https."
-            )
+            raise ValueError(f"URL scheme {parsed.scheme!r} is not allowed; use http or https.")
 
         self._url = url
         self._limit = limit
@@ -107,11 +105,7 @@ class SitemapLoader:
         url_entries = await self._collect_urls(httpx)
 
         if self._filter_urls:
-            url_entries = [
-                e
-                for e in url_entries
-                if any(f in e["loc"] for f in self._filter_urls)
-            ]
+            url_entries = [e for e in url_entries if any(f in e["loc"] for f in self._filter_urls)]
 
         if self._limit is not None:
             url_entries = url_entries[: self._limit]

--- a/src/synapsekit/loaders/sitemap.py
+++ b/src/synapsekit/loaders/sitemap.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+from .base import Document
+
+_MAX_TEXT_LENGTH = 100_000
+_MAX_CONCURRENCY = 10
+_DEFAULT_TIMEOUT = 30
+
+
+def _extract_text(html: str) -> str:
+    # Best-effort HTML to text extraction
+    from bs4 import BeautifulSoup
+
+    try:
+        soup = BeautifulSoup(html, "lxml")
+    except Exception:
+        soup = BeautifulSoup(html, "html.parser")
+    for tag in soup(["script", "style"]):
+        tag.decompose()
+    return soup.get_text(separator=" ", strip=True)[:_MAX_TEXT_LENGTH]
+
+
+def _parse_sitemap(xml: str, base_url: str) -> tuple[list[dict[str, str]], list[str]]:
+    """Return (url_entries, sitemap_index_urls).
+
+    *url_entries* — list of ``{"loc": ..., "lastmod": ...}`` dicts from ``<url>`` tags.
+    *sitemap_index_urls* — list of child sitemap URLs from ``<sitemap>`` tags.
+    """
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(xml, "lxml-xml")
+
+    # Sitemap index — contains nested <sitemap> entries
+    index_urls = [
+        urljoin(base_url, tag.find("loc").get_text(strip=True))
+        for tag in soup.find_all("sitemap")
+        if tag.find("loc")
+    ]
+
+    # Regular sitemap — contains <url> entries
+    url_entries: list[dict[str, str]] = []
+    for tag in soup.find_all("url"):
+        loc_tag = tag.find("loc")
+        if not loc_tag:
+            continue
+        lastmod_tag = tag.find("lastmod")
+        url_entries.append(
+            {
+                "loc": loc_tag.get_text(strip=True),
+                "lastmod": lastmod_tag.get_text(strip=True) if lastmod_tag else "",
+            }
+        )
+
+    return url_entries, index_urls
+
+
+class SitemapLoader:
+    """Discover and load pages from a website's sitemap.xml.
+
+    Supports both regular sitemaps and sitemap index files (nested sitemaps).
+    Each discovered page is fetched and its text is extracted as a
+    :class:`Document` with ``source``, ``url``, and ``lastmod`` metadata.
+
+    Parameters
+    ----------
+    url : str
+        URL of the sitemap — typically ``https://example.com/sitemap.xml``.
+    limit : int | None
+        Maximum number of pages to fetch (applied after URL discovery).
+    filter_urls : list[str] | None
+        Only load URLs that contain one of these substrings.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        limit: int | None = None,
+        filter_urls: list[str] | None = None,
+    ) -> None:
+        if not url:
+            raise ValueError("url must be provided")
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(
+                f"URL scheme {parsed.scheme!r} is not allowed; use http or https."
+            )
+
+        self._url = url
+        self._limit = limit
+        self._filter_urls = filter_urls
+
+    def load(self) -> list[Document]:
+        """Synchronous entry point."""
+        return asyncio.run(self.aload())
+
+    async def aload(self) -> list[Document]:
+        """Discover sitemap URLs then fetch pages concurrently in batches."""
+        try:
+            import httpx
+        except ImportError:
+            raise ImportError("httpx required: pip install synapsekit[web]") from None
+
+        url_entries = await self._collect_urls(httpx)
+
+        if self._filter_urls:
+            url_entries = [
+                e
+                for e in url_entries
+                if any(f in e["loc"] for f in self._filter_urls)
+            ]
+
+        if self._limit is not None:
+            url_entries = url_entries[: self._limit]
+
+        if not url_entries:
+            return []
+
+        docs: list[Document] = []
+        async with httpx.AsyncClient(follow_redirects=True, timeout=_DEFAULT_TIMEOUT) as client:
+            for i in range(0, len(url_entries), _MAX_CONCURRENCY):
+                batch = url_entries[i : i + _MAX_CONCURRENCY]
+                tasks = [self._fetch_page(client, entry) for entry in batch]
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+                for result in results:
+                    # Skip failed pages (network errors, parsing issues)
+                    # NOTE: failures are intentionally ignored for robustness
+                    if isinstance(result, Exception):
+                        continue
+                    if result:
+                        docs.append(result)
+
+        return docs
+
+    async def _collect_urls(self, httpx: Any) -> list[dict[str, str]]:
+        """Fetch and parse sitemaps, following sitemap index files."""
+        base_url = "{0.scheme}://{0.netloc}".format(urlparse(self._url))
+        to_visit: list[str] = [self._url]
+        visited: set[str] = set()
+        seen: set[str] = set()
+        all_entries: list[dict[str, str]] = []
+
+        async with httpx.AsyncClient(follow_redirects=True, timeout=_DEFAULT_TIMEOUT) as client:
+            while to_visit:
+                sitemap_url = to_visit.pop(0)
+                if sitemap_url in visited:
+                    continue
+                visited.add(sitemap_url)
+
+                try:
+                    resp = await client.get(sitemap_url)
+                    resp.raise_for_status()
+                except Exception:
+                    # Skip invalid or unreachable sitemap URLs
+                    continue
+
+                url_entries, index_urls = _parse_sitemap(resp.text, base_url)
+                for e in url_entries:
+                    loc = e.get("loc")
+                    if loc and loc not in seen:
+                        seen.add(loc)
+                        all_entries.append(e)
+                # Queue unvisited child sitemaps
+                to_visit.extend(u for u in index_urls if u not in visited)
+
+        return all_entries
+
+    async def _fetch_page(self, client: Any, entry: dict[str, str]) -> Document | None:
+        """Fetch a single page and return a Document, or None on failure."""
+        url = entry.get("loc")
+        if not url:
+            return None
+        try:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            text = _extract_text(resp.text)
+            if not text:
+                return None
+            return Document(
+                text=text,
+                metadata={
+                    "source": "sitemap",
+                    "url": url,
+                    "lastmod": entry.get("lastmod", ""),
+                },
+            )
+        except Exception:
+            return None

--- a/src/synapsekit/loaders/sitemap.py
+++ b/src/synapsekit/loaders/sitemap.py
@@ -36,9 +36,9 @@ def _parse_sitemap(xml: str, base_url: str) -> tuple[list[dict[str, str]], list[
 
     # Sitemap index — contains nested <sitemap> entries
     index_urls = [
-        urljoin(base_url, tag.find("loc").get_text(strip=True))
+        urljoin(base_url, loc_tag.get_text(strip=True))
         for tag in soup.find_all("sitemap")
-        if tag.find("loc")
+        if (loc_tag := tag.find("loc"))
     ]
 
     # Regular sitemap — contains <url> entries
@@ -130,7 +130,7 @@ class SitemapLoader:
                     # NOTE: failures are intentionally ignored for robustness
                     if isinstance(result, Exception):
                         continue
-                    if result:
+                    if isinstance(result, Document):
                         docs.append(result)
 
         return docs

--- a/tests/loaders/test_sitemap_loader.py
+++ b/tests/loaders/test_sitemap_loader.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from synapsekit.loaders import Document
+from synapsekit.loaders.sitemap import SitemapLoader, _parse_sitemap
+
+
+# ---------------------------------------------------------------------------
+# Sitemap XML fixtures
+# ---------------------------------------------------------------------------
+
+SIMPLE_SITEMAP = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/page1</loc>
+    <lastmod>2024-01-01</lastmod>
+  </url>
+  <url>
+    <loc>https://example.com/page2</loc>
+  </url>
+</urlset>
+"""
+
+SITEMAP_INDEX = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://example.com/sitemap-posts.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://example.com/sitemap-pages.xml</loc>
+  </sitemap>
+</sitemapindex>
+"""
+
+CHILD_SITEMAP = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/post/1</loc>
+    <lastmod>2024-03-01</lastmod>
+  </url>
+</urlset>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Initialisation validation
+# ---------------------------------------------------------------------------
+
+
+def test_init_requires_url() -> None:
+    with pytest.raises(ValueError, match="url must be provided"):
+        SitemapLoader(url="")
+
+
+def test_init_rejects_non_http_scheme() -> None:
+    with pytest.raises(ValueError, match="not allowed"):
+        SitemapLoader(url="ftp://example.com/sitemap.xml")
+
+
+def test_init_defaults() -> None:
+    loader = SitemapLoader(url="https://example.com/sitemap.xml")
+    assert loader._limit is None
+    assert loader._filter_urls is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_sitemap unit tests (pure, no HTTP)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_sitemap_url_entries() -> None:
+    pytest.importorskip("bs4")
+    pytest.importorskip("lxml")
+
+    entries, index_urls = _parse_sitemap(SIMPLE_SITEMAP, "https://example.com")
+
+    assert len(entries) == 2
+    assert entries[0]["loc"] == "https://example.com/page1"
+    assert entries[0]["lastmod"] == "2024-01-01"
+    assert entries[1]["loc"] == "https://example.com/page2"
+    assert entries[1]["lastmod"] == ""
+    assert index_urls == []
+
+
+def test_parse_sitemap_index() -> None:
+    pytest.importorskip("bs4")
+    pytest.importorskip("lxml")
+
+    entries, index_urls = _parse_sitemap(SITEMAP_INDEX, "https://example.com")
+
+    assert entries == []
+    assert "https://example.com/sitemap-posts.xml" in index_urls
+    assert "https://example.com/sitemap-pages.xml" in index_urls
+
+
+# ---------------------------------------------------------------------------
+# Missing dependencies
+# ---------------------------------------------------------------------------
+
+
+def test_load_import_error_missing_httpx() -> None:
+    with patch.dict("sys.modules", {"httpx": None}):
+        loader = SitemapLoader(url="https://example.com/sitemap.xml")
+        with pytest.raises(ImportError, match="httpx required"):
+            loader.load()
+
+
+# ---------------------------------------------------------------------------
+# Normal load (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+def _make_response(text: str, status: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.text = text
+    resp.status_code = status
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _make_async_client(responses: dict[str, str]) -> MagicMock:
+    """Build a mock AsyncClient whose .get() returns different bodies per URL."""
+
+    async def fake_get(url: str, **kwargs: object) -> MagicMock:
+        body = responses.get(url, "")
+        return _make_response(body)
+
+    client = MagicMock()
+    client.get = fake_get
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+PAGE_HTML = "<html><body><p>Hello from page one</p></body></html>"
+PAGE2_HTML = "<html><body><p>Content of page two</p></body></html>"
+
+
+def test_load_returns_documents() -> None:
+    pytest.importorskip("bs4")
+    pytest.importorskip("lxml")
+
+    responses = {
+        "https://example.com/sitemap.xml": SIMPLE_SITEMAP,
+        "https://example.com/page1": PAGE_HTML,
+        "https://example.com/page2": PAGE2_HTML,
+    }
+    mock_httpx = MagicMock()
+    mock_httpx.AsyncClient.return_value = _make_async_client(responses)
+
+    with patch.dict("sys.modules", {"httpx": mock_httpx}):
+        loader = SitemapLoader(url="https://example.com/sitemap.xml")
+        docs = loader.load()
+
+    assert len(docs) == 2
+    assert all(isinstance(d, Document) for d in docs)
+
+
+def test_load_metadata_correctness() -> None:
+    pytest.importorskip("bs4")
+    pytest.importorskip("lxml")
+
+    responses = {
+        "https://example.com/sitemap.xml": SIMPLE_SITEMAP,
+        "https://example.com/page1": PAGE_HTML,
+        "https://example.com/page2": PAGE2_HTML,
+    }
+    mock_httpx = MagicMock()
+    mock_httpx.AsyncClient.return_value = _make_async_client(responses)
+
+    with patch.dict("sys.modules", {"httpx": mock_httpx}):
+        loader = SitemapLoader(url="https://example.com/sitemap.xml")
+        docs = loader.load()
+
+    page1 = next(d for d in docs if d.metadata["url"] == "https://example.com/page1")
+    assert page1.metadata["source"] == "sitemap"
+    assert page1.metadata["lastmod"] == "2024-01-01"
+
+
+def test_load_respects_limit() -> None:
+    pytest.importorskip("bs4")
+    pytest.importorskip("lxml")
+
+    responses = {
+        "https://example.com/sitemap.xml": SIMPLE_SITEMAP,
+        "https://example.com/page1": PAGE_HTML,
+    }
+    mock_httpx = MagicMock()
+    mock_httpx.AsyncClient.return_value = _make_async_client(responses)
+
+    with patch.dict("sys.modules", {"httpx": mock_httpx}):
+        loader = SitemapLoader(url="https://example.com/sitemap.xml", limit=1)
+        docs = loader.load()
+
+    assert len(docs) == 1
+
+
+def test_load_filter_urls() -> None:
+    pytest.importorskip("bs4")
+    pytest.importorskip("lxml")
+
+    responses = {
+        "https://example.com/sitemap.xml": SIMPLE_SITEMAP,
+        "https://example.com/page1": PAGE_HTML,
+    }
+    mock_httpx = MagicMock()
+    mock_httpx.AsyncClient.return_value = _make_async_client(responses)
+
+    with patch.dict("sys.modules", {"httpx": mock_httpx}):
+        loader = SitemapLoader(
+            url="https://example.com/sitemap.xml",
+            filter_urls=["page1"],
+        )
+        docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].metadata["url"] == "https://example.com/page1"
+
+
+def test_load_empty_sitemap() -> None:
+    pytest.importorskip("bs4")
+    pytest.importorskip("lxml")
+
+    empty_sitemap = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+</urlset>
+"""
+    mock_httpx = MagicMock()
+    mock_httpx.AsyncClient.return_value = _make_async_client(
+        {"https://example.com/sitemap.xml": empty_sitemap}
+    )
+
+    with patch.dict("sys.modules", {"httpx": mock_httpx}):
+        loader = SitemapLoader(url="https://example.com/sitemap.xml")
+        docs = loader.load()
+
+    assert docs == []
+
+
+def test_load_sitemap_index_follows_children() -> None:
+    pytest.importorskip("bs4")
+    pytest.importorskip("lxml")
+
+    responses = {
+        "https://example.com/sitemap.xml": SITEMAP_INDEX,
+        "https://example.com/sitemap-posts.xml": CHILD_SITEMAP,
+        "https://example.com/sitemap-pages.xml": (
+            '<?xml version="1.0"?>'
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+            "<url><loc>https://example.com/about</loc></url>"
+            "</urlset>"
+        ),
+        "https://example.com/post/1": "<html><body><p>Post one</p></body></html>",
+        "https://example.com/about": "<html><body><p>About page</p></body></html>",
+    }
+    mock_httpx = MagicMock()
+    mock_httpx.AsyncClient.return_value = _make_async_client(responses)
+
+    with patch.dict("sys.modules", {"httpx": mock_httpx}):
+        loader = SitemapLoader(url="https://example.com/sitemap.xml")
+        docs = loader.load()
+
+    urls = {d.metadata["url"] for d in docs}
+    assert "https://example.com/post/1" in urls
+    assert "https://example.com/about" in urls
+
+
+def test_load_skips_failed_pages() -> None:
+    pytest.importorskip("bs4")
+    pytest.importorskip("lxml")
+
+    # page2 raises an exception — should be silently skipped
+    async def fake_get(url: str, **kwargs: object) -> MagicMock:
+        if url == "https://example.com/sitemap.xml":
+            return _make_response(SIMPLE_SITEMAP)
+        if url == "https://example.com/page1":
+            return _make_response(PAGE_HTML)
+        raise ConnectionError("network error")
+
+    client = MagicMock()
+    client.get = fake_get
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+
+    mock_httpx = MagicMock()
+    mock_httpx.AsyncClient.return_value = client
+
+    with patch.dict("sys.modules", {"httpx": mock_httpx}):
+        loader = SitemapLoader(url="https://example.com/sitemap.xml")
+        docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].metadata["url"] == "https://example.com/page1"

--- a/tests/loaders/test_sitemap_loader.py
+++ b/tests/loaders/test_sitemap_loader.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from synapsekit.loaders import Document
 from synapsekit.loaders.sitemap import SitemapLoader, _parse_sitemap
-
 
 # ---------------------------------------------------------------------------
 # Sitemap XML fixtures

--- a/tests/preflight/test_preflight.py
+++ b/tests/preflight/test_preflight.py
@@ -179,6 +179,7 @@ LOADER_NAMES = [
     "RTFLoader",
     "RedisLoader",
     "S3Loader",
+    "SitemapLoader",
     "SQLLoader",
     "SlackLoader",
     "StringLoader",
@@ -202,7 +203,7 @@ def test_all_loaders_in_all_list():
 
 
 def test_loader_count_matches_spec():
-    """We have exactly 46 names in the loaders __all__ (includes Document + StringLoader)."""
+    """We have exactly 47 names in the loaders __all__ (includes Document + StringLoader)."""
     import synapsekit.loaders as loaders_mod
 
     assert len(loaders_mod.__all__) == len(LOADER_NAMES)

--- a/uv.lock
+++ b/uv.lock
@@ -7910,9 +7910,11 @@ youtube = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "beautifulsoup4" },
     { name = "deptry" },
     { name = "hatchling" },
     { name = "httpx" },
+    { name = "lxml" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pyarrow" },
@@ -8066,9 +8068,11 @@ provides-extras = ["openai", "anthropic", "semantic", "colbert", "pdf", "wikiped
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "deptry", specifier = ">=0.16" },
     { name = "hatchling" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "lxml", specifier = ">=6.0.2" },
     { name = "mypy", specifier = ">=1.11" },
     { name = "pre-commit", specifier = ">=3.7" },
     { name = "pyarrow", specifier = ">=23.0.1" },


### PR DESCRIPTION
## Summary

Implements `SitemapLoader`, a new data loader that discovers all pages from a website's `sitemap.xml` (including nested sitemap index files), fetches each page, and returns a `list[Document]` with URL and lastmod metadata. 

Closes #71 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / internal improvement
- [ ] Dependency / tooling update

## Changes

- Added `src/synapsekit/loaders/sitemap.py`: `SitemapLoader` with sync `load()` + `async aload()`; lazy-imports `httpx` (raises clear `ImportError` if missing); recursively follows sitemap index files (BFS with visited-set to prevent cycles); fetches pages concurrently in batches of 10 (`_MAX_CONCURRENCY`); supports `filter_urls` (substring matching) and `limit`; URL deduplication via `seen` set in `_collect_urls`; `_fetch_page` returns `Document | None` (never raises failures silently skipped for robustness); safe BeautifulSoup parser fallback (`lxml` → `html.parser`); `_DEFAULT_TIMEOUT = 30` constant; HTTP/HTTPS scheme validation on init; metadata includes `source`, `url`, `lastmod`
- Added `tests/loaders/test_sitemap_loader.py`: 13 tests covering init validation, scheme rejection, `_parse_sitemap` unit tests (no HTTP), missing httpx, document output, metadata correctness, `limit`, `filter_urls`, empty sitemap, sitemap index following, and failed-page skipping; all HTTP mocked via `patch.dict("sys.modules")`
- Registered `SitemapLoader` in `src/synapsekit/loaders/__init__.py` (`__all__` + `_LOADERS`)
- Registered `SitemapLoader` in `src/synapsekit/__init__.py` (`__all__` + `_LAZY_IMPORTS`)
- Updated `tests/preflight/test_preflight.py`: added `SitemapLoader` to `LOADER_NAMES` spec and bumped expected count from 46 → 47

## Testing

- [x] All existing tests pass (`uv run pytest tests/ -q`)
- [x] New tests added for new behaviour
- [x] No API keys or secrets in the code