### PR TITLE
feat(loaders): add HubSpotLoader (issue #88)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ gdrive = ["google-api-python-client>=2.0", "google-auth>=2.0"]
 git = ["gitpython>=3.1"]
 gsheets = ["google-api-python-client>=2.0", "google-auth>=2.0"]
 jira = ["httpx>=0.27"]
+hubspot = ["hubspot-api-client>=8.0"]
 sql = ["sqlalchemy>=2.0"]
 mongodb = ["pymongo>=4.0"]
 azure = ["azure-storage-blob>=12.0"]
@@ -164,6 +165,7 @@ all = [
     "google-auth>=2.0",
     "feedparser>=6.0",
     "gitpython>=3.1",
+    "hubspot-api-client>=8.0",
     "supabase>=2.0",
     "pymongo>=4.0",
     "azure-storage-blob>=12.0",
@@ -305,6 +307,7 @@ slack-sdk = "slack_sdk"
 weaviate-client = "weaviate"
 atlassian-python-api = "atlassian"
 gitpython = "git"
+hubspot-api-client = "hubspot"
 azure-storage-blob = "azure"
 sqlite-vec = "sqlite_vec"
 

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -167,6 +167,7 @@ from .loaders.git import GitLoader
 from .loaders.github import GitHubLoader
 from .loaders.google_sheets import GoogleSheetsLoader
 from .loaders.html import HTMLLoader
+from .loaders.hubspot import HubSpotLoader
 from .loaders.image import ImageLoader
 from .loaders.jira import JiraLoader
 from .loaders.json_loader import JSONLoader
@@ -371,6 +372,7 @@ __all__ = [
     "GitHubLoader",
     "GitLoader",
     "GoogleSheetsLoader",
+    "HubSpotLoader",
     "JiraLoader",
     "LaTeXLoader",
     "MarkdownLoader",
@@ -638,6 +640,7 @@ _LAZY_IMPORTS = {
     "DiscordLoader": "loaders.discord",
     "XMLLoader": "loaders.xml_loader",
     "GoogleDriveLoader": "loaders.google_drive",
+    "HubSpotLoader": "loaders.hubspot",
     "MongoDBLoader": "loaders.mongodb",
     "OneDriveLoader": "loaders.onedrive",
     "AzureBlobLoader": "loaders.azure_blob",

--- a/src/synapsekit/loaders/__init__.py
+++ b/src/synapsekit/loaders/__init__.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from .azure_blob import AzureBlobLoader
 from .base import Document
+from .hubspot import HubSpotLoader
 from .markdown import MarkdownLoader
 from .mongodb import MongoDBLoader
 from .onedrive import OneDriveLoader
@@ -30,6 +31,7 @@ __all__ = [
     "GoogleDriveLoader",
     "GoogleSheetsLoader",
     "HTMLLoader",
+    "HubSpotLoader",
     "LaTeXLoader",
     "JSONLoader",
     "JiraLoader",
@@ -81,6 +83,7 @@ _LOADERS = {
     "GitLoader": ".git",
     "GoogleDriveLoader": ".google_drive",
     "GoogleSheetsLoader": ".google_sheets",
+    "HubSpotLoader": ".hubspot",
     "JiraLoader": ".jira",
     "SlackLoader": ".slack",
     "NotionLoader": ".notion",

--- a/src/synapsekit/loaders/hubspot.py
+++ b/src/synapsekit/loaders/hubspot.py
@@ -21,9 +21,10 @@ class HubSpotLoader:
         limit: int = 100,
         client: Any | None = None,
     ) -> None:
-        normalized_object_type = object_type.strip().lower()
-        if not normalized_object_type:
+        if not isinstance(object_type, str) or not object_type.strip():
             raise ValueError("object_type must be provided")
+
+        normalized_object_type = object_type.strip().lower()
         if normalized_object_type not in _SUPPORTED_OBJECT_TYPES:
             raise ValueError("object_type must be one of: contacts, deals, tickets")
 
@@ -56,7 +57,7 @@ class HubSpotLoader:
         properties = self._build_properties()
 
         response = api.get_page(limit=self._limit, archived=False, properties=properties)
-        results = getattr(response, "results", [])
+        results = getattr(response, "results", []) or []
 
         docs: list[Document] = []
         for index, item in enumerate(results):

--- a/src/synapsekit/loaders/hubspot.py
+++ b/src/synapsekit/loaders/hubspot.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from typing import Any
+
+from .base import Document
+
+_SUPPORTED_OBJECT_TYPES = {"contacts", "deals", "tickets"}
+
+
+class HubSpotLoader:
+    """Load CRM objects from HubSpot."""
+
+    def __init__(
+        self,
+        object_type: str,
+        access_token: str | None = None,
+        text_fields: list[str] | None = None,
+        metadata_fields: list[str] | None = None,
+        limit: int = 100,
+        client: Any | None = None,
+    ) -> None:
+        normalized_object_type = object_type.strip().lower()
+        if not normalized_object_type:
+            raise ValueError("object_type must be provided")
+        if normalized_object_type not in _SUPPORTED_OBJECT_TYPES:
+            raise ValueError("object_type must be one of: contacts, deals, tickets")
+
+        if client is None and not access_token:
+            raise ValueError("access_token is required unless client is provided")
+
+        if limit <= 0:
+            raise ValueError("limit must be greater than 0")
+
+        self._object_type = normalized_object_type
+        self._access_token = access_token
+        self._text_fields = text_fields
+        self._metadata_fields = metadata_fields
+        self._limit = limit
+        self._client = client
+
+    def load(self) -> list[Document]:
+        client = self._client
+        if client is None:
+            try:
+                from hubspot import HubSpot
+            except ImportError:
+                raise ImportError(
+                    "hubspot-api-client required: pip install synapsekit[hubspot]"
+                ) from None
+
+            client = HubSpot(access_token=self._access_token)
+
+        api = self._resolve_basic_api(client)
+        properties = self._build_properties()
+
+        response = api.get_page(limit=self._limit, archived=False, properties=properties)
+        results = getattr(response, "results", [])
+
+        docs: list[Document] = []
+        for index, item in enumerate(results):
+            record = self._normalize_record(item)
+            if record is None:
+                continue
+
+            text = self._build_text(record)
+            metadata = self._build_metadata(record, index)
+            docs.append(Document(text=text, metadata=metadata))
+
+        return docs
+
+    async def aload(self) -> list[Document]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.load)
+
+    def _resolve_basic_api(self, client: Any) -> Any:
+        if self._object_type == "contacts":
+            return client.crm.contacts.basic_api
+        if self._object_type == "deals":
+            return client.crm.deals.basic_api
+        return client.crm.tickets.basic_api
+
+    def _build_properties(self) -> list[str] | None:
+        fields: list[str] = []
+
+        if self._text_fields:
+            fields.extend(self._text_fields)
+        if self._metadata_fields:
+            fields.extend(self._metadata_fields)
+
+        if not fields:
+            return None
+
+        unique_fields: list[str] = []
+        for field in fields:
+            if field not in unique_fields:
+                unique_fields.append(field)
+
+        return unique_fields
+
+    def _normalize_record(self, item: Any) -> dict[str, Any] | None:
+        raw: Any = item
+
+        if hasattr(item, "to_dict") and callable(item.to_dict):
+            raw = item.to_dict()
+
+        if not isinstance(raw, Mapping):
+            return None
+
+        properties = raw.get("properties")
+        merged: dict[str, Any] = dict(properties) if isinstance(properties, Mapping) else {}
+
+        if "id" in raw:
+            merged["id"] = raw["id"]
+        if "created_at" in raw:
+            merged["created_at"] = raw["created_at"]
+        if "updated_at" in raw:
+            merged["updated_at"] = raw["updated_at"]
+        if "archived" in raw:
+            merged["archived"] = raw["archived"]
+
+        if not merged:
+            merged = dict(raw)
+
+        return merged
+
+    def _build_text(self, record: Mapping[str, Any]) -> str:
+        if self._text_fields:
+            values: list[str] = []
+            for field in self._text_fields:
+                value = record.get(field, "")
+                safe_value = "" if value is None else str(value)
+                values.append(f"{field}: {safe_value}")
+            return "\n".join(values)
+
+        return "\n".join(f"{k}: {v}" for k, v in record.items())
+
+    def _build_metadata(self, record: Mapping[str, Any], row: int) -> dict[str, Any]:
+        metadata: dict[str, Any] = {
+            "source": "hubspot",
+            "object_type": self._object_type,
+            "row": row,
+        }
+
+        if self._metadata_fields:
+            for field in self._metadata_fields:
+                if field in record:
+                    metadata[field] = record[field]
+        else:
+            metadata.update(record)
+
+        return metadata

--- a/tests/loaders/test_hubspot_loader.py
+++ b/tests/loaders/test_hubspot_loader.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapsekit.loaders import Document, HubSpotLoader
+
+
+def test_init_requires_object_type() -> None:
+    with pytest.raises(ValueError, match="object_type must be provided"):
+        HubSpotLoader(object_type="", access_token="token")
+
+
+def test_init_rejects_unsupported_object_type() -> None:
+    with pytest.raises(ValueError, match="object_type must be one of"):
+        HubSpotLoader(object_type="companies", access_token="token")
+
+
+def test_init_requires_access_token_without_client() -> None:
+    with pytest.raises(ValueError, match="access_token is required unless client is provided"):
+        HubSpotLoader(object_type="contacts")
+
+
+def test_init_requires_positive_limit() -> None:
+    with pytest.raises(ValueError, match="limit must be greater than 0"):
+        HubSpotLoader(object_type="contacts", access_token="token", limit=0)
+
+
+def test_load_import_error_missing_hubspot_client() -> None:
+    with patch.dict("sys.modules", {"hubspot": None}):
+        loader = HubSpotLoader(object_type="contacts", access_token="token")
+        with pytest.raises(ImportError, match="hubspot-api-client required"):
+            loader.load()
+
+
+@patch.dict("sys.modules", {"hubspot": MagicMock()})
+def test_load_contacts_with_credentials_and_default_fields() -> None:
+    import sys
+
+    mock_hubspot_cls = sys.modules["hubspot"].HubSpot
+    mock_client = MagicMock()
+    mock_hubspot_cls.return_value = mock_client
+
+    mock_client.crm.contacts.basic_api.get_page.return_value.results = [
+        {
+            "id": "1",
+            "properties": {
+                "firstname": "Ada",
+                "lastname": "Lovelace",
+                "email": "ada@example.com",
+            },
+            "archived": False,
+        }
+    ]
+
+    loader = HubSpotLoader(object_type="contacts", access_token="token")
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert isinstance(docs[0], Document)
+    assert "firstname: Ada" in docs[0].text
+    assert "email: ada@example.com" in docs[0].text
+    assert docs[0].metadata["source"] == "hubspot"
+    assert docs[0].metadata["object_type"] == "contacts"
+    assert docs[0].metadata["row"] == 0
+    assert docs[0].metadata["id"] == "1"
+
+    mock_hubspot_cls.assert_called_once_with(access_token="token")
+    mock_client.crm.contacts.basic_api.get_page.assert_called_once_with(
+        limit=100,
+        archived=False,
+        properties=None,
+    )
+
+
+def test_load_with_injected_client_and_field_selection() -> None:
+    mock_client = MagicMock()
+
+    record_obj = MagicMock()
+    record_obj.to_dict.return_value = {
+        "id": "deal-1",
+        "properties": {
+            "dealname": "Big Deal",
+            "amount": "25000",
+            "pipeline": "default",
+        },
+    }
+    mock_client.crm.deals.basic_api.get_page.return_value.results = [record_obj]
+
+    loader = HubSpotLoader(
+        object_type="deals",
+        client=mock_client,
+        text_fields=["dealname", "amount"],
+        metadata_fields=["id", "pipeline"],
+        limit=25,
+    )
+
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].text == "dealname: Big Deal\namount: 25000"
+    assert docs[0].metadata["source"] == "hubspot"
+    assert docs[0].metadata["object_type"] == "deals"
+    assert docs[0].metadata["id"] == "deal-1"
+    assert docs[0].metadata["pipeline"] == "default"
+    assert "amount" not in docs[0].metadata
+
+    mock_client.crm.deals.basic_api.get_page.assert_called_once_with(
+        limit=25,
+        archived=False,
+        properties=["dealname", "amount", "id", "pipeline"],
+    )
+
+
+def test_aload() -> None:
+    mock_client = MagicMock()
+    mock_client.crm.tickets.basic_api.get_page.return_value.results = [
+        {
+            "id": "ticket-1",
+            "properties": {
+                "subject": "Reset password",
+                "content": "User cannot sign in",
+            },
+        }
+    ]
+
+    loader = HubSpotLoader(
+        object_type="tickets",
+        client=mock_client,
+        text_fields=["subject", "content"],
+    )
+
+    docs = asyncio.run(loader.aload())
+
+    assert len(docs) == 1
+    assert docs[0].text == "subject: Reset password\ncontent: User cannot sign in"
+
+
+def test_load_skips_non_mapping_records() -> None:
+    mock_client = MagicMock()
+    broken_record = MagicMock()
+    broken_record.to_dict.return_value = "not-a-mapping"
+
+    mock_client.crm.contacts.basic_api.get_page.return_value.results = [
+        "bad",
+        broken_record,
+        {"id": "2", "properties": {"firstname": "Grace"}},
+    ]
+
+    loader = HubSpotLoader(
+        object_type="contacts",
+        client=mock_client,
+        text_fields=["firstname"],
+    )
+
+    docs = loader.load()
+    assert len(docs) == 1
+    assert docs[0].metadata["id"] == "2"
+
+
+def test_exports_from_synapsekit_and_loaders_modules() -> None:
+    import synapsekit
+    from synapsekit.loaders import __all__ as loaders_all
+
+    loaders = importlib.import_module("synapsekit.loaders")
+
+    assert "HubSpotLoader" in synapsekit.__all__
+    assert "HubSpotLoader" in loaders_all
+    assert "HubSpotLoader" in loaders.__all__
+    assert hasattr(synapsekit, "HubSpotLoader")
+    assert hasattr(loaders, "HubSpotLoader")

--- a/tests/loaders/test_hubspot_loader.py
+++ b/tests/loaders/test_hubspot_loader.py
@@ -14,6 +14,11 @@ def test_init_requires_object_type() -> None:
         HubSpotLoader(object_type="", access_token="token")
 
 
+def test_init_requires_object_type_when_none() -> None:
+    with pytest.raises(ValueError, match="object_type must be provided"):
+        HubSpotLoader(object_type=None, access_token="token")  # type: ignore[arg-type]
+
+
 def test_init_rejects_unsupported_object_type() -> None:
     with pytest.raises(ValueError, match="object_type must be one of"):
         HubSpotLoader(object_type="companies", access_token="token")
@@ -159,6 +164,16 @@ def test_load_skips_non_mapping_records() -> None:
     docs = loader.load()
     assert len(docs) == 1
     assert docs[0].metadata["id"] == "2"
+
+
+def test_load_handles_none_results() -> None:
+    mock_client = MagicMock()
+    mock_client.crm.contacts.basic_api.get_page.return_value.results = None
+
+    loader = HubSpotLoader(object_type="contacts", client=mock_client)
+    docs = loader.load()
+
+    assert docs == []
 
 
 def test_exports_from_synapsekit_and_loaders_modules() -> None:

--- a/tests/preflight/test_preflight.py
+++ b/tests/preflight/test_preflight.py
@@ -166,6 +166,7 @@ LOADER_NAMES = [
     "GoogleDriveLoader",
     "GoogleSheetsLoader",
     "HTMLLoader",
+    "HubSpotLoader",
     "LaTeXLoader",
     "JSONLoader",
     "JiraLoader",
@@ -202,7 +203,7 @@ def test_all_loaders_in_all_list():
 
 
 def test_loader_count_matches_spec():
-    """We have exactly 46 names in the loaders __all__ (includes Document + StringLoader)."""
+    """We have exactly 47 names in the loaders __all__ (includes Document + StringLoader)."""
     import synapsekit.loaders as loaders_mod
 
     assert len(loaders_mod.__all__) == len(LOADER_NAMES)


### PR DESCRIPTION
## Summary
- add `HubSpotLoader` for HubSpot CRM objects (`contacts`, `deals`, `tickets`)
- support `access_token`, `object_type`, `text_fields`, `metadata_fields`, `limit`, and async `aload()`
- wire loader exports in `synapsekit.loaders` and top-level `synapsekit`
- add `hubspot = ["hubspot-api-client>=8.0"]` optional dependency and deptry module map
- add loader tests and preflight loader count/list updates
- harden loader for `object_type=None` and `response.results=None`

## Validation
- ruff check src/ tests/
- ruff format --check src/ tests/
- pytest tests/loaders/test_hubspot_loader.py -q
- pytest tests/preflight/test_preflight.py::test_loader_count_matches_spec -q
- pytest tests/ -q
- deptry src/

Closes #88
