### PR TITLE
feat(agents): SelfHealingAgent — auto-downgrade model when cost threshold exceeded

### DIFF
--- a/src/synapsekit/agents/executor.py
+++ b/src/synapsekit/agents/executor.py
@@ -84,6 +84,11 @@ class AgentExecutor:
         async for token in self._agent.stream(query):
             yield token
 
+    async def stream_steps(self, query: str) -> AsyncGenerator:
+        """Async: stream step-by-step events including thoughts and actions."""
+        async for event in self._agent.stream_steps(query):
+            yield event
+
     def run_sync(self, query: str) -> str:
         """Sync: run agent (for scripts / notebooks)."""
         return run_sync(self.run(query))

--- a/src/synapsekit/agents/function_calling.py
+++ b/src/synapsekit/agents/function_calling.py
@@ -174,6 +174,7 @@ class FunctionCallingAgent:
         """Stream step-by-step events for function-calling agent."""
         from .step_events import (
             ActionEvent,
+            CostDowngradeEvent,
             ErrorEvent,
             FinalAnswerEvent,
             ObservationEvent,
@@ -191,7 +192,25 @@ class FunctionCallingAgent:
         tool_schemas = self._registry.schemas()
 
         for _ in range(self._max_iterations):
+            # Check for cost-downgrade events from router (pre-call)
+            if hasattr(self._llm, "consume_events"):
+                for raw_event in self._llm.consume_events():
+                    yield CostDowngradeEvent(
+                        from_model=raw_event["from_model"],
+                        to_model=raw_event["to_model"],
+                        reason=raw_event["reason"],
+                    )
+
             result: dict[str, Any] = await self._llm.call_with_tools(messages, tool_schemas)
+
+            # Check for cost-downgrade events after call
+            if hasattr(self._llm, "consume_events"):
+                for raw_event in self._llm.consume_events():
+                    yield CostDowngradeEvent(
+                        from_model=raw_event["from_model"],
+                        to_model=raw_event["to_model"],
+                        reason=raw_event["reason"],
+                    )
 
             tool_calls = result.get("tool_calls")
             content = result.get("content")

--- a/src/synapsekit/agents/react.py
+++ b/src/synapsekit/agents/react.py
@@ -204,6 +204,7 @@ class ReActAgent:
         """Stream step-by-step events including thoughts, actions, and tokens."""
         from .step_events import (
             ActionEvent,
+            CostDowngradeEvent,
             ErrorEvent,
             FinalAnswerEvent,
             ObservationEvent,
@@ -217,8 +218,25 @@ class ReActAgent:
         for _ in range(self._max_iterations):
             messages = self._build_messages(query, memory_context)
 
+            # Check for cost-downgrade events from router (pre-call)
+            if hasattr(self._llm, "consume_events"):
+                for raw_event in self._llm.consume_events():
+                    yield CostDowngradeEvent(
+                        from_model=raw_event["from_model"],
+                        to_model=raw_event["to_model"],
+                        reason=raw_event["reason"],
+                    )
+
             full_response = ""
             async for token in self._llm.stream_with_messages(messages):
+                # Also check during stream if supported (rare)
+                if hasattr(self._llm, "consume_events"):
+                    for raw_event in self._llm.consume_events():
+                        yield CostDowngradeEvent(
+                            from_model=raw_event["from_model"],
+                            to_model=raw_event["to_model"],
+                            reason=raw_event["reason"],
+                        )
                 yield TokenEvent(token=token)
                 full_response += token
 

--- a/src/synapsekit/agents/step_events.py
+++ b/src/synapsekit/agents/step_events.py
@@ -56,6 +56,22 @@ class ErrorEvent:
     type: str = "error"
 
 
+@dataclass
+class CostDowngradeEvent:
+    """Agent downgraded the model due to cost constraints."""
+
+    from_model: str
+    to_model: str
+    reason: str
+    type: str = "cost_downgrade"
+
+
 StepEvent = (
-    ThoughtEvent | ActionEvent | ObservationEvent | TokenEvent | FinalAnswerEvent | ErrorEvent
+    ThoughtEvent
+    | ActionEvent
+    | ObservationEvent
+    | TokenEvent
+    | FinalAnswerEvent
+    | ErrorEvent
+    | CostDowngradeEvent
 )

--- a/src/synapsekit/llm/cost_router.py
+++ b/src/synapsekit/llm/cost_router.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from ..llm._factory import make_llm
+from ..observability.budget_guard import BudgetExceededError
 from ..observability.tracer import COST_TABLE
 from .base import BaseLLM, LLMConfig
 
@@ -164,3 +165,218 @@ class CostRouter(BaseLLM):
     def selected_model(self) -> str | None:
         """The model that was actually used for the last call."""
         return self._selected_model
+
+
+class CostQualityRouter(BaseLLM):
+    """Router that automatically downgrades models to stay within a cost budget.
+
+    Example::
+
+        router = CostQualityRouter(
+            candidates=[gpt4o, gpt4o_mini, groq_llama],
+            max_cost_per_call_usd=0.02,
+            on_exceed="downgrade",
+        )
+        # If gpt4o is estimated to exceed $0.02, it fallbacks to gpt4o_mini.
+        answer = await router.generate("Complex reasoning task")
+    """
+
+    def __init__(
+        self,
+        candidates: list[BaseLLM],
+        max_cost_per_call_usd: float,
+        on_exceed: Literal["downgrade", "raise", "skip"] = "downgrade",
+    ) -> None:
+        super().__init__(LLMConfig(model="__cost_quality_router__", api_key="", provider="openai"))
+        self.candidates = candidates
+        self.max_cost_per_call_usd = max_cost_per_call_usd
+        self.on_exceed = on_exceed
+        self._pending_events: list[dict[str, Any]] = []
+
+    def _estimate_cost(self, llm: BaseLLM, messages: list[dict[str, Any]]) -> float:
+        """Heuristic cost estimation based on character count."""
+        model = llm.config.model
+        pricing = COST_TABLE.get(model)
+        if not pricing:
+            return 0.0
+
+        # Input estimate (4 chars ~ 1 token)
+        total_chars = sum(len(str(m.get("content", ""))) for m in messages)
+        input_tokens = total_chars // 4
+
+        # Output estimate (use max_tokens or default)
+        output_tokens = llm.config.max_tokens or 1024
+
+        return (input_tokens * pricing["input"]) + (output_tokens * pricing["output"])
+
+    def _record_downgrade(self, from_model: str, to_model: str, reason: str) -> None:
+        self._pending_events.append(
+            {
+                "type": "cost_downgrade",
+                "from_model": from_model,
+                "to_model": to_model,
+                "reason": reason,
+            }
+        )
+
+    def consume_events(self) -> list[dict[str, Any]]:
+        """Return and clear pending events."""
+        events = self._pending_events[:]
+        self._pending_events.clear()
+        return events
+
+    async def generate_with_messages(self, messages: list[dict[str, Any]], **kw: Any) -> str:
+        for i, llm in enumerate(self.candidates):
+            cost = self._estimate_cost(llm, messages)
+            if cost > self.max_cost_per_call_usd:
+                if self.on_exceed == "downgrade" and i < len(self.candidates) - 1:
+                    self._record_downgrade(
+                        llm.config.model,
+                        self.candidates[i + 1].config.model,
+                        f"Estimated cost ${cost:.6f} exceeds limit ${self.max_cost_per_call_usd:.6f}",
+                    )
+                    continue
+                elif self.on_exceed == "raise":
+                    raise BudgetExceededError(
+                        f"Estimated cost ${cost:.6f} exceeds limit ${self.max_cost_per_call_usd:.6f}",
+                        limit_type="per_call",
+                        limit_value=self.max_cost_per_call_usd,
+                        current=cost,
+                    )
+                elif self.on_exceed == "skip":
+                    return ""
+
+                # Last candidate or unknown strategy
+                if cost > self.max_cost_per_call_usd:
+                    raise BudgetExceededError(
+                        f"Final candidate '{llm.config.model}' estimated cost ${cost:.6f} exceeds limit ${self.max_cost_per_call_usd:.6f}",
+                        limit_type="per_call",
+                        limit_value=self.max_cost_per_call_usd,
+                        current=cost,
+                    )
+
+            try:
+                return await llm.generate_with_messages(messages, **kw)
+            except BudgetExceededError as exc:
+                if self.on_exceed == "downgrade" and i < len(self.candidates) - 1:
+                    self._record_downgrade(
+                        llm.config.model,
+                        self.candidates[i + 1].config.model,
+                        f"Budget exceeded during call: {exc}",
+                    )
+                    continue
+                raise
+
+        raise BudgetExceededError(
+            "All candidates exhausted or budget exceeded",
+            limit_type="per_call",
+            limit_value=self.max_cost_per_call_usd,
+            current=0.0,
+        )
+
+    async def stream_with_messages(
+        self, messages: list[dict[str, Any]], **kw: Any
+    ) -> AsyncGenerator[str]:
+        # Implementation note: real-time streaming fallback is hard because tokens
+        # might have already been yielded. For now, we only downgrade BEFORE
+        # starting the stream based on estimation.
+        for i, llm in enumerate(self.candidates):
+            cost = self._estimate_cost(llm, messages)
+            if cost > self.max_cost_per_call_usd:
+                if self.on_exceed == "downgrade" and i < len(self.candidates) - 1:
+                    self._record_downgrade(
+                        llm.config.model,
+                        self.candidates[i + 1].config.model,
+                        f"Estimated cost ${cost:.6f} exceeds limit ${self.max_cost_per_call_usd:.6f}",
+                    )
+                    continue
+                elif self.on_exceed == "raise":
+                    raise BudgetExceededError(
+                        f"Estimated cost ${cost:.6f} exceeds limit ${self.max_cost_per_call_usd:.6f}",
+                        limit_type="per_call",
+                        limit_value=self.max_cost_per_call_usd,
+                        current=cost,
+                    )
+                elif self.on_exceed == "skip":
+                    return
+
+            try:
+                async for token in llm.stream_with_messages(messages, **kw):
+                    yield token
+                return
+            except BudgetExceededError:
+                if self.on_exceed == "downgrade" and i < len(self.candidates) - 1:
+                    # Note: tokens might have already been yielded!
+                    self._record_downgrade(
+                        llm.config.model,
+                        self.candidates[i + 1].config.model,
+                        "Budget exceeded mid-stream",
+                    )
+                    continue
+                raise
+
+    async def stream(self, prompt: str, **kw: Any) -> AsyncGenerator[str]:
+        messages = [{"role": "user", "content": prompt}]
+        async for token in self.stream_with_messages(messages, **kw):
+            yield token
+
+    async def generate(self, prompt: str, **kw: Any) -> str:
+        messages = [{"role": "user", "content": prompt}]
+        return await self.generate_with_messages(messages, **kw)
+
+    async def _call_with_tools_impl(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        for i, llm in enumerate(self.candidates):
+            # We estimate cost based on messages + tools size
+            cost = self._estimate_cost(llm, messages)
+            # Add an arbitrary 10% overhead for tools
+            cost *= 1.1
+
+            if cost > self.max_cost_per_call_usd:
+                if self.on_exceed == "downgrade" and i < len(self.candidates) - 1:
+                    self._record_downgrade(
+                        llm.config.model,
+                        self.candidates[i + 1].config.model,
+                        f"Estimated cost ${cost:.6f} exceeds limit ${self.max_cost_per_call_usd:.6f}",
+                    )
+                    continue
+                elif self.on_exceed == "raise":
+                    raise BudgetExceededError(
+                        f"Estimated cost ${cost:.6f} exceeds limit ${self.max_cost_per_call_usd:.6f}",
+                        limit_type="per_call",
+                        limit_value=self.max_cost_per_call_usd,
+                        current=cost,
+                    )
+                elif self.on_exceed == "skip":
+                    return {"content": "", "tool_calls": None}
+
+                if cost > self.max_cost_per_call_usd:
+                    raise BudgetExceededError(
+                        f"Final candidate '{llm.config.model}' estimated cost ${cost:.6f} exceeds limit ${self.max_cost_per_call_usd:.6f}",
+                        limit_type="per_call",
+                        limit_value=self.max_cost_per_call_usd,
+                        current=cost,
+                    )
+
+            try:
+                # Bypass _call_with_tools_impl to get the candidate's retry/rate limit logic
+                return await llm.call_with_tools(messages, tools)
+            except BudgetExceededError as exc:
+                if self.on_exceed == "downgrade" and i < len(self.candidates) - 1:
+                    self._record_downgrade(
+                        llm.config.model,
+                        self.candidates[i + 1].config.model,
+                        f"Budget exceeded during call: {exc}",
+                    )
+                    continue
+                raise
+
+        raise BudgetExceededError(
+            "All candidates exhausted or budget exceeded",
+            limit_type="per_call",
+            limit_value=self.max_cost_per_call_usd,
+            current=0.0,
+        )

--- a/tests/test_issue_598_self_healing.py
+++ b/tests/test_issue_598_self_healing.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+
+from synapsekit.agents.executor import AgentConfig, AgentExecutor
+from synapsekit.agents.step_events import CostDowngradeEvent
+from synapsekit.llm.base import BaseLLM, LLMConfig
+from synapsekit.llm.cost_router import CostQualityRouter
+from synapsekit.observability.budget_guard import BudgetExceededError
+
+
+class _MockLLM(BaseLLM):
+    def __init__(self, model: str, cost_to_raise: float | None = None):
+        super().__init__(LLMConfig(model=model, api_key="test", provider="openai"))
+        self.cost_to_raise = cost_to_raise
+
+    async def generate_with_messages(self, messages: list[dict], **kw) -> str:
+        if self.cost_to_raise is not None:
+            raise BudgetExceededError("Too expensive", "per_call", 0.01, self.cost_to_raise)
+        return f"Response from {self.config.model}"
+
+    async def stream_with_messages(self, messages: list[dict], **kw) -> AsyncGenerator[str]:
+        if self.cost_to_raise is not None:
+            raise BudgetExceededError("Too expensive", "per_call", 0.01, self.cost_to_raise)
+        yield f"Response from {self.config.model}"
+
+    async def stream(self, prompt: str, **kw) -> AsyncGenerator[str]:
+        if self.cost_to_raise is not None:
+            raise BudgetExceededError("Too expensive", "per_call", 0.01, self.cost_to_raise)
+        yield f"Response from {self.config.model}"
+
+    async def _call_with_tools_impl(
+        self, messages: list[dict[str, Any]], tools: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        if self.cost_to_raise is not None:
+            raise BudgetExceededError("Too expensive", "per_call", 0.01, self.cost_to_raise)
+        return {"content": f"Tool response from {self.config.model}", "tool_calls": None}
+
+
+@pytest.mark.asyncio
+async def test_cost_quality_router_downgrade():
+    expensive = _MockLLM("gpt-4o")
+    cheap = _MockLLM("gpt-4o-mini")
+
+    router = CostQualityRouter(
+        candidates=[expensive, cheap], max_cost_per_call_usd=0.005, on_exceed="downgrade"
+    )
+
+    messages = [{"role": "user", "content": "x" * 10000}]
+    res = await router.generate_with_messages(messages)
+    assert "gpt-4o-mini" in res
+
+    events = router.consume_events()
+    assert len(events) == 1
+    assert events[0]["from_model"] == "gpt-4o"
+    assert events[0]["to_model"] == "gpt-4o-mini"
+
+
+@pytest.mark.asyncio
+async def test_cost_quality_router_exhaustion():
+    expensive = _MockLLM("gpt-4o")
+    router = CostQualityRouter(
+        candidates=[expensive], max_cost_per_call_usd=0.000001, on_exceed="downgrade"
+    )
+
+    with pytest.raises(BudgetExceededError):
+        await router.generate_with_messages([{"role": "user", "content": "hello"}])
+
+
+@pytest.mark.asyncio
+async def test_agent_executor_surfaces_downgrade_react():
+    expensive = _MockLLM("gpt-4o")
+    cheap = _MockLLM("gpt-4o-mini")
+
+    router = CostQualityRouter(
+        candidates=[expensive, cheap], max_cost_per_call_usd=0.001, on_exceed="downgrade"
+    )
+
+    executor = AgentExecutor(AgentConfig(llm=router, tools=[], agent_type="react"))
+
+    events = []
+    async for event in executor.stream_steps("Explain quantum computing in 10000 words"):
+        events.append(event)
+
+    downgrade_events = [e for e in events if isinstance(e, CostDowngradeEvent)]
+    assert len(downgrade_events) >= 1
+    assert downgrade_events[0].from_model == "gpt-4o"
+    assert downgrade_events[0].to_model == "gpt-4o-mini"
+
+
+@pytest.mark.asyncio
+async def test_agent_executor_surfaces_downgrade_function_calling():
+    expensive = _MockLLM("gpt-4o")
+    cheap = _MockLLM("gpt-4o-mini")
+
+    router = CostQualityRouter(
+        candidates=[expensive, cheap], max_cost_per_call_usd=0.001, on_exceed="downgrade"
+    )
+
+    executor = AgentExecutor(AgentConfig(llm=router, tools=[], agent_type="function_calling"))
+
+    events = []
+    async for event in executor.stream_steps("Explain quantum computing in 10000 words"):
+        events.append(event)
+
+    downgrade_events = [e for e in events if isinstance(e, CostDowngradeEvent)]
+    assert len(downgrade_events) >= 1
+    assert downgrade_events[0].from_model == "gpt-4o"
+    assert downgrade_events[0].to_model == "gpt-4o-mini"


### PR DESCRIPTION
Resolves #598.

### Description
This PR introduces self-healing cost management for agents by implementing an automatic model downgrade mechanism when cost thresholds are exceeded. 

### Key Changes
*   **CostQualityRouter**: Added a new router class that accepts a list of candidate models and a `max_cost_per_call_usd`. It estimates the cost of a call and automatically falls back to the next cheaper model in the chain if the `on_exceed="downgrade"` strategy is used.
*   **BudgetExceededError**: Reused and appropriately raised when the entire fallback chain is exhausted without meeting the budget constraints.
*   **Event Transparency**: Added `CostDowngradeEvent` to `step_events.py`. Updated `stream_steps` in `AgentExecutor`, `ReActAgent`, and `FunctionCallingAgent` to surface these downgrade events in the step stream.
*   **Testing**: Added comprehensive tests in `tests/test_issue_598_self_healing.py` covering downgrade triggers, budget exhaustion, and event emission for both ReAct and Function Calling agents.