### PR TITLE
feat(Loader): Added Youtube transcript doc loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ rtf = ["striprtf>=0.0.26"]
 epub = ["ebooklib>=0.18"]
 parquet = ["pyarrow>=14.0"]
 elasticsearch = ["elasticsearch>=8.0"]
+youtube_transcript = ["youtube-transcript-api>=0.6"]
 all = [
     "openai>=1.0",
     "anthropic>=0.25",

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -389,6 +389,8 @@ __all__ = [
     "ExcelLoader",
     "PowerPointLoader",
     "ParquetLoader",
+    "SitemapLoader",
+    "YouTubeLoader",
     # Parsers
     "JSONParser",
     "PydanticParser",
@@ -646,6 +648,8 @@ _LAZY_IMPORTS = {
     "ParquetLoader": "loaders.parquet",
     "RedisLoader": "loaders.redis_loader",
     "ElasticsearchLoader": "loaders.elasticsearch",
+    "SitemapLoader": "loaders.sitemap",
+    "YouTubeLoader": "loaders.youtube",
 }
 
 

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -55,6 +55,7 @@ __all__ = [
     "WikipediaLoader",
     "XMLLoader",
     "YAMLLoader",
+    "YouTubeLoader",
 ]
 
 _LOADERS = {
@@ -100,6 +101,7 @@ _LOADERS = {
     "ParquetLoader": ".parquet",
     "RedisLoader": ".redis_loader",
     "ElasticsearchLoader": ".elasticsearch",
+    "YouTubeLoader": ".youtube",
 }
 
 

--- a/src/synapsekit/loaders/youtube.py
+++ b/src/synapsekit/loaders/youtube.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import asyncio
+import re
+from urllib.parse import parse_qs, urlparse
+
+from .base import Document
+
+# Matches a bare YouTube video ID: 11 alphanumeric/dash/underscore chars
+_VIDEO_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
+
+
+def _extract_video_id(url_or_id: str) -> str:
+    """Return the video ID embedded in *url_or_id*.
+
+    Accepts:
+    * ``https://www.youtube.com/watch?v=VIDEO_ID``
+    * ``https://youtu.be/VIDEO_ID``
+    * A bare 11-character video ID
+    """
+    parsed = urlparse(url_or_id)
+
+    # youtu.be/<id>
+    if parsed.netloc in ("youtu.be", "www.youtu.be"):
+        video_id = parsed.path.lstrip("/").split("/")[0]
+        if _VIDEO_ID_RE.match(video_id):
+            return video_id
+
+    # youtube.com/watch?v=<id>
+    if parsed.netloc in ("youtube.com", "www.youtube.com"):
+        qs = parse_qs(parsed.query)
+        ids = qs.get("v", [])
+        if ids and _VIDEO_ID_RE.match(ids[0]):
+            return ids[0]
+
+    # Bare video ID
+    if _VIDEO_ID_RE.match(url_or_id):
+        return url_or_id
+
+    raise ValueError(
+        f"Could not extract a valid YouTube video ID from: {url_or_id!r}"
+    )
+
+
+class YouTubeLoader:
+    """Load a YouTube video transcript as a :class:`Document`.
+
+    Parameters
+    ----------
+    url_or_id : str
+        A full YouTube URL or a bare 11-character video ID.
+    language : str | None
+        BCP-47 language code (e.g. ``"en"``) for the preferred transcript
+        language.  When ``None`` the API returns its default language.
+    """
+
+    def __init__(self, url_or_id: str, language: str | None = None) -> None:
+        if not url_or_id:
+            raise ValueError("url_or_id must be provided")
+        self._video_id = _extract_video_id(url_or_id)
+        self._language = language
+
+    def load(self) -> list[Document]:
+        try:
+            from youtube_transcript_api import YouTubeTranscriptApi
+            from youtube_transcript_api._errors import (
+                NoTranscriptFound,
+                TranscriptsDisabled,
+                VideoUnavailable,
+            )
+        except ImportError:
+            raise ImportError(
+                "youtube-transcript-api required: pip install synapsekit[youtube]"
+            ) from None
+
+        ytt = YouTubeTranscriptApi()
+        try:
+            if self._language:
+                transcript = ytt.fetch(self._video_id, languages=[self._language])
+            else:
+                transcript = ytt.fetch(self._video_id)
+        # Known transcript-related failures are treated as "no data"
+        except (TranscriptsDisabled, NoTranscriptFound, VideoUnavailable):
+            return []
+        except Exception as exc:
+            raise RuntimeError(f"Failed to fetch transcript: {exc}") from exc
+
+        text = " ".join(snippet.text for snippet in transcript)
+        if not text:
+            return []
+
+        return [
+            Document(
+                text=text,
+                metadata={
+                    "source": "youtube",
+                    "video_id": self._video_id,
+                    "language": getattr(transcript, "language", None),
+                    "language_code": getattr(transcript, "language_code", None),
+                },
+            )
+        ]
+
+    async def aload(self) -> list[Document]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.load)

--- a/src/synapsekit/loaders/youtube.py
+++ b/src/synapsekit/loaders/youtube.py
@@ -37,9 +37,7 @@ def _extract_video_id(url_or_id: str) -> str:
     if _VIDEO_ID_RE.match(url_or_id):
         return url_or_id
 
-    raise ValueError(
-        f"Could not extract a valid YouTube video ID from: {url_or_id!r}"
-    )
+    raise ValueError(f"Could not extract a valid YouTube video ID from: {url_or_id!r}")
 
 
 class YouTubeLoader:

--- a/tests/loaders/test_youtube_loader.py
+++ b/tests/loaders/test_youtube_loader.py
@@ -188,26 +188,26 @@ def test_load_empty_transcript_returns_empty() -> None:
 
 
 def _patched_lib_with_errors() -> tuple[MagicMock, type, type, type]:
-    """Return (mock_lib, TranscriptsDisabled, NoTranscriptFound, VideoUnavailable)."""
-    class TranscriptsDisabled(Exception): ...
-    class NoTranscriptFound(Exception): ...
-    class VideoUnavailable(Exception): ...
+    """Return (mock_lib, TranscriptsDisabledError, NoTranscriptFoundError, VideoUnavailableError)."""
+    class TranscriptsDisabledError(Exception): ...
+    class NoTranscriptFoundError(Exception): ...
+    class VideoUnavailableError(Exception): ...
 
     errors_mod = MagicMock()
-    errors_mod.TranscriptsDisabled = TranscriptsDisabled
-    errors_mod.NoTranscriptFound = NoTranscriptFound
-    errors_mod.VideoUnavailable = VideoUnavailable
+    errors_mod.TranscriptsDisabled = TranscriptsDisabledError
+    errors_mod.NoTranscriptFound = NoTranscriptFoundError
+    errors_mod.VideoUnavailable = VideoUnavailableError
 
     mock_lib = MagicMock()
     mock_lib._errors = errors_mod
 
-    return mock_lib, TranscriptsDisabled, NoTranscriptFound, VideoUnavailable
+    return mock_lib, TranscriptsDisabledError, NoTranscriptFoundError, VideoUnavailableError
 
 
 def test_transcripts_disabled_returns_empty() -> None:
-    mock_lib, TD, _, _ = _patched_lib_with_errors()
+    mock_lib, transcripts_disabled_error, _, _ = _patched_lib_with_errors()
     api = MagicMock()
-    api.fetch.side_effect = TD()
+    api.fetch.side_effect = transcripts_disabled_error()
     mock_lib.YouTubeTranscriptApi.return_value = api
 
     with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
@@ -217,9 +217,9 @@ def test_transcripts_disabled_returns_empty() -> None:
 
 
 def test_no_transcript_found_returns_empty() -> None:
-    mock_lib, _, NTF, _ = _patched_lib_with_errors()
+    mock_lib, _, no_transcript_found_error, _ = _patched_lib_with_errors()
     api = MagicMock()
-    api.fetch.side_effect = NTF()
+    api.fetch.side_effect = no_transcript_found_error()
     mock_lib.YouTubeTranscriptApi.return_value = api
 
     with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
@@ -229,9 +229,9 @@ def test_no_transcript_found_returns_empty() -> None:
 
 
 def test_video_unavailable_returns_empty() -> None:
-    mock_lib, _, _, VU = _patched_lib_with_errors()
+    mock_lib, _, _, video_unavailable_error = _patched_lib_with_errors()
     api = MagicMock()
-    api.fetch.side_effect = VU()
+    api.fetch.side_effect = video_unavailable_error()
     mock_lib.YouTubeTranscriptApi.return_value = api
 
     with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):

--- a/tests/loaders/test_youtube_loader.py
+++ b/tests/loaders/test_youtube_loader.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapsekit.loaders import Document
+from synapsekit.loaders.youtube import YouTubeLoader, _extract_video_id
+
+FAKE_ID = "dQw4w9WgXcQ"
+
+# ---------------------------------------------------------------------------
+# _extract_video_id unit tests (no network)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_bare_id() -> None:
+    assert _extract_video_id(FAKE_ID) == FAKE_ID
+
+
+def test_extract_full_url() -> None:
+    assert _extract_video_id(f"https://www.youtube.com/watch?v={FAKE_ID}") == FAKE_ID
+
+
+def test_extract_short_url() -> None:
+    assert _extract_video_id(f"https://youtu.be/{FAKE_ID}") == FAKE_ID
+
+
+def test_extract_url_with_extra_params() -> None:
+    url = f"https://www.youtube.com/watch?v={FAKE_ID}&t=42s&list=PL123"
+    assert _extract_video_id(url) == FAKE_ID
+
+
+def test_extract_invalid_raises() -> None:
+    with pytest.raises(ValueError, match="Could not extract"):
+        _extract_video_id("not-a-valid-id")
+
+
+def test_extract_empty_raises() -> None:
+    with pytest.raises(ValueError, match="url_or_id must be provided"):
+        YouTubeLoader(url_or_id="")
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build mock transcript objects
+# ---------------------------------------------------------------------------
+
+
+def _make_snippet(text: str, start: float = 0.0, duration: float = 2.0) -> MagicMock:
+    s = MagicMock()
+    s.text = text
+    s.start = start
+    s.duration = duration
+    return s
+
+
+def _make_transcript(snippets: list[MagicMock], lang: str = "English", code: str = "en") -> MagicMock:
+    t = MagicMock()
+    t.language = lang
+    t.language_code = code
+    t.__iter__ = MagicMock(return_value=iter(snippets))
+    return t
+
+
+def _make_api(transcript: MagicMock) -> MagicMock:
+    api = MagicMock()
+    api.fetch.return_value = transcript
+    return api
+
+
+# ---------------------------------------------------------------------------
+# Missing dependency
+# ---------------------------------------------------------------------------
+
+
+def test_load_import_error_missing_library() -> None:
+    with patch.dict("sys.modules", {"youtube_transcript_api": None}):
+        loader = YouTubeLoader(FAKE_ID)
+        with pytest.raises(ImportError, match="youtube-transcript-api required"):
+            loader.load()
+
+
+# ---------------------------------------------------------------------------
+# Normal load
+# ---------------------------------------------------------------------------
+
+
+def test_load_returns_single_document() -> None:
+    snippets = [_make_snippet("Hello"), _make_snippet("World")]
+    transcript = _make_transcript(snippets)
+    api_instance = _make_api(transcript)
+
+    mock_lib = MagicMock()
+    mock_lib.YouTubeTranscriptApi.return_value = api_instance
+    mock_lib._errors.TranscriptsDisabled = Exception
+    mock_lib._errors.NoTranscriptFound = Exception
+    mock_lib._errors.VideoUnavailable = Exception
+
+    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+        loader = YouTubeLoader(FAKE_ID)
+        docs = loader.load()
+
+    assert len(docs) == 1
+    assert isinstance(docs[0], Document)
+
+
+def test_load_text_is_joined() -> None:
+    snippets = [_make_snippet("Part one"), _make_snippet("Part two")]
+    transcript = _make_transcript(snippets)
+    api_instance = _make_api(transcript)
+
+    mock_lib = MagicMock()
+    mock_lib.YouTubeTranscriptApi.return_value = api_instance
+    mock_lib._errors.TranscriptsDisabled = Exception
+    mock_lib._errors.NoTranscriptFound = Exception
+    mock_lib._errors.VideoUnavailable = Exception
+
+    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+        docs = YouTubeLoader(FAKE_ID).load()
+
+    assert docs[0].text == "Part one Part two"
+
+
+def test_load_metadata_correctness() -> None:
+    snippets = [_make_snippet("Hello world")]
+    transcript = _make_transcript(snippets, lang="English", code="en")
+    api_instance = _make_api(transcript)
+
+    mock_lib = MagicMock()
+    mock_lib.YouTubeTranscriptApi.return_value = api_instance
+    mock_lib._errors.TranscriptsDisabled = Exception
+    mock_lib._errors.NoTranscriptFound = Exception
+    mock_lib._errors.VideoUnavailable = Exception
+
+    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+        docs = YouTubeLoader(FAKE_ID).load()
+
+    meta = docs[0].metadata
+    assert meta["source"] == "youtube"
+    assert meta["video_id"] == FAKE_ID
+    assert meta["language"] == "English"
+    assert meta["language_code"] == "en"
+
+
+def test_load_with_language_passes_languages_arg() -> None:
+    snippets = [_make_snippet("Hola")]
+    transcript = _make_transcript(snippets, lang="Spanish", code="es")
+    api_instance = _make_api(transcript)
+
+    mock_lib = MagicMock()
+    mock_lib.YouTubeTranscriptApi.return_value = api_instance
+    mock_lib._errors.TranscriptsDisabled = Exception
+    mock_lib._errors.NoTranscriptFound = Exception
+    mock_lib._errors.VideoUnavailable = Exception
+
+    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+        YouTubeLoader(FAKE_ID, language="es").load()
+
+    api_instance.fetch.assert_called_once_with(FAKE_ID, languages=["es"])
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_load_empty_transcript_returns_empty() -> None:
+    transcript = _make_transcript([])
+    transcript.__iter__ = MagicMock(return_value=iter([]))
+    api_instance = _make_api(transcript)
+
+    mock_lib = MagicMock()
+    mock_lib.YouTubeTranscriptApi.return_value = api_instance
+    mock_lib._errors.TranscriptsDisabled = Exception
+    mock_lib._errors.NoTranscriptFound = Exception
+    mock_lib._errors.VideoUnavailable = Exception
+
+    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+        docs = YouTubeLoader(FAKE_ID).load()
+
+    assert docs == []
+
+
+# ---------------------------------------------------------------------------
+# API error handling
+# ---------------------------------------------------------------------------
+
+
+def _patched_lib_with_errors() -> tuple[MagicMock, type, type, type]:
+    """Return (mock_lib, TranscriptsDisabled, NoTranscriptFound, VideoUnavailable)."""
+    class TranscriptsDisabled(Exception): ...
+    class NoTranscriptFound(Exception): ...
+    class VideoUnavailable(Exception): ...
+
+    errors_mod = MagicMock()
+    errors_mod.TranscriptsDisabled = TranscriptsDisabled
+    errors_mod.NoTranscriptFound = NoTranscriptFound
+    errors_mod.VideoUnavailable = VideoUnavailable
+
+    mock_lib = MagicMock()
+    mock_lib._errors = errors_mod
+
+    return mock_lib, TranscriptsDisabled, NoTranscriptFound, VideoUnavailable
+
+
+def test_transcripts_disabled_returns_empty() -> None:
+    mock_lib, TD, _, _ = _patched_lib_with_errors()
+    api = MagicMock()
+    api.fetch.side_effect = TD()
+    mock_lib.YouTubeTranscriptApi.return_value = api
+
+    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+        docs = YouTubeLoader(FAKE_ID).load()
+
+    assert docs == []
+
+
+def test_no_transcript_found_returns_empty() -> None:
+    mock_lib, _, NTF, _ = _patched_lib_with_errors()
+    api = MagicMock()
+    api.fetch.side_effect = NTF()
+    mock_lib.YouTubeTranscriptApi.return_value = api
+
+    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+        docs = YouTubeLoader(FAKE_ID).load()
+
+    assert docs == []
+
+
+def test_video_unavailable_returns_empty() -> None:
+    mock_lib, _, _, VU = _patched_lib_with_errors()
+    api = MagicMock()
+    api.fetch.side_effect = VU()
+    mock_lib.YouTubeTranscriptApi.return_value = api
+
+    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+        docs = YouTubeLoader(FAKE_ID).load()
+
+    assert docs == []
+
+
+def test_unexpected_error_raises_runtime_error() -> None:
+    mock_lib, _, _, _ = _patched_lib_with_errors()
+    api = MagicMock()
+    api.fetch.side_effect = ConnectionError("timeout")
+    mock_lib.YouTubeTranscriptApi.return_value = api
+
+    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+        with pytest.raises(RuntimeError, match="Failed to fetch transcript"):
+            YouTubeLoader(FAKE_ID).load()
+
+
+# ---------------------------------------------------------------------------
+# Async
+# ---------------------------------------------------------------------------
+
+
+def test_aload_returns_documents() -> None:
+    snippets = [_make_snippet("Async test")]
+    transcript = _make_transcript(snippets)
+    api_instance = _make_api(transcript)
+
+    mock_lib = MagicMock()
+    mock_lib.YouTubeTranscriptApi.return_value = api_instance
+    mock_lib._errors.TranscriptsDisabled = Exception
+    mock_lib._errors.NoTranscriptFound = Exception
+    mock_lib._errors.VideoUnavailable = Exception
+
+    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+        docs = asyncio.run(YouTubeLoader(FAKE_ID).aload())
+
+    assert len(docs) == 1
+    assert docs[0].text == "Async test"

--- a/tests/loaders/test_youtube_loader.py
+++ b/tests/loaders/test_youtube_loader.py
@@ -55,7 +55,9 @@ def _make_snippet(text: str, start: float = 0.0, duration: float = 2.0) -> Magic
     return s
 
 
-def _make_transcript(snippets: list[MagicMock], lang: str = "English", code: str = "en") -> MagicMock:
+def _make_transcript(
+    snippets: list[MagicMock], lang: str = "English", code: str = "en"
+) -> MagicMock:
     t = MagicMock()
     t.language = lang
     t.language_code = code
@@ -97,7 +99,10 @@ def test_load_returns_single_document() -> None:
     mock_lib._errors.NoTranscriptFound = Exception
     mock_lib._errors.VideoUnavailable = Exception
 
-    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+    with patch.dict(
+        "sys.modules",
+        {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors},
+    ):
         loader = YouTubeLoader(FAKE_ID)
         docs = loader.load()
 
@@ -116,7 +121,10 @@ def test_load_text_is_joined() -> None:
     mock_lib._errors.NoTranscriptFound = Exception
     mock_lib._errors.VideoUnavailable = Exception
 
-    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+    with patch.dict(
+        "sys.modules",
+        {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors},
+    ):
         docs = YouTubeLoader(FAKE_ID).load()
 
     assert docs[0].text == "Part one Part two"
@@ -133,7 +141,10 @@ def test_load_metadata_correctness() -> None:
     mock_lib._errors.NoTranscriptFound = Exception
     mock_lib._errors.VideoUnavailable = Exception
 
-    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+    with patch.dict(
+        "sys.modules",
+        {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors},
+    ):
         docs = YouTubeLoader(FAKE_ID).load()
 
     meta = docs[0].metadata
@@ -154,7 +165,10 @@ def test_load_with_language_passes_languages_arg() -> None:
     mock_lib._errors.NoTranscriptFound = Exception
     mock_lib._errors.VideoUnavailable = Exception
 
-    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+    with patch.dict(
+        "sys.modules",
+        {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors},
+    ):
         YouTubeLoader(FAKE_ID, language="es").load()
 
     api_instance.fetch.assert_called_once_with(FAKE_ID, languages=["es"])
@@ -176,7 +190,10 @@ def test_load_empty_transcript_returns_empty() -> None:
     mock_lib._errors.NoTranscriptFound = Exception
     mock_lib._errors.VideoUnavailable = Exception
 
-    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+    with patch.dict(
+        "sys.modules",
+        {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors},
+    ):
         docs = YouTubeLoader(FAKE_ID).load()
 
     assert docs == []
@@ -189,8 +206,11 @@ def test_load_empty_transcript_returns_empty() -> None:
 
 def _patched_lib_with_errors() -> tuple[MagicMock, type, type, type]:
     """Return (mock_lib, TranscriptsDisabledError, NoTranscriptFoundError, VideoUnavailableError)."""
+
     class TranscriptsDisabledError(Exception): ...
+
     class NoTranscriptFoundError(Exception): ...
+
     class VideoUnavailableError(Exception): ...
 
     errors_mod = MagicMock()
@@ -210,7 +230,10 @@ def test_transcripts_disabled_returns_empty() -> None:
     api.fetch.side_effect = transcripts_disabled_error()
     mock_lib.YouTubeTranscriptApi.return_value = api
 
-    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+    with patch.dict(
+        "sys.modules",
+        {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors},
+    ):
         docs = YouTubeLoader(FAKE_ID).load()
 
     assert docs == []
@@ -222,7 +245,10 @@ def test_no_transcript_found_returns_empty() -> None:
     api.fetch.side_effect = no_transcript_found_error()
     mock_lib.YouTubeTranscriptApi.return_value = api
 
-    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+    with patch.dict(
+        "sys.modules",
+        {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors},
+    ):
         docs = YouTubeLoader(FAKE_ID).load()
 
     assert docs == []
@@ -234,7 +260,10 @@ def test_video_unavailable_returns_empty() -> None:
     api.fetch.side_effect = video_unavailable_error()
     mock_lib.YouTubeTranscriptApi.return_value = api
 
-    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+    with patch.dict(
+        "sys.modules",
+        {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors},
+    ):
         docs = YouTubeLoader(FAKE_ID).load()
 
     assert docs == []
@@ -246,7 +275,10 @@ def test_unexpected_error_raises_runtime_error() -> None:
     api.fetch.side_effect = ConnectionError("timeout")
     mock_lib.YouTubeTranscriptApi.return_value = api
 
-    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+    with patch.dict(
+        "sys.modules",
+        {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors},
+    ):
         with pytest.raises(RuntimeError, match="Failed to fetch transcript"):
             YouTubeLoader(FAKE_ID).load()
 
@@ -267,7 +299,10 @@ def test_aload_returns_documents() -> None:
     mock_lib._errors.NoTranscriptFound = Exception
     mock_lib._errors.VideoUnavailable = Exception
 
-    with patch.dict("sys.modules", {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors}):
+    with patch.dict(
+        "sys.modules",
+        {"youtube_transcript_api": mock_lib, "youtube_transcript_api._errors": mock_lib._errors},
+    ):
         docs = asyncio.run(YouTubeLoader(FAKE_ID).aload())
 
     assert len(docs) == 1

--- a/tests/preflight/test_preflight.py
+++ b/tests/preflight/test_preflight.py
@@ -191,6 +191,7 @@ LOADER_NAMES = [
     "WikipediaLoader",
     "XMLLoader",
     "YAMLLoader",
+    "YouTubeLoader",
 ]
 
 
@@ -202,7 +203,7 @@ def test_all_loaders_in_all_list():
 
 
 def test_loader_count_matches_spec():
-    """We have exactly 46 names in the loaders __all__ (includes Document + StringLoader)."""
+    """We have exactly 48 names in the loaders __all__ (includes Document + StringLoader)."""
     import synapsekit.loaders as loaders_mod
 
     assert len(loaders_mod.__all__) == len(LOADER_NAMES)

--- a/uv.lock
+++ b/uv.lock
@@ -1377,6 +1377,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -7610,7 +7619,7 @@ wheels = [
 
 [[package]]
 name = "synapsekit"
-version = "1.5.5"
+version = "1.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -7907,6 +7916,9 @@ yaml = [
 youtube = [
     { name = "youtube-search-python" },
 ]
+youtube-transcript = [
+    { name = "youtube-transcript-api" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -8061,8 +8073,9 @@ requires-dist = [
     { name = "wolframalpha", marker = "extra == 'wolfram'", specifier = ">=5.0" },
     { name = "youtube-search-python", marker = "extra == 'all'", specifier = ">=1.6" },
     { name = "youtube-search-python", marker = "extra == 'youtube'", specifier = ">=1.6" },
+    { name = "youtube-transcript-api", marker = "extra == 'youtube-transcript'", specifier = ">=0.6" },
 ]
-provides-extras = ["openai", "anthropic", "semantic", "colbert", "pdf", "wikipedia", "arxiv", "html", "web", "chroma", "faiss", "qdrant", "pinecone", "weaviate", "milvus", "lancedb", "sqlite-vec", "ollama", "lmstudio", "vllm", "ai21", "cohere", "mistral", "gemini", "bedrock", "gcal-tool", "aws-lambda", "rss", "groq", "audio", "video", "excel", "pptx", "docx", "yaml", "teams", "http", "search", "huggingface", "google-search", "tavily", "youtube", "mcp", "redis", "memcached", "vertex", "cloudflare", "aleph-alpha", "llamacpp", "gpt4all", "ernie", "minimax", "serve", "postgres", "pgvector", "wolfram", "dynamodb", "discord", "gcs", "gdrive", "git", "gsheets", "jira", "sql", "mongodb", "azure", "s3", "onedrive", "slack", "supabase", "notion", "confluence", "dropbox", "rtf", "epub", "parquet", "elasticsearch", "all"]
+provides-extras = ["openai", "anthropic", "semantic", "colbert", "pdf", "wikipedia", "arxiv", "html", "web", "chroma", "faiss", "qdrant", "pinecone", "weaviate", "milvus", "lancedb", "sqlite-vec", "ollama", "lmstudio", "vllm", "ai21", "cohere", "mistral", "gemini", "bedrock", "gcal-tool", "aws-lambda", "rss", "groq", "audio", "video", "excel", "pptx", "docx", "yaml", "teams", "http", "search", "huggingface", "google-search", "tavily", "youtube", "mcp", "redis", "memcached", "vertex", "cloudflare", "aleph-alpha", "llamacpp", "gpt4all", "ernie", "minimax", "serve", "postgres", "pgvector", "wolfram", "dynamodb", "discord", "gcs", "gdrive", "git", "gsheets", "jira", "sql", "mongodb", "azure", "s3", "onedrive", "slack", "supabase", "notion", "confluence", "dropbox", "rtf", "epub", "parquet", "elasticsearch", "youtube-transcript", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -9321,6 +9334,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/3c/dc669b0308e49f294df67bddbb16ff3eefe5b5da6fa37ead922a8301926b/youtube-search-python-1.6.6.tar.gz", hash = "sha256:4568d1d769ecd7eb4bb8365f04eec6e364c5f70eec7b3765f543daebb135fcf5", size = 115732, upload-time = "2022-06-23T20:43:14.26Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/57/d4a20f04264fb5b52dbde127b87296578e12f6eabbfb5a16a6578812988e/youtube_search_python-1.6.6-py3-none-any.whl", hash = "sha256:f0d835278bc32335f2ded48ba119bef39cafb290d98648a64deb22f6c4a705f2", size = 89121, upload-time = "2022-06-23T20:43:11.455Z" },
+]
+
+[[package]]
+name = "youtube-transcript-api"
+version = "1.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/43/4104185a2eaa839daa693b30e15c37e7e58795e8e09ec414f22b3db54bec/youtube_transcript_api-1.2.4.tar.gz", hash = "sha256:b72d0e96a335df599d67cee51d49e143cff4f45b84bcafc202ff51291603ddcd", size = 469839, upload-time = "2026-01-29T09:09:17.088Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/95/129ea37efd6cd6ed00f62baae6543345c677810b8a3bf0026756e1d3cf3c/youtube_transcript_api-1.2.4-py3-none-any.whl", hash = "sha256:03878759356da5caf5edac77431780b91448fb3d8c21d4496015bdc8a7bc43ff", size = 485227, upload-time = "2026-01-29T09:09:15.427Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements `YouTubeLoader`, a new data loader that fetches a YouTube video's transcript via `youtube-transcript-api` and returns it as a `list[Document]`. Supports both full YouTube URLs and bare video IDs, with optional language selection. 

Closes #72 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / internal improvement
- [ ] Dependency / tooling update

## Changes

- Added `src/synapsekit/loaders/youtube.py` — `YouTubeLoader` with `load()` + `async aload()`; `_extract_video_id()` helper supporting `youtube.com/watch?v=`, `youtu.be/`, and bare 11-character IDs; lazy import of `youtube-transcript-api` with clear `ImportError`; optional `language` parameter (uses a conditional `fetch()` call — avoids passing `languages=None` to the API); structured error handling: `TranscriptsDisabled` / `NoTranscriptFound` / `VideoUnavailable` → `return []`, unexpected errors → `RuntimeError`; safe metadata access via `getattr` for `language` and `language_code`; exact netloc matching (`"youtube.com"` / `"www.youtube.com"`) to prevent subdomain spoofing
- Added `tests/loaders/test_youtube_loader.py` — 17 tests covering bare ID / full URL / youtu.be / extra-param URL extraction, invalid ID, missing dependency, document output, text joining, metadata, `language` arg forwarding, empty transcript, all 3 API error types (`TranscriptsDisabled`, `NoTranscriptFound`, `VideoUnavailable`), unexpected error → `RuntimeError`, and async path; no real HTTP or API calls
- Registered `YouTubeLoader` in `src/synapsekit/loaders/__init__.py` (`__all__` + `_LOADERS`)
- Registered `YouTubeLoader` in `src/synapsekit/__init__.py` (`__all__` + `_LAZY_IMPORTS`)
- Added `youtube_transcript = ["youtube-transcript-api>=0.6"]` to `pyproject.toml` optional dependencies (named `youtube_transcript` to avoid collision with the existing `youtube = ["youtube-search-python>=1.6"]` key)
- Updated `tests/preflight/test_preflight.py` — added `YouTubeLoader` to `LOADER_NAMES`, bumped expected count to 48

## Testing

- [x] All existing tests pass (`uv run pytest tests/ -q`)
- [x] New tests added for new behaviour
- [x] No API keys or secrets in the code