### PR TITLE
feat(agents): add CronTrigger for scheduled agent execution

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -38,8 +38,12 @@ jobs:
           URL="${{ github.event.pull_request.html_url }}"
           NUMBER="${{ github.event.pull_request.number }}"
           PAYLOAD="{\"embeds\":[{\"title\":\"PR #${NUMBER} opened\",\"description\":\"**${TITLE}**\n\n[View PR](${URL})\",\"color\":3447003,\"footer\":{\"text\":\"${AUTHOR}\"}}]}"
-          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_PR_FEED }}" -H "Content-Type: application/json" -d "$PAYLOAD"
-          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_GITHUB_ACTIVITY }}" -H "Content-Type: application/json" -d "$PAYLOAD"
+          if [ -n "${{ secrets.DISCORD_WEBHOOK_PR_FEED }}" ]; then
+            curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_PR_FEED }}" -H "Content-Type: application/json" -d "$PAYLOAD"
+          fi
+          if [ -n "${{ secrets.DISCORD_WEBHOOK_GITHUB_ACTIVITY }}" ]; then
+            curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_GITHUB_ACTIVITY }}" -H "Content-Type: application/json" -d "$PAYLOAD"
+          fi
 
   notify-pr-merged:
     if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ rss = ["feedparser>=6.0"]
 groq = ["groq>=0.9"]
 audio = ["openai>=1.0"]
 video = ["openai>=1.0"]
+cron = ["croniter>=2.0"]
 excel = ["openpyxl>=3.1"]
 pptx = ["python-pptx>=0.6"]
 docx = ["python-docx>=1.0"]
@@ -164,6 +165,7 @@ all = [
     "psycopg[binary]>=3.1",
     "asyncpg>=0.29",
     "groq>=0.9",
+    "croniter>=2.0",
     "llama-cpp-python>=0.2",
     "erniebot>=0.5",
     "wolframalpha>=5.0",

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -34,6 +34,7 @@ from .agents import (
     Crew,
     CrewAgent,
     CrewResult,
+    CronTrigger,
     DateTimeTool,
     DuckDuckGoSearchTool,
     EmailTool,
@@ -86,6 +87,7 @@ from .agents import (
     ToolResult,
     TopicRestrictor,
     TranslationTool,
+    TriggerResult,
     TwilioTool,
     VectorSearchTool,
     WeatherTool,
@@ -426,6 +428,8 @@ __all__ = [
     "FunctionCallingAgent",
     "AgentExecutor",
     "AgentConfig",
+    "CronTrigger",
+    "TriggerResult",
     # Tool decorator
     "tool",
     # Multi-agent

--- a/src/synapsekit/agents/__init__.py
+++ b/src/synapsekit/agents/__init__.py
@@ -83,6 +83,7 @@ from .tools import (
     WolframAlphaTool,
     YouTubeSearchTool,
 )
+from .triggers import CronTrigger, TriggerResult
 
 __all__ = [
     # Core
@@ -97,6 +98,8 @@ __all__ = [
     "FunctionCallingAgent",
     "AgentExecutor",
     "AgentConfig",
+    "CronTrigger",
+    "TriggerResult",
     # Guardrails
     "ContentFilter",
     "Guardrails",

--- a/src/synapsekit/agents/tools/http_request.py
+++ b/src/synapsekit/agents/tools/http_request.py
@@ -69,7 +69,7 @@ class HTTPRequestTool(BaseTool):
             await self._session.close()
             self._session = None
 
-    async def __aenter__(self) -> "HTTPRequestTool":
+    async def __aenter__(self) -> HTTPRequestTool:
         return self
 
     async def __aexit__(self, *_: object) -> None:

--- a/src/synapsekit/agents/triggers/__init__.py
+++ b/src/synapsekit/agents/triggers/__init__.py
@@ -1,0 +1,3 @@
+from .cron import CronTrigger, TriggerResult
+
+__all__ = ["CronTrigger", "TriggerResult"]

--- a/src/synapsekit/agents/triggers/cron.py
+++ b/src/synapsekit/agents/triggers/cron.py
@@ -1,0 +1,295 @@
+"""Schedule-based agent execution via cron expressions or interval shorthand."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import re
+from collections.abc import Awaitable, Callable, Coroutine
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any, Literal
+from zoneinfo import ZoneInfo
+
+from ...observability.audit_log import AuditLog
+
+_INTERVAL_PATTERN = re.compile(r"^(?P<value>\d+)(?P<unit>[smhd])$")
+MissedRunPolicy = Literal["skip", "catch_up"]
+
+
+@dataclass(frozen=True)
+class TriggerResult:
+    """Result metadata for a single scheduled trigger execution."""
+
+    scheduled_for: datetime
+    started_at: datetime
+    finished_at: datetime
+    input_text: str
+    output: Any = None
+    error: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class CronTrigger:
+    """Run an agent on a cron schedule or fixed interval."""
+
+    def __init__(
+        self,
+        agent: Any,
+        *,
+        input: str,
+        schedule: str | None = None,
+        every: str | None = None,
+        timezone: str = "UTC",
+        missed_run_policy: MissedRunPolicy = "skip",
+        audit_log: AuditLog | None = None,
+        result_sink: Callable[[TriggerResult], Awaitable[None] | None] | None = None,
+        clock: Callable[[], datetime] | None = None,
+        sleep_func: Callable[[float], Coroutine[Any, Any, None]] | None = None,
+        max_catch_up_runs: int = 100,
+    ) -> None:
+        if (schedule is None) == (every is None):
+            raise ValueError("Provide exactly one of 'schedule' or 'every'.")
+        if missed_run_policy not in {"skip", "catch_up"}:
+            raise ValueError("missed_run_policy must be 'skip' or 'catch_up'.")
+        if max_catch_up_runs < 1:
+            raise ValueError("max_catch_up_runs must be >= 1.")
+
+        self.agent = agent
+        self.input = input
+        self.schedule = schedule
+        self.every = every
+        self.timezone = timezone
+        self.missed_run_policy = missed_run_policy
+        self.audit_log = audit_log
+        self.result_sink = result_sink
+        self.max_catch_up_runs = max_catch_up_runs
+
+        self._zone = ZoneInfo(timezone)
+        self._clock = clock or (lambda: datetime.now(self._zone))
+        self._sleep = sleep_func or asyncio.sleep
+        self._interval = self._parse_interval(every) if every is not None else None
+        self._stop_event = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        self._sleep_task: asyncio.Task[None] | None = None
+        self._next_run_at: datetime | None = None
+
+    @property
+    def is_running(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    @property
+    def next_run_at(self) -> datetime | None:
+        return self._next_run_at
+
+    async def start(self) -> None:
+        if self.is_running:
+            return
+        self._stop_event = asyncio.Event()
+        self._next_run_at = self._first_run_after(self._now())
+        self._task = asyncio.create_task(
+            self._run_loop(), name=f"CronTrigger[{self._source_name()}]"
+        )
+
+    async def stop(self) -> None:
+        task = self._task
+        if task is None:
+            return
+
+        self._stop_event.set()
+        if self._sleep_task is not None and not self._sleep_task.done():
+            self._sleep_task.cancel()
+
+        if asyncio.current_task() is task:
+            return
+
+        await task
+
+    async def _run_loop(self) -> None:
+        try:
+            if self._next_run_at is None:
+                self._next_run_at = self._first_run_after(self._now())
+
+            while not self._stop_event.is_set():
+                next_run = self._next_run_at
+                if next_run is None:
+                    next_run = self._first_run_after(self._now())
+                    self._next_run_at = next_run
+
+                now = self._now()
+                if now < next_run:
+                    await self._sleep_until(next_run)
+                    continue
+
+                if self.missed_run_policy == "catch_up":
+                    scheduled_runs, next_run_at = self._collect_catch_up_runs(next_run)
+                else:
+                    scheduled_runs = [next_run]
+                    next_run_at = None
+
+                for scheduled_for in scheduled_runs:
+                    await self._execute_run(scheduled_for)
+                    if self._stop_event.is_set():
+                        break
+
+                if self._stop_event.is_set():
+                    break
+
+                if self.missed_run_policy == "catch_up":
+                    self._next_run_at = next_run_at
+                else:
+                    self._next_run_at = self._next_future_run(scheduled_runs[-1])
+        finally:
+            self._sleep_task = None
+            self._task = None
+
+    async def _sleep_until(self, target: datetime) -> None:
+        delay = max(0.0, (target - self._now()).total_seconds())
+        self._sleep_task = asyncio.create_task(self._sleep(delay))
+        try:
+            await self._sleep_task
+        except asyncio.CancelledError:
+            if not self._stop_event.is_set():
+                raise
+        finally:
+            self._sleep_task = None
+
+    def _collect_catch_up_runs(self, first_due: datetime) -> tuple[list[datetime], datetime]:
+        scheduled_runs = [first_due]
+        next_run = self._advance(first_due)
+        now = self._now()
+
+        while next_run <= now and len(scheduled_runs) < self.max_catch_up_runs:
+            scheduled_runs.append(next_run)
+            next_run = self._advance(next_run)
+
+        return scheduled_runs, next_run
+
+    def _next_future_run(self, previous_run: datetime) -> datetime:
+        next_run = self._advance(previous_run)
+        now = self._now()
+        while next_run <= now:
+            next_run = self._advance(next_run)
+        return next_run
+
+    async def _execute_run(self, scheduled_for: datetime) -> None:
+        started_at = self._now()
+        output: Any = None
+        error_text: str | None = None
+
+        try:
+            output = await self._invoke_agent(self.input)
+        except Exception as exc:  # pragma: no cover - behavior preserved via logging/result sink
+            error_text = f"{type(exc).__name__}: {exc}"
+
+        finished_at = self._now()
+        result = TriggerResult(
+            scheduled_for=scheduled_for,
+            started_at=started_at,
+            finished_at=finished_at,
+            input_text=self.input,
+            output=output,
+            error=error_text,
+            metadata={
+                "timezone": self.timezone,
+                "schedule": self.schedule,
+                "every": self.every,
+                "missed_run_policy": self.missed_run_policy,
+            },
+        )
+
+        if self.audit_log is not None:
+            self.audit_log.record(
+                model=self._model_name(),
+                input_text=self.input,
+                output_text="" if output is None else str(output),
+                latency_ms=(finished_at - started_at).total_seconds() * 1000,
+                user=self._source_name(),
+                metadata={
+                    **result.metadata,
+                    "scheduled_for": scheduled_for.isoformat(),
+                    "started_at": started_at.isoformat(),
+                    "finished_at": finished_at.isoformat(),
+                    "error": error_text,
+                },
+            )
+
+        if self.result_sink is not None:
+            maybe_awaitable = self.result_sink(result)
+            if inspect.isawaitable(maybe_awaitable):
+                await maybe_awaitable
+
+    async def _invoke_agent(self, payload: str) -> Any:
+        runner = getattr(self.agent, "run", None)
+        if runner is None:
+            if not callable(self.agent):
+                raise TypeError("agent must be callable or define a 'run' method")
+            runner = self.agent
+
+        result = runner(payload)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    def _first_run_after(self, base: datetime) -> datetime:
+        return self._advance(base)
+
+    def _advance(self, base: datetime) -> datetime:
+        if self._interval is not None:
+            return base + self._interval
+        return self._cron_next(base)
+
+    def _cron_next(self, base: datetime) -> datetime:
+        try:
+            from croniter import croniter  # type: ignore[import-untyped]
+        except ModuleNotFoundError as exc:  # pragma: no cover - exercised only without optional dep
+            raise ImportError(
+                "CronTrigger schedule support requires the optional dependency 'croniter'. "
+                'Install it with: pip install "synapsekit[cron]" (or pip install croniter)'
+            ) from exc
+
+        cron = croniter(self.schedule, base)
+        next_run = cron.get_next(datetime)
+        return self._normalize_datetime(next_run)
+
+    def _now(self) -> datetime:
+        current = self._clock()
+        return self._normalize_datetime(current)
+
+    def _normalize_datetime(self, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value.replace(tzinfo=self._zone)
+        return value.astimezone(self._zone)
+
+    def _model_name(self) -> str:
+        llm = getattr(getattr(self.agent, "config", None), "llm", None)
+        for attr in ("model", "model_name", "name"):
+            candidate = getattr(llm, attr, None)
+            if candidate:
+                return str(candidate)
+        return type(self.agent).__name__
+
+    def _source_name(self) -> str:
+        agent_id = getattr(getattr(self.agent, "config", None), "agent_id", None)
+        if agent_id:
+            return str(agent_id)
+        return type(self.agent).__name__
+
+    @staticmethod
+    def _parse_interval(raw: str | None) -> timedelta:
+        if raw is None:
+            raise ValueError("every must not be None")
+
+        match = _INTERVAL_PATTERN.fullmatch(raw.strip())
+        if match is None:
+            raise ValueError("every must use interval shorthand like '30m', '1h', '10s', or '2d'.")
+
+        value = int(match.group("value"))
+        unit = match.group("unit")
+        unit_map = {
+            "s": "seconds",
+            "m": "minutes",
+            "h": "hours",
+            "d": "days",
+        }
+        return timedelta(**{unit_map[unit]: value})

--- a/src/synapsekit/evaluation/pipeline.py
+++ b/src/synapsekit/evaluation/pipeline.py
@@ -73,8 +73,8 @@ class EvaluationPipeline:
             ]
         )
 
-        scores = {m.name: r.score for m, r in zip(self._metrics, metric_results)}
-        details = {m.name: r for m, r in zip(self._metrics, metric_results)}
+        scores = {m.name: r.score for m, r in zip(self._metrics, metric_results, strict=True)}
+        details = {m.name: r for m, r in zip(self._metrics, metric_results, strict=True)}
         return EvaluationResult(scores=scores, details=details)
 
     async def evaluate_batch(

--- a/src/synapsekit/llm/_semantic_cache.py
+++ b/src/synapsekit/llm/_semantic_cache.py
@@ -14,7 +14,7 @@ class SemanticCache:
     cached responses when similarity exceeds a threshold.
 
     Vectors are L2-normalised on insertion so lookup reduces to a single
-    batched matrix–vector multiply (one BLAS call) instead of a Python
+    batched matrix-vector multiply (one BLAS call) instead of a Python
     for-loop over individual dot products.
 
     Usage::
@@ -65,7 +65,7 @@ class SemanticCache:
 
         Returns the cached response if similarity >= threshold, else None.
         All cached vectors are L2-normalised, so the cosine similarity matrix
-        is computed as a single BLAS matrix–vector multiply instead of a
+        is computed as a single BLAS matrix-vector multiply instead of a
         Python-level loop.
         """
         if not self._entries:
@@ -77,11 +77,11 @@ class SemanticCache:
 
         # Rebuild the stacked matrix only when entries have changed
         if self._dirty or self._matrix is None:
-            self._matrix = np.vstack(self._vectors)  # (n, D) – one allocation
+            self._matrix = np.vstack(self._vectors)  # (n, D) - one allocation
             self._dirty = False
 
         # One BLAS call replaces the entire Python for-loop
-        scores = self._matrix @ query_arr  # (n,) – dot == cosine for unit vecs
+        scores = self._matrix @ query_arr  # (n,) - dot == cosine for unit vecs
         best_idx = int(np.argmax(scores))
         best_score = float(scores[best_idx])
 

--- a/src/synapsekit/llm/_sqlite_cache.py
+++ b/src/synapsekit/llm/_sqlite_cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+from contextlib import suppress
 from typing import Any
 
 from ._cache import AsyncLRUCache
@@ -67,14 +68,12 @@ class SQLiteLLMCache:
 
     def close(self) -> None:
         """Close the underlying SQLite connection. Idempotent."""
-        try:
+        with suppress(Exception):
             self._conn.close()
-        except Exception:
-            pass
 
     # ── context manager ────────────────────────────────────────────────────
 
-    def __enter__(self) -> "SQLiteLLMCache":
+    def __enter__(self) -> SQLiteLLMCache:
         return self
 
     def __exit__(self, *_: object) -> None:
@@ -82,7 +81,5 @@ class SQLiteLLMCache:
 
     def __del__(self) -> None:
         """Last-resort cleanup if the caller forgets to call close()."""
-        try:
+        with suppress(Exception):
             self.close()
-        except Exception:
-            pass

--- a/src/synapsekit/retrieval/ensemble.py
+++ b/src/synapsekit/retrieval/ensemble.py
@@ -54,7 +54,7 @@ class EnsembleRetriever:
         )
 
         scores: dict[str, float] = {}
-        for results, weight in zip(all_results, self._weights):
+        for results, weight in zip(all_results, self._weights, strict=True):
             for rank, text in enumerate(results):
                 scores[text] = scores.get(text, 0.0) + weight / (self._rrf_k + rank + 1)
 

--- a/src/synapsekit/retrieval/vectorstore.py
+++ b/src/synapsekit/retrieval/vectorstore.py
@@ -27,7 +27,7 @@ class InMemoryVectorStore(VectorStore):
 
     * **O(fetch_k²) MMR precomputation** — the pairwise similarity matrix for
       the candidate pool is computed once with a single BLAS call before the
-      greedy selection loop, replacing O(top_k × fetch_k × selected) Python-
+      greedy selection loop, replacing O(top_k x fetch_k x selected) Python-
       level dot products.
     """
 
@@ -84,9 +84,7 @@ class InMemoryVectorStore(VectorStore):
         """
         if not metadata_filter:
             return None
-        candidate_sets = [
-            self._index.get(k, {}).get(v, set()) for k, v in metadata_filter.items()
-        ]
+        candidate_sets = [self._index.get(k, {}).get(v, set()) for k, v in metadata_filter.items()]
         if not candidate_sets or any(not s for s in candidate_sets):
             return []
         return sorted(set.intersection(*candidate_sets))
@@ -173,7 +171,7 @@ class InMemoryVectorStore(VectorStore):
 
         The pairwise similarity matrix for the candidate pool is precomputed
         with a single BLAS call before the greedy loop, replacing the previous
-        O(top_k × fetch_k × selected) Python-level dot-product recomputation.
+        O(top_k x fetch_k x selected) Python-level dot-product recomputation.
         """
         if not self._texts:
             return []
@@ -204,17 +202,16 @@ class InMemoryVectorStore(VectorStore):
             return []
 
         pool_indices = [idx for idx, _ in pool]
-        pool_rel_scores = [rel for _, rel in pool]
 
         # ── precompute pairwise similarity matrix for the pool (one BLAS call) ──
-        pool_vecs = self._vectors[pool_indices]     # (fetch_k, D)
-        sim_matrix = pool_vecs @ pool_vecs.T         # (fetch_k, fetch_k)
+        pool_vecs = self._vectors[pool_indices]  # (fetch_k, D)
+        sim_matrix = pool_vecs @ pool_vecs.T  # (fetch_k, fetch_k)
 
         # Greedy MMR selection
-        selected: list[int] = []           # global indices of selected docs
-        selected_pos: list[int] = []       # corresponding positions in pool
+        selected: list[int] = []  # global indices of selected docs
+        selected_pos: list[int] = []  # corresponding positions in pool
 
-        selected_set: set[int] = set()     # O(1) membership test
+        selected_set: set[int] = set()  # O(1) membership test
 
         for _ in range(min(top_k, len(pool))):
             best_global_idx = -1

--- a/tests/agents/test_cron_trigger.py
+++ b/tests/agents/test_cron_trigger.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import asyncio
+import builtins
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import synapsekit.agents.triggers.cron as cron_module
+from synapsekit import CronTrigger as TopLevelCronTrigger
+from synapsekit import TriggerResult as TopLevelTriggerResult
+from synapsekit.agents.triggers import CronTrigger, TriggerResult
+from synapsekit.observability import AuditLog
+
+
+@dataclass
+class ControlledClock:
+    current: datetime
+    advances: list[float] | None = None
+    block_after_calls: int | None = None
+
+    def __post_init__(self) -> None:
+        self.sleep_calls: list[float] = []
+        self._blocker = asyncio.Event()
+
+    def now(self) -> datetime:
+        return self.current
+
+    async def sleep(self, seconds: float) -> None:
+        self.sleep_calls.append(seconds)
+        index = len(self.sleep_calls) - 1
+        actual = seconds
+        if self.advances is not None and index < len(self.advances):
+            actual = self.advances[index]
+        self.current += timedelta(seconds=actual)
+        await asyncio.sleep(0)
+        if self.block_after_calls is not None and len(self.sleep_calls) >= self.block_after_calls:
+            await self._blocker.wait()
+
+
+async def spin(count: int = 10) -> None:
+    for _ in range(count):
+        await asyncio.sleep(0)
+
+
+def test_trigger_exports_are_importable() -> None:
+    assert TopLevelCronTrigger is CronTrigger
+    assert TopLevelTriggerResult is TriggerResult
+
+
+@pytest.mark.asyncio
+async def test_interval_trigger_runs_and_logs_to_audit_log() -> None:
+    clock = ControlledClock(
+        current=datetime(2026, 1, 1, 9, 0, tzinfo=UTC),
+        block_after_calls=2,
+    )
+    agent = SimpleNamespace(
+        run=AsyncMock(return_value="summary ready"),
+        config=SimpleNamespace(agent_id="daily-brief"),
+    )
+    audit_log = AuditLog(backend="memory")
+
+    trigger = CronTrigger(
+        agent=agent,
+        every="5s",
+        input="summarize yesterday",
+        timezone="UTC",
+        audit_log=audit_log,
+        clock=clock.now,
+        sleep_func=clock.sleep,
+    )
+
+    await trigger.start()
+    await spin()
+
+    assert agent.run.await_count == 1
+    assert len(audit_log) == 1
+    entry = audit_log.query(limit=1)[0]
+    assert entry.input_text == "summarize yesterday"
+    assert entry.output_text == "summary ready"
+    assert entry.user == "daily-brief"
+
+    await trigger.stop()
+
+
+@pytest.mark.asyncio
+async def test_cron_expression_uses_croniter_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeCronIter:
+        def __init__(self, expr: str, base: datetime) -> None:
+            assert expr == "*/15 * * * *"
+            self.expr = expr
+            self.base = base
+
+        def get_next(self, result_type: type[datetime]) -> datetime:
+            assert result_type is datetime
+            self.base = self.base + timedelta(minutes=15)
+            return self.base
+
+    monkeypatch.setitem(sys.modules, "croniter", SimpleNamespace(croniter=FakeCronIter))
+
+    clock = ControlledClock(
+        current=datetime(2026, 1, 1, 9, 0, tzinfo=UTC),
+        block_after_calls=2,
+    )
+    agent = SimpleNamespace(run=AsyncMock(return_value="ran"))
+
+    trigger = CronTrigger(
+        agent=agent,
+        schedule="*/15 * * * *",
+        input="tick",
+        timezone="UTC",
+        clock=clock.now,
+        sleep_func=clock.sleep,
+    )
+
+    await trigger.start()
+    await spin()
+
+    assert clock.sleep_calls[0] == 900
+    assert agent.run.await_count == 1
+
+    await trigger.stop()
+
+
+@pytest.mark.asyncio
+async def test_catch_up_replays_missed_interval_runs() -> None:
+    clock = ControlledClock(
+        current=datetime(2026, 1, 1, 9, 0, tzinfo=UTC),
+        advances=[16, 5],
+        block_after_calls=2,
+    )
+    agent = SimpleNamespace(run=AsyncMock(return_value="ok"))
+
+    trigger = CronTrigger(
+        agent=agent,
+        every="5s",
+        input="check queue",
+        timezone="UTC",
+        missed_run_policy="catch_up",
+        clock=clock.now,
+        sleep_func=clock.sleep,
+    )
+
+    await trigger.start()
+    await spin()
+
+    assert agent.run.await_count == 3
+
+    await trigger.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_waits_for_in_flight_run_to_finish() -> None:
+    clock = ControlledClock(current=datetime(2026, 1, 1, 9, 0, tzinfo=UTC))
+    started = asyncio.Event()
+    release = asyncio.Event()
+    finished = asyncio.Event()
+
+    async def run(_: str) -> str:
+        started.set()
+        await release.wait()
+        finished.set()
+        return "done"
+
+    agent = SimpleNamespace(run=run)
+    trigger = CronTrigger(
+        agent=agent,
+        every="5s",
+        input="do work",
+        timezone="UTC",
+        clock=clock.now,
+        sleep_func=clock.sleep,
+    )
+
+    await trigger.start()
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    stop_task = asyncio.create_task(trigger.stop())
+    await asyncio.sleep(0)
+    assert not stop_task.done()
+
+    release.set()
+    await asyncio.wait_for(stop_task, timeout=1)
+
+    assert finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_skip_policy_drops_overdue_runs_after_long_execution() -> None:
+    clock = ControlledClock(
+        current=datetime(2026, 1, 1, 9, 0, tzinfo=UTC),
+        block_after_calls=2,
+    )
+    audit_log = AuditLog(backend="memory")
+
+    async def run(_: str) -> str:
+        if len(audit_log) == 0:
+            clock.current += timedelta(seconds=16)
+        return "ok"
+
+    trigger = CronTrigger(
+        agent=SimpleNamespace(run=run),
+        every="5s",
+        input="process once",
+        timezone="UTC",
+        audit_log=audit_log,
+        clock=clock.now,
+        sleep_func=clock.sleep,
+    )
+
+    await trigger.start()
+    await spin()
+    await trigger.stop()
+
+    assert len(audit_log) == 1
+    assert audit_log.query(limit=1)[0].metadata["scheduled_for"] == "2026-01-01T09:00:05+00:00"
+    assert trigger.next_run_at == datetime(2026, 1, 1, 9, 0, 25, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_result_sink_can_stop_trigger_without_self_await_deadlock() -> None:
+    clock = ControlledClock(current=datetime(2026, 1, 1, 9, 0, tzinfo=UTC))
+    stopped = asyncio.Event()
+    trigger: CronTrigger | None = None
+
+    async def sink(_: object) -> None:
+        assert trigger is not None
+        await trigger.stop()
+        stopped.set()
+
+    trigger = CronTrigger(
+        agent=SimpleNamespace(run=AsyncMock(return_value="done")),
+        every="5s",
+        input="stop after first run",
+        timezone="UTC",
+        clock=clock.now,
+        sleep_func=clock.sleep,
+        result_sink=sink,
+    )
+
+    await trigger.start()
+    await asyncio.wait_for(stopped.wait(), timeout=1)
+
+    assert not trigger.is_running
+
+
+def test_default_clock_is_timezone_aware(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeDateTime:
+        @classmethod
+        def now(cls, tz: object = None) -> datetime:
+            assert tz is not None
+            return datetime(2026, 1, 1, 9, 0, tzinfo=tz)
+
+    monkeypatch.setattr(cron_module, "datetime", FakeDateTime)
+    trigger = CronTrigger(
+        agent=SimpleNamespace(run=AsyncMock(return_value="done")),
+        every="5s",
+        input="aware now",
+        timezone="Asia/Kolkata",
+    )
+
+    assert trigger._now() == datetime(
+        2026,
+        1,
+        1,
+        9,
+        0,
+        tzinfo=trigger.next_run_at.tzinfo if trigger.next_run_at else trigger._zone,
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_croniter_error_mentions_synapsekit_cron_extra(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_import = builtins.__import__
+
+    def fake_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "croniter":
+            raise ModuleNotFoundError(name)
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("croniter", None)
+
+    trigger = CronTrigger(
+        agent=SimpleNamespace(run=AsyncMock(return_value="done")),
+        schedule="0 9 * * *",
+        input="cron",
+        timezone="UTC",
+        clock=lambda: datetime(2026, 1, 1, 9, 0, tzinfo=UTC),
+        sleep_func=AsyncMock(),
+    )
+
+    with pytest.raises(ImportError, match="synapsekit\\[cron\\]"):
+        await trigger.start()

--- a/tests/test_perf_regression.py
+++ b/tests/test_perf_regression.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from collections import deque
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -333,9 +332,9 @@ class TestWebScraperRegression:
 
     @pytest.mark.asyncio
     async def test_validate_url_is_async_coroutine(self):
-        from synapsekit.agents.tools.web_scraper import _validate_url
-
         import inspect
+
+        from synapsekit.agents.tools.web_scraper import _validate_url
 
         assert inspect.iscoroutinefunction(_validate_url)
 
@@ -384,8 +383,9 @@ class TestWebScraperRegression:
 
     @pytest.mark.asyncio
     async def test_gaierror_is_ignored(self):
-        from synapsekit.agents.tools.web_scraper import _validate_url
         import socket
+
+        from synapsekit.agents.tools.web_scraper import _validate_url
 
         with patch("socket.gethostbyname", side_effect=socket.gaierror):
             # Should not raise — unknown hosts are allowed through
@@ -421,9 +421,9 @@ class TestHTTPRequestToolRegression:
         mock_instance.request.return_value.__aenter__ = AsyncMock(return_value=resp)
         mock_instance.request.return_value.__aexit__ = AsyncMock(return_value=False)
 
-        MockSession = MagicMock(return_value=mock_instance)
+        mock_session_cls = MagicMock(return_value=mock_instance)
         mock_aiohttp = MagicMock()
-        mock_aiohttp.ClientSession = MockSession
+        mock_aiohttp.ClientSession = mock_session_cls
         mock_aiohttp.ClientTimeout = MagicMock(return_value=MagicMock())
 
         with patch.dict(sys.modules, {"aiohttp": mock_aiohttp}):
@@ -433,7 +433,7 @@ class TestHTTPRequestToolRegression:
             await tool.run(url="https://example.com")
 
         # Session constructor called exactly once despite two run() calls
-        assert MockSession.call_count == 1
+        assert mock_session_cls.call_count == 1
 
     @pytest.mark.asyncio
     async def test_aclose_clears_session(self):
@@ -812,8 +812,8 @@ class TestEvaluationPipelineRegression:
     @pytest.mark.asyncio
     async def test_batch_concurrency_semaphore_limits_concurrent(self):
         """Semaphore must cap concurrent evaluations at `concurrency`."""
-        from synapsekit.evaluation.pipeline import EvaluationPipeline
         from synapsekit.evaluation.base import MetricResult
+        from synapsekit.evaluation.pipeline import EvaluationPipeline
 
         active: list[int] = []
         peak: list[int] = [0]
@@ -832,7 +832,7 @@ class TestEvaluationPipelineRegression:
         pipeline = EvaluationPipeline([m])
         samples = [{"question": f"q{i}", "answer": "a"} for i in range(20)]
         await pipeline.evaluate_batch(samples, concurrency=3)
-        # Peak concurrent evaluations must not exceed concurrency × metrics
+        # Peak concurrent evaluations must not exceed concurrency x metrics
         assert peak[0] <= 3
 
 
@@ -847,10 +847,13 @@ class TestSitemapLoaderRegression:
     @pytest.mark.asyncio
     async def test_collect_urls_uses_deque(self):
         """_collect_urls must use a deque, not a plain list."""
-        import synapsekit.loaders.sitemap as sitemap_module
         import inspect
 
-        source = inspect.getsource(sitemap_module._SitemapLoader__class__ if False else sitemap_module)
+        import synapsekit.loaders.sitemap as sitemap_module
+
+        source = inspect.getsource(
+            sitemap_module._SitemapLoader__class__ if False else sitemap_module
+        )
         # Check deque is imported and used in the source
         assert "deque" in source
         assert "popleft" in source


### PR DESCRIPTION
## Summary
- add `CronTrigger` for interval and cron-based agent scheduling
- export the trigger API and add optional `cron` extra for `croniter`
- add focused CronTrigger tests and clear existing Ruff/format blockers so CI stays green

## Testing
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run mypy
- uv run deptry src/
- uv run pytest tests/ -q

Closes #583