### PR TITLE
feat(loaders): add SalesforceLoader (issue #89)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ gsheets = ["google-api-python-client>=2.0", "google-auth>=2.0"]
 jira = ["httpx>=0.27"]
 sql = ["sqlalchemy>=2.0"]
 mongodb = ["pymongo>=4.0"]
+salesforce = ["simple-salesforce>=1.12"]
 azure = ["azure-storage-blob>=12.0"]
 s3 = ["boto3>=1.34"]
 onedrive = []
@@ -166,6 +167,7 @@ all = [
     "gitpython>=3.1",
     "supabase>=2.0",
     "pymongo>=4.0",
+    "simple-salesforce>=1.12",
     "azure-storage-blob>=12.0",
     "elasticsearch>=8.0",
 ]
@@ -305,6 +307,7 @@ slack-sdk = "slack_sdk"
 weaviate-client = "weaviate"
 atlassian-python-api = "atlassian"
 gitpython = "git"
+simple-salesforce = "simple_salesforce"
 azure-storage-blob = "azure"
 sqlite-vec = "sqlite_vec"
 

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -178,6 +178,7 @@ from .loaders.pdf import PDFLoader
 from .loaders.rss import RSSLoader
 from .loaders.rtf import RTFLoader
 from .loaders.s3 import S3Loader
+from .loaders.salesforce import SalesforceLoader
 from .loaders.sql import SQLLoader
 from .loaders.teams import TeamsLoader
 from .loaders.text import StringLoader, TextLoader
@@ -385,6 +386,7 @@ __all__ = [
     "RTFLoader",
     "RedisLoader",
     "S3Loader",
+    "SalesforceLoader",
     "WikipediaLoader",
     "ExcelLoader",
     "PowerPointLoader",
@@ -642,6 +644,7 @@ _LAZY_IMPORTS = {
     "OneDriveLoader": "loaders.onedrive",
     "AzureBlobLoader": "loaders.azure_blob",
     "S3Loader": "loaders.s3",
+    "SalesforceLoader": "loaders.salesforce",
     "DropboxLoader": "loaders.dropbox",
     "ParquetLoader": "loaders.parquet",
     "RedisLoader": "loaders.redis_loader",

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -6,6 +6,7 @@ from .markdown import MarkdownLoader
 from .mongodb import MongoDBLoader
 from .onedrive import OneDriveLoader
 from .s3 import S3Loader
+from .salesforce import SalesforceLoader
 from .text import StringLoader, TextLoader
 
 __all__ = [
@@ -43,6 +44,7 @@ __all__ = [
     "RTFLoader",
     "RedisLoader",
     "S3Loader",
+    "SalesforceLoader",
     "SQLLoader",
     "SlackLoader",
     "StringLoader",
@@ -88,6 +90,7 @@ _LOADERS = {
     "RSSLoader": ".rss",
     "RTFLoader": ".rtf",
     "S3Loader": ".s3",
+    "SalesforceLoader": ".salesforce",
     "SQLLoader": ".sql",
     "SupabaseLoader": ".supabase",
     "TeamsLoader": ".teams",

--- a/src/synapsekit/loaders/salesforce.py
+++ b/src/synapsekit/loaders/salesforce.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from typing import Any
+
+from .base import Document
+
+
+class SalesforceLoader:
+    """Load Salesforce records via SOQL query."""
+
+    def __init__(
+        self,
+        soql_query: str,
+        username: str | None = None,
+        password: str | None = None,
+        security_token: str | None = None,
+        domain: str = "login",
+        text_fields: list[str] | None = None,
+        metadata_fields: list[str] | None = None,
+        client: Any | None = None,
+    ) -> None:
+        if not soql_query:
+            raise ValueError("soql_query must be provided")
+
+        if client is None and (not username or not password or not security_token):
+            raise ValueError(
+                "username, password, and security_token are required unless client is provided"
+            )
+
+        self._soql_query = soql_query
+        self._username = username
+        self._password = password
+        self._security_token = security_token
+        self._domain = domain
+        self._text_fields = text_fields
+        self._metadata_fields = metadata_fields
+        self._client = client
+
+    def load(self) -> list[Document]:
+        client = self._client
+        if client is None:
+            try:
+                from simple_salesforce import Salesforce
+            except ImportError:
+                raise ImportError(
+                    "simple-salesforce required: pip install synapsekit[salesforce]"
+                ) from None
+
+            client = Salesforce(
+                username=self._username,
+                password=self._password,
+                security_token=self._security_token,
+                domain=self._domain,
+            )
+
+        result = client.query_all(self._soql_query)
+        records = result.get("records", []) if isinstance(result, Mapping) else []
+
+        docs: list[Document] = []
+        for idx, raw_record in enumerate(records):
+            if not isinstance(raw_record, Mapping):
+                continue
+
+            clean_record = {k: v for k, v in raw_record.items() if k != "attributes"}
+            text = self._build_text(clean_record)
+            metadata = self._build_metadata(clean_record, raw_record.get("attributes"), idx)
+            docs.append(Document(text=text, metadata=metadata))
+
+        return docs
+
+    async def aload(self) -> list[Document]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.load)
+
+    def _build_text(self, record: Mapping[str, Any]) -> str:
+        if self._text_fields:
+            parts = []
+            for field in self._text_fields:
+                value = record.get(field, "")
+                safe_value = "" if value is None else str(value)
+                parts.append(f"{field}: {safe_value}")
+            return "\n".join(parts)
+
+        return "\n".join(f"{k}: {v}" for k, v in record.items())
+
+    def _build_metadata(
+        self,
+        record: Mapping[str, Any],
+        attributes: Any,
+        row: int,
+    ) -> dict[str, Any]:
+        metadata: dict[str, Any] = {
+            "source": "salesforce",
+            "query": self._soql_query,
+            "row": row,
+        }
+
+        if isinstance(attributes, Mapping) and "type" in attributes:
+            metadata["object"] = attributes["type"]
+
+        if self._metadata_fields:
+            for field in self._metadata_fields:
+                if field in record:
+                    metadata[field] = record[field]
+        else:
+            metadata.update(record)
+
+        return metadata

--- a/tests/loaders/test_salesforce_loader.py
+++ b/tests/loaders/test_salesforce_loader.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapsekit.loaders import Document, SalesforceLoader
+
+
+def test_init_requires_soql_query() -> None:
+    with pytest.raises(ValueError, match="soql_query must be provided"):
+        SalesforceLoader(
+            soql_query="",
+            username="user@example.com",
+            password="secret",
+            security_token="token",
+        )
+
+
+def test_init_requires_credentials_without_client() -> None:
+    with pytest.raises(ValueError, match="username, password, and security_token are required"):
+        SalesforceLoader(soql_query="SELECT Id FROM Account")
+
+
+def test_load_import_error_missing_simple_salesforce() -> None:
+    with patch.dict("sys.modules", {"simple_salesforce": None}):
+        loader = SalesforceLoader(
+            soql_query="SELECT Id FROM Account",
+            username="user@example.com",
+            password="secret",
+            security_token="token",
+        )
+        with pytest.raises(ImportError, match="simple-salesforce required"):
+            loader.load()
+
+
+@patch.dict("sys.modules", {"simple_salesforce": MagicMock()})
+def test_load_with_credentials_and_default_text_metadata() -> None:
+    import sys
+
+    mock_salesforce_cls = sys.modules["simple_salesforce"].Salesforce
+    mock_client = MagicMock()
+    mock_salesforce_cls.return_value = mock_client
+
+    query = "SELECT Id, Name, Industry FROM Account"
+    mock_client.query_all.return_value = {
+        "records": [
+            {
+                "attributes": {
+                    "type": "Account",
+                    "url": "/services/data/v60.0/sobjects/Account/001",
+                },
+                "Id": "001",
+                "Name": "Acme",
+                "Industry": "Technology",
+            }
+        ]
+    }
+
+    loader = SalesforceLoader(
+        soql_query=query,
+        username="user@example.com",
+        password="secret",
+        security_token="token",
+    )
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert isinstance(docs[0], Document)
+    assert "Id: 001" in docs[0].text
+    assert "Name: Acme" in docs[0].text
+    assert docs[0].metadata["source"] == "salesforce"
+    assert docs[0].metadata["query"] == query
+    assert docs[0].metadata["row"] == 0
+    assert docs[0].metadata["object"] == "Account"
+    assert docs[0].metadata["Id"] == "001"
+
+    mock_salesforce_cls.assert_called_once_with(
+        username="user@example.com",
+        password="secret",
+        security_token="token",
+        domain="login",
+    )
+    mock_client.query_all.assert_called_once_with(query)
+
+
+def test_load_with_injected_client_and_field_selection() -> None:
+    mock_client = MagicMock()
+    mock_client.query_all.return_value = {
+        "records": [
+            {
+                "attributes": {"type": "Lead"},
+                "Id": "00Q1",
+                "Name": "Alex",
+                "Description": None,
+                "OwnerId": "005X",
+                "Company": "Acme",
+            }
+        ]
+    }
+
+    loader = SalesforceLoader(
+        soql_query="SELECT Id, Name, Description, OwnerId FROM Lead",
+        client=mock_client,
+        text_fields=["Name", "Description"],
+        metadata_fields=["Id", "OwnerId"],
+    )
+
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].text == "Name: Alex\nDescription: "
+    assert docs[0].metadata["source"] == "salesforce"
+    assert docs[0].metadata["object"] == "Lead"
+    assert docs[0].metadata["Id"] == "00Q1"
+    assert docs[0].metadata["OwnerId"] == "005X"
+    assert "Company" not in docs[0].metadata
+
+
+def test_aload() -> None:
+    mock_client = MagicMock()
+    mock_client.query_all.return_value = {
+        "records": [{"attributes": {"type": "Contact"}, "Id": "003A", "Name": "Taylor"}]
+    }
+
+    loader = SalesforceLoader(
+        soql_query="SELECT Id, Name FROM Contact",
+        client=mock_client,
+        text_fields=["Name"],
+    )
+
+    docs = asyncio.run(loader.aload())
+    assert len(docs) == 1
+    assert docs[0].text == "Name: Taylor"
+
+
+def test_load_skips_non_mapping_records() -> None:
+    mock_client = MagicMock()
+    mock_client.query_all.return_value = {
+        "records": [
+            "not-a-record",
+            {"attributes": {"type": "Contact"}, "Id": "003A", "Name": "Taylor"},
+        ]
+    }
+
+    loader = SalesforceLoader(
+        soql_query="SELECT Id, Name FROM Contact",
+        client=mock_client,
+        text_fields=["Name"],
+    )
+
+    docs = loader.load()
+    assert len(docs) == 1
+    assert docs[0].metadata["object"] == "Contact"
+
+
+def test_exports_from_synapsekit_and_loaders_modules() -> None:
+    import synapsekit
+    from synapsekit.loaders import __all__ as loaders_all
+
+    loaders = importlib.import_module("synapsekit.loaders")
+
+    assert "SalesforceLoader" in synapsekit.__all__
+    assert "SalesforceLoader" in loaders_all
+    assert "SalesforceLoader" in loaders.__all__
+    assert hasattr(synapsekit, "SalesforceLoader")
+    assert hasattr(loaders, "SalesforceLoader")

--- a/tests/preflight/test_preflight.py
+++ b/tests/preflight/test_preflight.py
@@ -179,6 +179,7 @@ LOADER_NAMES = [
     "RTFLoader",
     "RedisLoader",
     "S3Loader",
+    "SalesforceLoader",
     "SQLLoader",
     "SlackLoader",
     "StringLoader",
@@ -202,7 +203,7 @@ def test_all_loaders_in_all_list():
 
 
 def test_loader_count_matches_spec():
-    """We have exactly 46 names in the loaders __all__ (includes Document + StringLoader)."""
+    """We have exactly 47 names in the loaders __all__ (includes Document + StringLoader)."""
     import synapsekit.loaders as loaders_mod
 
     assert len(loaders_mod.__all__) == len(LOADER_NAMES)


### PR DESCRIPTION
## Summary
- add `SalesforceLoader` to load records from Salesforce using SOQL (`query_all`)
- support auth credentials (`username`, `password`, `security_token`, `domain`) or injected client for testing
- convert Salesforce records into `list[Document]` with robust metadata
- add optional dependency: `salesforce = ["simple-salesforce>=1.12"]`
- wire exports in `synapsekit.loaders` and top-level `synapsekit`

## Commit split
1. `feat(loaders): add SalesforceLoader with SOQL support (#89)`
2. `test(loaders): cover SalesforceLoader scenarios (#89)`

## Validation
- `python -m ruff check src tests`
- `python -m ruff format --check src tests`
- `python -m pytest tests/loaders -q`

Closes #89
