### PR TITLE
feat(Loader): Added airtable docs loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ rtf = ["striprtf>=0.0.26"]
 epub = ["ebooklib>=0.18"]
 parquet = ["pyarrow>=14.0"]
 elasticsearch = ["elasticsearch>=8.0"]
+airtable = ["pyairtable>=2.0"]
 all = [
     "openai>=1.0",
     "anthropic>=0.25",
@@ -168,6 +169,7 @@ all = [
     "pymongo>=4.0",
     "azure-storage-blob>=12.0",
     "elasticsearch>=8.0",
+    "pyairtable>=2.0",
 ]
 
 [dependency-groups]

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -572,6 +572,7 @@ __all__ = [
     "ImageContent",
     "MultimodalMessage",
     "AudioLoader",
+    "AirtableLoader",
     "VideoLoader",
     "ImageLoader",
     "YAMLLoader",
@@ -628,6 +629,7 @@ _LAZY_IMPORTS = {
     "RedisCheckpointer": "graph.checkpointers.redis",
     "PostgresCheckpointer": "graph.checkpointers.postgres",
     # Loaders
+    "AirtableLoader": "loaders.airtable",
     "AudioLoader": "loaders.audio",
     "VideoLoader": "loaders.video",
     "DocxLoader": "loaders.docx",

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -9,6 +9,7 @@ from .s3 import S3Loader
 from .text import StringLoader, TextLoader
 
 __all__ = [
+    "AirtableLoader",
     "ArXivLoader",
     "AudioLoader",
     "AzureBlobLoader",
@@ -58,6 +59,7 @@ __all__ = [
 ]
 
 _LOADERS = {
+    "AirtableLoader": ".airtable",
     "ArXivLoader": ".arxiv",
     "AzureBlobLoader": ".azure_blob",
     "PDFLoader": ".pdf",

--- a/src/synapsekit/loaders/airtable.py
+++ b/src/synapsekit/loaders/airtable.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from .base import Document
+
+
+class AirtableLoader:
+    """Load records from an Airtable table as Documents."""
+
+    def __init__(
+        self,
+        api_key: str,
+        base_id: str,
+        table_name: str,
+        text_fields: list[str] | None = None,
+        limit: int | None = None,
+    ) -> None:
+        if not api_key:
+            raise ValueError("api_key must be provided")
+        if not base_id:
+            raise ValueError("base_id must be provided")
+        if not table_name:
+            raise ValueError("table_name must be provided")
+
+        self._api_key = api_key
+        self._base_id = base_id
+        self._table_name = table_name
+        self._text_fields = text_fields
+        self._limit = limit
+
+    def load(self) -> list[Document]:
+        try:
+            from pyairtable import Table
+        except ImportError:
+            raise ImportError("pyairtable required: pip install synapsekit[airtable]") from None
+
+        try:
+            table = Table(self._api_key, self._base_id, self._table_name)
+            # NOTE: table.all() handles pagination internally
+            records = table.all(max_records=self._limit) if self._limit else table.all()
+        except Exception as e:
+            raise RuntimeError(f"Failed to load Airtable records: {e}") from e
+
+        if not records:
+            return []
+
+        docs: list[Document] = []
+        for record in records:
+            # Airtable stores user data under "fields"
+            fields = record.get("fields", {})
+            if not isinstance(fields, dict):
+                fields = {}
+
+            text = self._build_text(fields)
+            if not text:
+                continue
+
+            metadata: dict[str, Any] = {
+                "source": "airtable",
+                "record_id": record.get("id"),
+                "created_time": record.get("createdTime"),
+                **fields,
+            }
+            docs.append(Document(text=text, metadata=metadata))
+
+        return docs
+
+    async def aload(self) -> list[Document]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.load)
+
+    def _build_text(self, fields: dict[str, Any]) -> str:
+        parts: list[str] = []
+        if self._text_fields is not None:
+            for field in self._text_fields:
+                val = fields.get(field)
+                if val not in (None, ""):
+                    if isinstance(val, (list, dict)):
+                        val = str(val)
+                    parts.append(str(val))
+            return " ".join(parts)
+
+        for val in fields.values():
+            if val not in (None, ""):
+                if isinstance(val, (list, dict)):
+                    val = str(val)
+                parts.append(str(val))
+        return " ".join(parts)

--- a/tests/loaders/test_airtable_loader.py
+++ b/tests/loaders/test_airtable_loader.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapsekit.loaders import Document
+from synapsekit.loaders.airtable import AirtableLoader
+
+
+def test_init_requires_api_key() -> None:
+    with pytest.raises(ValueError, match="api_key must be provided"):
+        AirtableLoader(api_key="", base_id="base", table_name="table")
+
+
+def test_init_requires_base_id() -> None:
+    with pytest.raises(ValueError, match="base_id must be provided"):
+        AirtableLoader(api_key="key", base_id="", table_name="table")
+
+
+def test_init_requires_table_name() -> None:
+    with pytest.raises(ValueError, match="table_name must be provided"):
+        AirtableLoader(api_key="key", base_id="base", table_name="")
+
+
+def test_load_missing_pyairtable_import_error() -> None:
+    with patch.dict("sys.modules", {"pyairtable": None}):
+        loader = AirtableLoader(api_key="key", base_id="base", table_name="table")
+        with pytest.raises(ImportError, match=r"synapsekit\[airtable\]"):
+            loader.load()
+
+
+@patch.dict("sys.modules", {"pyairtable": MagicMock()})
+def test_load_uses_text_fields_and_builds_metadata() -> None:
+    import sys
+
+    mock_table_class = sys.modules["pyairtable"].Table
+    mock_table = MagicMock()
+    mock_table_class.return_value = mock_table
+    mock_table.all.return_value = [
+        {
+            "id": "rec1",
+            "fields": {"title": "Hello", "body": "World", "count": 3},
+            "createdTime": "2026-01-01T00:00:00.000Z",
+        }
+    ]
+
+    loader = AirtableLoader(
+        api_key="key",
+        base_id="app123",
+        table_name="Articles",
+        text_fields=["title", "body"],
+    )
+    docs = loader.load()
+
+    mock_table_class.assert_called_once_with("key", "app123", "Articles")
+    mock_table.all.assert_called_once_with()
+    assert len(docs) == 1
+    assert isinstance(docs[0], Document)
+    assert docs[0].text == "Hello World"
+    assert docs[0].metadata["source"] == "airtable"
+    assert docs[0].metadata["record_id"] == "rec1"
+    assert docs[0].metadata["created_time"] == "2026-01-01T00:00:00.000Z"
+    assert docs[0].metadata["title"] == "Hello"
+    assert docs[0].metadata["body"] == "World"
+    assert docs[0].metadata["count"] == 3
+
+
+@patch.dict("sys.modules", {"pyairtable": MagicMock()})
+def test_load_uses_limit_via_max_records() -> None:
+    import sys
+
+    mock_table_class = sys.modules["pyairtable"].Table
+    mock_table = MagicMock()
+    mock_table_class.return_value = mock_table
+    mock_table.all.return_value = []
+
+    loader = AirtableLoader(api_key="key", base_id="base", table_name="table", limit=5)
+    docs = loader.load()
+
+    assert docs == []
+    mock_table.all.assert_called_once_with(max_records=5)
+
+
+@patch.dict("sys.modules", {"pyairtable": MagicMock()})
+def test_load_skips_empty_records() -> None:
+    import sys
+
+    mock_table_class = sys.modules["pyairtable"].Table
+    mock_table = MagicMock()
+    mock_table_class.return_value = mock_table
+    mock_table.all.return_value = [
+        {"id": "rec1", "fields": {"title": "", "body": None}, "createdTime": "2026-01-01"},
+        {"id": "rec2", "fields": {"title": "Keep me"}, "createdTime": "2026-01-02"},
+    ]
+
+    loader = AirtableLoader(api_key="key", base_id="base", table_name="table")
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].metadata["record_id"] == "rec2"
+    assert docs[0].text == "Keep me"
+
+
+@patch.dict("sys.modules", {"pyairtable": MagicMock()})
+def test_load_wraps_api_failures() -> None:
+    import sys
+
+    mock_table_class = sys.modules["pyairtable"].Table
+    mock_table = MagicMock()
+    mock_table_class.return_value = mock_table
+    mock_table.all.side_effect = Exception("boom")
+
+    loader = AirtableLoader(api_key="key", base_id="base", table_name="table")
+
+    with pytest.raises(RuntimeError, match="Failed to load Airtable records"):
+        loader.load()
+
+
+@patch.dict("sys.modules", {"pyairtable": MagicMock()})
+def test_aload_runs() -> None:
+    import sys
+
+    mock_table_class = sys.modules["pyairtable"].Table
+    mock_table = MagicMock()
+    mock_table_class.return_value = mock_table
+    mock_table.all.return_value = [
+        {"id": "rec1", "fields": {"name": "Alice"}, "createdTime": "2026-01-01"}
+    ]
+
+    loader = AirtableLoader(api_key="key", base_id="base", table_name="table")
+    docs = asyncio.run(loader.aload())
+
+    assert len(docs) == 1
+    assert docs[0].text == "Alice"

--- a/tests/preflight/test_preflight.py
+++ b/tests/preflight/test_preflight.py
@@ -145,6 +145,7 @@ def test_llm_provider_count_matches_spec():
 # ---------------------------------------------------------------------------
 
 LOADER_NAMES = [
+    "AirtableLoader",
     "ArXivLoader",
     "AudioLoader",
     "AzureBlobLoader",
@@ -202,7 +203,7 @@ def test_all_loaders_in_all_list():
 
 
 def test_loader_count_matches_spec():
-    """We have exactly 46 names in the loaders __all__ (includes Document + StringLoader)."""
+    """We have exactly 47 names in the loaders __all__ (includes Document + StringLoader)."""
     import synapsekit.loaders as loaders_mod
 
     assert len(loaders_mod.__all__) == len(LOADER_NAMES)

--- a/uv.lock
+++ b/uv.lock
@@ -2707,6 +2707,15 @@ wheels = [
 ]
 
 [[package]]
+name = "inflection"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/7e/691d061b7329bc8d54edbf0ec22fbfb2afe61facb681f9aaa9bff7a27d04/inflection-0.5.1.tar.gz", hash = "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417", size = 15091, upload-time = "2020-08-22T08:16:29.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2", size = 9454, upload-time = "2020-08-22T08:16:27.816Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5440,6 +5449,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pyairtable"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "inflection" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/8a572580e02297cef7ae01053a8b550b7759ea80326cd3231df87b00555b/pyairtable-3.3.0.tar.gz", hash = "sha256:d6d3b77f6feb7a02a84779c2235d37a46605f36030cf20ed99b08bab73108a8c", size = 150168, upload-time = "2025-11-05T20:11:41.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/7b/bebb0ebb86353b63740869ed10ac1fef1636ccc6042beb1d8d3956cad02d/pyairtable-3.3.0-py2.py3-none-any.whl", hash = "sha256:38af09c18659918b96539ac4d9730c9656f6ce2088cdff692dd311fa16802acf", size = 101513, upload-time = "2025-11-05T20:11:40.137Z" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "23.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -7610,7 +7635,7 @@ wheels = [
 
 [[package]]
 name = "synapsekit"
-version = "1.5.5"
+version = "1.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -7621,6 +7646,9 @@ dependencies = [
 [package.optional-dependencies]
 ai21 = [
     { name = "ai21" },
+]
+airtable = [
+    { name = "pyairtable" },
 ]
 aleph-alpha = [
     { name = "aleph-alpha-client" },
@@ -7661,6 +7689,7 @@ all = [
     { name = "pgvector" },
     { name = "pinecone" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "pyairtable" },
     { name = "pymilvus" },
     { name = "pymongo" },
     { name = "pypdf" },
@@ -8022,6 +8051,8 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], marker = "extra == 'all'", specifier = ">=3.1" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'pgvector'", specifier = ">=3.1" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1" },
+    { name = "pyairtable", marker = "extra == 'airtable'", specifier = ">=2.0" },
+    { name = "pyairtable", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=14.0" },
     { name = "pymilvus", marker = "extra == 'all'", specifier = ">=2.4" },
     { name = "pymilvus", marker = "extra == 'milvus'", specifier = ">=2.4" },
@@ -8062,7 +8093,7 @@ requires-dist = [
     { name = "youtube-search-python", marker = "extra == 'all'", specifier = ">=1.6" },
     { name = "youtube-search-python", marker = "extra == 'youtube'", specifier = ">=1.6" },
 ]
-provides-extras = ["openai", "anthropic", "semantic", "colbert", "pdf", "wikipedia", "arxiv", "html", "web", "chroma", "faiss", "qdrant", "pinecone", "weaviate", "milvus", "lancedb", "sqlite-vec", "ollama", "lmstudio", "vllm", "ai21", "cohere", "mistral", "gemini", "bedrock", "gcal-tool", "aws-lambda", "rss", "groq", "audio", "video", "excel", "pptx", "docx", "yaml", "teams", "http", "search", "huggingface", "google-search", "tavily", "youtube", "mcp", "redis", "memcached", "vertex", "cloudflare", "aleph-alpha", "llamacpp", "gpt4all", "ernie", "minimax", "serve", "postgres", "pgvector", "wolfram", "dynamodb", "discord", "gcs", "gdrive", "git", "gsheets", "jira", "sql", "mongodb", "azure", "s3", "onedrive", "slack", "supabase", "notion", "confluence", "dropbox", "rtf", "epub", "parquet", "elasticsearch", "all"]
+provides-extras = ["openai", "anthropic", "semantic", "colbert", "pdf", "wikipedia", "arxiv", "html", "web", "chroma", "faiss", "qdrant", "pinecone", "weaviate", "milvus", "lancedb", "sqlite-vec", "ollama", "lmstudio", "vllm", "ai21", "cohere", "mistral", "gemini", "bedrock", "gcal-tool", "aws-lambda", "rss", "groq", "audio", "video", "excel", "pptx", "docx", "yaml", "teams", "http", "search", "huggingface", "google-search", "tavily", "youtube", "mcp", "redis", "memcached", "vertex", "cloudflare", "aleph-alpha", "llamacpp", "gpt4all", "ernie", "minimax", "serve", "postgres", "pgvector", "wolfram", "dynamodb", "discord", "gcs", "gdrive", "git", "gsheets", "jira", "sql", "mongodb", "azure", "s3", "onedrive", "slack", "supabase", "notion", "confluence", "dropbox", "rtf", "epub", "parquet", "elasticsearch", "airtable", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Adds AirtableLoader to load records from Airtable tables as Documents, with lazy import support for pyairtable.

Closes #78  

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / internal improvement
- [ ] Dependency / tooling update

## Changes

<!-- List the key changes made. -->

- Added src/synapsekit/loaders/airtable.py — new loader with table.all() for pagination, text field extraction, metadata enrichment
- Added pyairtable>=2.0 optional dependency in pyproject.toml
- Added export registration in src/synapsekit/loaders/__init__.py and src/synapsekit/__init__.py
- Added tests/loaders/test_airtable_loader.py — 9 tests covering core behavior
- Updated tests/preflight/test_preflight.py — added loader count and name to preflight spec

## Testing

- [x] All existing tests pass (`uv run pytest tests/ -q`)
- [x] New tests added for new behaviour
- [x] No API keys or secrets in the code