### PR TITLE
feat(rag): auto-evaluate faithfulness/relevancy during traced calls

### DIFF
--- a/src/synapsekit/agents/tools/http_request.py
+++ b/src/synapsekit/agents/tools/http_request.py
@@ -69,7 +69,7 @@ class HTTPRequestTool(BaseTool):
             await self._session.close()
             self._session = None
 
-    async def __aenter__(self) -> "HTTPRequestTool":
+    async def __aenter__(self) -> HTTPRequestTool:
         return self
 
     async def __aexit__(self, *_: object) -> None:

--- a/src/synapsekit/evaluation/pipeline.py
+++ b/src/synapsekit/evaluation/pipeline.py
@@ -73,8 +73,8 @@ class EvaluationPipeline:
             ]
         )
 
-        scores = {m.name: r.score for m, r in zip(self._metrics, metric_results)}
-        details = {m.name: r for m, r in zip(self._metrics, metric_results)}
+        scores = {m.name: r.score for m, r in zip(self._metrics, metric_results, strict=True)}
+        details = {m.name: r for m, r in zip(self._metrics, metric_results, strict=True)}
         return EvaluationResult(scores=scores, details=details)
 
     async def evaluate_batch(

--- a/src/synapsekit/llm/_semantic_cache.py
+++ b/src/synapsekit/llm/_semantic_cache.py
@@ -14,7 +14,7 @@ class SemanticCache:
     cached responses when similarity exceeds a threshold.
 
     Vectors are L2-normalised on insertion so lookup reduces to a single
-    batched matrix–vector multiply (one BLAS call) instead of a Python
+    batched matrix-vector multiply (one BLAS call) instead of a Python
     for-loop over individual dot products.
 
     Usage::
@@ -65,7 +65,7 @@ class SemanticCache:
 
         Returns the cached response if similarity >= threshold, else None.
         All cached vectors are L2-normalised, so the cosine similarity matrix
-        is computed as a single BLAS matrix–vector multiply instead of a
+        is computed as a single BLAS matrix-vector multiply instead of a
         Python-level loop.
         """
         if not self._entries:
@@ -77,11 +77,11 @@ class SemanticCache:
 
         # Rebuild the stacked matrix only when entries have changed
         if self._dirty or self._matrix is None:
-            self._matrix = np.vstack(self._vectors)  # (n, D) – one allocation
+            self._matrix = np.vstack(self._vectors)  # (n, D) - one allocation
             self._dirty = False
 
         # One BLAS call replaces the entire Python for-loop
-        scores = self._matrix @ query_arr  # (n,) – dot == cosine for unit vecs
+        scores = self._matrix @ query_arr  # (n,) - dot == cosine for unit vecs
         best_idx = int(np.argmax(scores))
         best_score = float(scores[best_idx])
 

--- a/src/synapsekit/llm/_sqlite_cache.py
+++ b/src/synapsekit/llm/_sqlite_cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+from contextlib import suppress
 from typing import Any
 
 from ._cache import AsyncLRUCache
@@ -67,14 +68,12 @@ class SQLiteLLMCache:
 
     def close(self) -> None:
         """Close the underlying SQLite connection. Idempotent."""
-        try:
+        with suppress(Exception):
             self._conn.close()
-        except Exception:
-            pass
 
     # ── context manager ────────────────────────────────────────────────────
 
-    def __enter__(self) -> "SQLiteLLMCache":
+    def __enter__(self) -> SQLiteLLMCache:
         return self
 
     def __exit__(self, *_: object) -> None:
@@ -82,7 +81,5 @@ class SQLiteLLMCache:
 
     def __del__(self) -> None:
         """Last-resort cleanup if the caller forgets to call close()."""
-        try:
+        with suppress(Exception):
             self.close()
-        except Exception:
-            pass

--- a/src/synapsekit/observability/tracer.py
+++ b/src/synapsekit/observability/tracer.py
@@ -41,23 +41,109 @@ class _Record:
     latency_ms: float
 
 
-class TokenTracer:
-    """Track token usage, latency, and estimated cost per session."""
+@dataclass
+class _QualityRecord:
+    call_id: int
+    faithfulness: float | None
+    relevancy: float | None
+    timestamp: float
 
-    def __init__(self, model: str, enabled: bool = True) -> None:
+    @property
+    def mean_score(self) -> float | None:
+        vals = [v for v in (self.faithfulness, self.relevancy) if v is not None]
+        if not vals:
+            return None
+        return sum(vals) / len(vals)
+
+
+class TokenTracer:
+    """Track token usage, latency, estimated cost, and quality trends per session."""
+
+    def __init__(
+        self,
+        model: str,
+        enabled: bool = True,
+        quality_window: int = 5,
+        quality_trend_threshold: float = 0.03,
+    ) -> None:
         self.model = model
         self.enabled = enabled
+        self.quality_window = max(2, quality_window)
+        self.quality_trend_threshold = max(0.0, quality_trend_threshold)
         self._records: list[_Record] = []
+        self._quality_records: list[_QualityRecord] = []
 
     def record(
         self,
         input_tokens: int,
         output_tokens: int,
         latency_ms: float,
-    ) -> None:
+    ) -> int:
+        """Record one LLM call and return its 1-based call id."""
         if not self.enabled:
-            return
+            return 0
         self._records.append(_Record(input_tokens, output_tokens, latency_ms))
+        return len(self._records)
+
+    def record_quality(
+        self,
+        faithfulness: float | None = None,
+        relevancy: float | None = None,
+        call_id: int | None = None,
+        timestamp: float | None = None,
+    ) -> int:
+        """Record quality metrics for a call (faithfulness/relevancy)."""
+        if not self.enabled:
+            return 0
+        if faithfulness is None and relevancy is None:
+            return 0
+
+        resolved_call_id = call_id if call_id is not None else len(self._records)
+        self._quality_records.append(
+            _QualityRecord(
+                call_id=max(0, resolved_call_id),
+                faithfulness=faithfulness,
+                relevancy=relevancy,
+                timestamp=timestamp if timestamp is not None else time.time(),
+            )
+        )
+        return resolved_call_id
+
+    def quality_history(self) -> list[dict[str, float | int | None]]:
+        """Return recorded quality metrics in insertion order."""
+        return [
+            {
+                "call_id": r.call_id,
+                "faithfulness": r.faithfulness,
+                "relevancy": r.relevancy,
+                "timestamp": r.timestamp,
+            }
+            for r in self._quality_records
+        ]
+
+    def _quality_trend(self) -> str:
+        scores = [r.mean_score for r in self._quality_records]
+        numeric_scores = [s for s in scores if s is not None]
+
+        if len(numeric_scores) < self.quality_window:
+            return "stable"
+
+        recent = numeric_scores[-self.quality_window :]
+        split = len(recent) // 2
+        if split == 0:
+            return "stable"
+
+        first = recent[:split]
+        second = recent[split:]
+        first_avg = sum(first) / len(first)
+        second_avg = sum(second) / len(second)
+        delta = second_avg - first_avg
+
+        if delta >= self.quality_trend_threshold:
+            return "improving"
+        if delta <= -self.quality_trend_threshold:
+            return "degrading"
+        return "stable"
 
     def summary(self) -> dict:
         total_input = sum(r.input_tokens for r in self._records)
@@ -68,6 +154,16 @@ class TokenTracer:
         cost_input = total_input * costs.get("input", 0.0)
         cost_output = total_output * costs.get("output", 0.0)
 
+        faithfulness_values = [
+            r.faithfulness for r in self._quality_records if r.faithfulness is not None
+        ]
+        relevancy_values = [r.relevancy for r in self._quality_records if r.relevancy is not None]
+
+        avg_faithfulness = (
+            sum(faithfulness_values) / len(faithfulness_values) if faithfulness_values else 0.0
+        )
+        avg_relevancy = sum(relevancy_values) / len(relevancy_values) if relevancy_values else 0.0
+
         return {
             "model": self.model,
             "calls": len(self._records),
@@ -76,10 +172,14 @@ class TokenTracer:
             "total_tokens": total_input + total_output,
             "total_latency_ms": round(total_latency, 2),
             "estimated_cost_usd": round(cost_input + cost_output, 6),
+            "avg_faithfulness": round(avg_faithfulness, 4),
+            "avg_relevancy": round(avg_relevancy, 4),
+            "quality_trend": self._quality_trend(),
         }
 
     def reset(self) -> None:
         self._records.clear()
+        self._quality_records.clear()
 
     def start_timer(self) -> float:
         """Return current time in ms for use with record()."""

--- a/src/synapsekit/rag/facade.py
+++ b/src/synapsekit/rag/facade.py
@@ -219,6 +219,7 @@ class RAG:
         temperature: float = 0.2,
         max_tokens: int = 1024,
         trace: bool = True,
+        auto_eval: bool = False,
     ) -> None:
         llm = _make_llm(model, api_key, provider, system_prompt, temperature, max_tokens)
         embeddings = SynapsekitEmbeddings(model=embedding_model)
@@ -235,6 +236,7 @@ class RAG:
                 tracer=tracer,
                 retrieval_top_k=retrieval_top_k,
                 system_prompt=system_prompt,
+                auto_eval=auto_eval,
             )
         )
         self._embeddings = embeddings

--- a/src/synapsekit/rag/pipeline.py
+++ b/src/synapsekit/rag/pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 
@@ -25,6 +26,7 @@ class RAGConfig:
     system_prompt: str = "Answer using only the provided context. If the context does not contain the answer, say so."
     chunk_size: int = 512
     chunk_overlap: int = 50
+    auto_eval: bool = False
     splitter: BaseSplitter | None = field(default=None)
 
 
@@ -40,6 +42,7 @@ class RAGPipeline:
             chunk_size=config.chunk_size,
             chunk_overlap=config.chunk_overlap,
         )
+        self._auto_eval_tasks: set[asyncio.Task[None]] = set()
 
     def __repr__(self) -> str:
         model = type(self.config.llm).__name__
@@ -121,11 +124,75 @@ class RAGPipeline:
 
                 if tracer:
                     used = self.config.llm.tokens_used
-                    tracer.record(
+                    call_id = tracer.record(
                         input_tokens=used["input"],
                         output_tokens=used["output"],
                         latency_ms=tracer.elapsed_ms(t0),
                     )
+
+                    if self.config.auto_eval and tracer.enabled:
+                        self._schedule_auto_eval(
+                            query=query,
+                            answer=answer,
+                            contexts=chunks,
+                            call_id=call_id,
+                        )
+
+    def _schedule_auto_eval(
+        self,
+        query: str,
+        answer: str,
+        contexts: list[str],
+        call_id: int,
+    ) -> None:
+        task = asyncio.create_task(
+            self._run_auto_eval(
+                query=query,
+                answer=answer,
+                contexts=contexts,
+                call_id=call_id,
+            )
+        )
+        self._auto_eval_tasks.add(task)
+        task.add_done_callback(self._auto_eval_tasks.discard)
+
+    async def _run_auto_eval(
+        self,
+        query: str,
+        answer: str,
+        contexts: list[str],
+        call_id: int,
+    ) -> None:
+        tracer = self.config.tracer
+        if tracer is None or not tracer.enabled:
+            return
+
+        try:
+            from ..evaluation import EvaluationPipeline, FaithfulnessMetric, RelevancyMetric
+
+            metrics = [
+                FaithfulnessMetric(self.config.llm),
+                RelevancyMetric(self.config.llm),
+            ]
+            pipeline = EvaluationPipeline(metrics=metrics)
+            result = await pipeline.evaluate(
+                question=query,
+                answer=answer,
+                contexts=contexts,
+            )
+            tracer.record_quality(
+                faithfulness=result.scores.get("faithfulness"),
+                relevancy=result.scores.get("relevancy"),
+                call_id=call_id,
+            )
+        except Exception:
+            # Auto-eval is best-effort. Never break the primary RAG call.
+            return
+
+    async def wait_for_auto_eval(self) -> None:
+        if not self._auto_eval_tasks:
+            return
+        await asyncio.gather(*list(self._auto_eval_tasks), return_exceptions=True)
 
     async def ask(self, query: str, top_k: int | None = None) -> str:
         return "".join([t async for t in self.stream(query, top_k=top_k)])

--- a/src/synapsekit/retrieval/ensemble.py
+++ b/src/synapsekit/retrieval/ensemble.py
@@ -54,7 +54,7 @@ class EnsembleRetriever:
         )
 
         scores: dict[str, float] = {}
-        for results, weight in zip(all_results, self._weights):
+        for results, weight in zip(all_results, self._weights, strict=True):
             for rank, text in enumerate(results):
                 scores[text] = scores.get(text, 0.0) + weight / (self._rrf_k + rank + 1)
 

--- a/src/synapsekit/retrieval/vectorstore.py
+++ b/src/synapsekit/retrieval/vectorstore.py
@@ -27,7 +27,7 @@ class InMemoryVectorStore(VectorStore):
 
     * **O(fetch_k²) MMR precomputation** — the pairwise similarity matrix for
       the candidate pool is computed once with a single BLAS call before the
-      greedy selection loop, replacing O(top_k × fetch_k × selected) Python-
+      greedy selection loop, replacing O(top_k x fetch_k x selected) Python-
       level dot products.
     """
 
@@ -84,9 +84,7 @@ class InMemoryVectorStore(VectorStore):
         """
         if not metadata_filter:
             return None
-        candidate_sets = [
-            self._index.get(k, {}).get(v, set()) for k, v in metadata_filter.items()
-        ]
+        candidate_sets = [self._index.get(k, {}).get(v, set()) for k, v in metadata_filter.items()]
         if not candidate_sets or any(not s for s in candidate_sets):
             return []
         return sorted(set.intersection(*candidate_sets))
@@ -173,7 +171,7 @@ class InMemoryVectorStore(VectorStore):
 
         The pairwise similarity matrix for the candidate pool is precomputed
         with a single BLAS call before the greedy loop, replacing the previous
-        O(top_k × fetch_k × selected) Python-level dot-product recomputation.
+        O(top_k x fetch_k x selected) Python-level dot-product recomputation.
         """
         if not self._texts:
             return []
@@ -204,17 +202,16 @@ class InMemoryVectorStore(VectorStore):
             return []
 
         pool_indices = [idx for idx, _ in pool]
-        pool_rel_scores = [rel for _, rel in pool]
 
         # ── precompute pairwise similarity matrix for the pool (one BLAS call) ──
-        pool_vecs = self._vectors[pool_indices]     # (fetch_k, D)
-        sim_matrix = pool_vecs @ pool_vecs.T         # (fetch_k, fetch_k)
+        pool_vecs = self._vectors[pool_indices]  # (fetch_k, D)
+        sim_matrix = pool_vecs @ pool_vecs.T  # (fetch_k, fetch_k)
 
         # Greedy MMR selection
-        selected: list[int] = []           # global indices of selected docs
-        selected_pos: list[int] = []       # corresponding positions in pool
+        selected: list[int] = []  # global indices of selected docs
+        selected_pos: list[int] = []  # corresponding positions in pool
 
-        selected_set: set[int] = set()     # O(1) membership test
+        selected_set: set[int] = set()  # O(1) membership test
 
         for _ in range(min(top_k, len(pool))):
             best_global_idx = -1

--- a/tests/agents/test_tools_behavioral.py
+++ b/tests/agents/test_tools_behavioral.py
@@ -248,8 +248,8 @@ class TestShellTool:
     @pytest.mark.asyncio
     async def test_timeout_triggers_error(self):
         tool = ShellTool(timeout=1)
-        # sleep 5 should timeout after 1 second
-        result = await tool.run(command="sleep 5")
+        slow_cmd = f'"{sys.executable}" -c "import time; time.sleep(5)"'
+        result = await tool.run(command=slow_cmd)
         assert result.error is not None
         assert "timed out" in result.error.lower()
 

--- a/tests/observability/test_tracer.py
+++ b/tests/observability/test_tracer.py
@@ -64,3 +64,32 @@ class TestTokenTracer:
         t0 = tracer.start_timer()
         elapsed = tracer.elapsed_ms(t0)
         assert elapsed >= 0.0
+
+    def test_quality_history_and_averages(self):
+        tracer = TokenTracer(model="gpt-4o-mini")
+        tracer.record(input_tokens=100, output_tokens=50, latency_ms=10.0)
+        tracer.record_quality(faithfulness=0.8, relevancy=0.6, call_id=1)
+        tracer.record(input_tokens=100, output_tokens=50, latency_ms=10.0)
+        tracer.record_quality(faithfulness=1.0, relevancy=0.9, call_id=2)
+
+        history = tracer.quality_history()
+        assert len(history) == 2
+        assert history[0]["call_id"] == 1
+        assert history[1]["call_id"] == 2
+
+        s = tracer.summary()
+        assert s["avg_faithfulness"] == 0.9
+        assert s["avg_relevancy"] == 0.75
+
+    def test_quality_trend_improving_and_degrading(self):
+        improving = TokenTracer(model="gpt-4o-mini", quality_window=4, quality_trend_threshold=0.01)
+        for score in [0.2, 0.3, 0.8, 0.9]:
+            improving.record(input_tokens=1, output_tokens=1, latency_ms=1.0)
+            improving.record_quality(faithfulness=score, relevancy=score)
+        assert improving.summary()["quality_trend"] == "improving"
+
+        degrading = TokenTracer(model="gpt-4o-mini", quality_window=4, quality_trend_threshold=0.01)
+        for score in [0.9, 0.8, 0.3, 0.2]:
+            degrading.record(input_tokens=1, output_tokens=1, latency_ms=1.0)
+            degrading.record_quality(faithfulness=score, relevancy=score)
+        assert degrading.summary()["quality_trend"] == "degrading"

--- a/tests/rag/test_facade.py
+++ b/tests/rag/test_facade.py
@@ -161,3 +161,7 @@ class TestRAGFacade:
         _patch_rag(rag)
         await rag.ask("test")
         assert rag.tracer.summary()["calls"] == 0
+
+    def test_auto_eval_flag_propagates_to_pipeline(self):
+        rag = RAG(model="gpt-4o-mini", api_key="sk-test", auto_eval=True)
+        assert rag._pipeline.config.auto_eval is True

--- a/tests/rag/test_pipeline.py
+++ b/tests/rag/test_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -171,3 +172,95 @@ class TestRAGPipeline:
         pipeline = RAGPipeline(RAGConfig(llm=llm, retriever=retriever, memory=ConversationMemory()))
         # add should not raise — TextSplitter is pure Python
         await pipeline.add("Hello world. This is a test document.")
+
+    @pytest.mark.asyncio
+    async def test_auto_eval_non_blocking(self):
+        llm = make_mock_llm()
+        retriever = make_mock_retriever(chunks=["Context chunk 1."])
+        memory = ConversationMemory()
+        tracer = TokenTracer(model="gpt-4o-mini")
+        pipeline = RAGPipeline(
+            RAGConfig(
+                llm=llm,
+                retriever=retriever,
+                memory=memory,
+                tracer=tracer,
+                auto_eval=True,
+            )
+        )
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def fake_run_auto_eval(*, query, answer, contexts, call_id):
+            started.set()
+            await release.wait()
+
+        pipeline._run_auto_eval = fake_run_auto_eval  # type: ignore[method-assign]
+
+        answer = await asyncio.wait_for(pipeline.ask("What is this?"), timeout=0.5)
+        assert answer == "Hello world"
+
+        await asyncio.sleep(0)
+        assert started.is_set(), "auto_eval task should be scheduled in the background"
+
+        release.set()
+        await pipeline.wait_for_auto_eval()
+
+    @pytest.mark.asyncio
+    async def test_auto_eval_records_quality_scores(self):
+        llm = make_mock_llm()
+        retriever = make_mock_retriever(chunks=["Context chunk 1."])
+        memory = ConversationMemory()
+        tracer = TokenTracer(model="gpt-4o-mini")
+        pipeline = RAGPipeline(
+            RAGConfig(
+                llm=llm,
+                retriever=retriever,
+                memory=memory,
+                tracer=tracer,
+                auto_eval=True,
+            )
+        )
+
+        async def fake_run_auto_eval(*, query, answer, contexts, call_id):
+            tracer.record_quality(faithfulness=0.9, relevancy=0.8, call_id=call_id)
+
+        pipeline._run_auto_eval = fake_run_auto_eval  # type: ignore[method-assign]
+
+        await pipeline.ask("What is this?")
+        await pipeline.wait_for_auto_eval()
+
+        summary = tracer.summary()
+        assert summary["avg_faithfulness"] == 0.9
+        assert summary["avg_relevancy"] == 0.8
+
+    @pytest.mark.asyncio
+    async def test_auto_eval_disabled_by_default(self):
+        llm = make_mock_llm()
+        retriever = make_mock_retriever(chunks=["Context chunk 1."])
+        memory = ConversationMemory()
+        tracer = TokenTracer(model="gpt-4o-mini")
+        pipeline = RAGPipeline(
+            RAGConfig(
+                llm=llm,
+                retriever=retriever,
+                memory=memory,
+                tracer=tracer,
+                auto_eval=False,
+            )
+        )
+
+        called = False
+
+        async def fake_run_auto_eval(*, query, answer, contexts, call_id):
+            nonlocal called
+            called = True
+
+        pipeline._run_auto_eval = fake_run_auto_eval  # type: ignore[method-assign]
+
+        await pipeline.ask("What is this?")
+        await asyncio.sleep(0)
+
+        assert not called
+        assert tracer.summary()["avg_faithfulness"] == 0.0

--- a/tests/test_perf_regression.py
+++ b/tests/test_perf_regression.py
@@ -849,17 +849,15 @@ class TestSitemapLoaderRegression:
         """_collect_urls must use a deque, not a plain list."""
         import inspect
 
-        import synapsekit.loaders.sitemap as sitemap_module
+        from synapsekit.loaders import sitemap as sitemap_module
 
-        source = inspect.getsource(
-            sitemap_module._SitemapLoader__class__ if False else sitemap_module
-        )
+        source = inspect.getsource(sitemap_module)
         # Check deque is imported and used in the source
         assert "deque" in source
         assert "popleft" in source
 
     def test_deque_imported_in_module(self):
-        import synapsekit.loaders.sitemap as mod
+        from synapsekit.loaders import sitemap as mod
 
         # deque must be importable from the module's namespace
         assert "deque" in dir(mod) or hasattr(mod, "deque") or "deque" in mod.__dict__

--- a/tests/test_perf_regression.py
+++ b/tests/test_perf_regression.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from collections import deque
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -333,9 +332,9 @@ class TestWebScraperRegression:
 
     @pytest.mark.asyncio
     async def test_validate_url_is_async_coroutine(self):
-        from synapsekit.agents.tools.web_scraper import _validate_url
-
         import inspect
+
+        from synapsekit.agents.tools.web_scraper import _validate_url
 
         assert inspect.iscoroutinefunction(_validate_url)
 
@@ -384,8 +383,9 @@ class TestWebScraperRegression:
 
     @pytest.mark.asyncio
     async def test_gaierror_is_ignored(self):
-        from synapsekit.agents.tools.web_scraper import _validate_url
         import socket
+
+        from synapsekit.agents.tools.web_scraper import _validate_url
 
         with patch("socket.gethostbyname", side_effect=socket.gaierror):
             # Should not raise — unknown hosts are allowed through
@@ -421,9 +421,9 @@ class TestHTTPRequestToolRegression:
         mock_instance.request.return_value.__aenter__ = AsyncMock(return_value=resp)
         mock_instance.request.return_value.__aexit__ = AsyncMock(return_value=False)
 
-        MockSession = MagicMock(return_value=mock_instance)
+        mock_session_cls = MagicMock(return_value=mock_instance)
         mock_aiohttp = MagicMock()
-        mock_aiohttp.ClientSession = MockSession
+        mock_aiohttp.ClientSession = mock_session_cls
         mock_aiohttp.ClientTimeout = MagicMock(return_value=MagicMock())
 
         with patch.dict(sys.modules, {"aiohttp": mock_aiohttp}):
@@ -433,7 +433,7 @@ class TestHTTPRequestToolRegression:
             await tool.run(url="https://example.com")
 
         # Session constructor called exactly once despite two run() calls
-        assert MockSession.call_count == 1
+        assert mock_session_cls.call_count == 1
 
     @pytest.mark.asyncio
     async def test_aclose_clears_session(self):
@@ -812,8 +812,8 @@ class TestEvaluationPipelineRegression:
     @pytest.mark.asyncio
     async def test_batch_concurrency_semaphore_limits_concurrent(self):
         """Semaphore must cap concurrent evaluations at `concurrency`."""
-        from synapsekit.evaluation.pipeline import EvaluationPipeline
         from synapsekit.evaluation.base import MetricResult
+        from synapsekit.evaluation.pipeline import EvaluationPipeline
 
         active: list[int] = []
         peak: list[int] = [0]
@@ -832,7 +832,7 @@ class TestEvaluationPipelineRegression:
         pipeline = EvaluationPipeline([m])
         samples = [{"question": f"q{i}", "answer": "a"} for i in range(20)]
         await pipeline.evaluate_batch(samples, concurrency=3)
-        # Peak concurrent evaluations must not exceed concurrency × metrics
+        # Peak concurrent evaluations must not exceed concurrency x metrics
         assert peak[0] <= 3
 
 
@@ -847,10 +847,13 @@ class TestSitemapLoaderRegression:
     @pytest.mark.asyncio
     async def test_collect_urls_uses_deque(self):
         """_collect_urls must use a deque, not a plain list."""
-        import synapsekit.loaders.sitemap as sitemap_module
         import inspect
 
-        source = inspect.getsource(sitemap_module._SitemapLoader__class__ if False else sitemap_module)
+        import synapsekit.loaders.sitemap as sitemap_module
+
+        source = inspect.getsource(
+            sitemap_module._SitemapLoader__class__ if False else sitemap_module
+        )
         # Check deque is imported and used in the source
         assert "deque" in source
         assert "popleft" in source


### PR DESCRIPTION
## Summary
- add auto_eval flag to RAGConfig and RAG facade to enable automatic eval on traced calls
- schedule non-blocking background eval in RAGPipeline and expose wait_for_auto_eval() for tests/consumers
- extend TokenTracer with quality recording/history/trend and averaged faithfulness/relevancy in summary()
- add/adjust tests for pipeline auto-eval flow, tracer quality stats, and CI portability lint fixes

## Validation
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run mypy
- uv run deptry src/
- uv run pytest tests/ -q (2735 passed, 59 skipped)

Closes #591