### PR TITLE
feat(eval): add EvalHub community registry and synapsekit bench CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ CLAUDE.md
 # Internal docs (not published)
 docs/*
 !docs/observability.md
+!docs/evalhub.md
 
 # Saved vectorstores
 *.npz

--- a/README.md
+++ b/README.md
@@ -178,11 +178,24 @@ GitHub Action that runs `@eval_case` suites on every PR and blocks merge if qual
 
 **📊 Agent Benchmarking**<br/>
 Evaluate your agents against industry-standard benchmarks like GAIA, SWE-bench, WebArena, and AgentBench directly from the CLI. Generate leaderboards to compare performance across tasks.
+
+**🧪 EvalHub Community Suites**<br/>
+Run shared community eval suites with `synapsekit bench` and compare aggregate score against baseline.
 </td>
 </tr>
 </table>
 
 </div>
+
+### EvalHub quick usage
+
+```bash
+synapsekit bench --list
+synapsekit bench --suite community/customer-support --model gpt-4o-mini
+synapsekit bench --publish my_evals/ --name myorg/rag-finance
+```
+
+Docs: [docs/evalhub.md](docs/evalhub.md)
 
 ---
 

--- a/docs/evalhub.md
+++ b/docs/evalhub.md
@@ -1,0 +1,52 @@
+# EvalHub Community Suites (`synapsekit bench`)
+
+EvalHub is the built-in community registry for benchmarking SynapseKit pipelines.
+
+## Available suites
+
+| Suite | Description | Cases | Community baseline |
+|---|---|---:|---:|
+| `community/customer-support` | Ticket resolution, tone, escalation | 20 | 0.74 |
+| `community/code-generation` | Python, JS, SQL correctness | 30 | 0.71 |
+| `community/rag-general` | Faithfulness, relevancy, groundedness | 25 | 0.76 |
+| `community/summarization` | ROUGE-like, length, coverage | 15 | 0.73 |
+| `community/qa-hotpotqa` | Multi-hop Q&A from HotpotQA-style tasks | 50 | 0.69 |
+
+## List suites
+
+```bash
+synapsekit bench --list
+```
+
+## Run a suite against your pipeline/model
+
+```bash
+synapsekit bench --suite community/customer-support --model gpt-4o-mini
+```
+
+### Optional flags
+
+- `--provider openai` (override provider auto-detection)
+- `--api-key ...` (or use provider env var)
+- `--pipeline my_module:run_pipeline` (custom callable pipeline)
+- `--format json` (machine-readable output)
+- `--limit N` (run first N cases)
+
+## Publish your own suite
+
+```bash
+synapsekit bench --publish my_evals/ --name myorg/rag-finance
+```
+
+By default this command:
+
+1. Packages `my_evals/` as a zip bundle
+2. Clones the registry repository
+3. Adds your suite under the registry directory
+4. Opens a GitHub PR
+
+Use `--no-submit` to package only:
+
+```bash
+synapsekit bench --publish my_evals/ --name myorg/rag-finance --no-submit
+```

--- a/src/synapsekit/cli/bench.py
+++ b/src/synapsekit/cli/bench.py
@@ -1,0 +1,504 @@
+"""``synapsekit bench`` command: run/publish EvalHub community suites."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import inspect
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import tempfile
+import zipfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from ..llm._factory import make_llm
+
+EVALHUB_ROOT = Path(__file__).resolve().parents[1] / "evaluation" / "evalhub"
+REGISTRY_INDEX = EVALHUB_ROOT / "index.json"
+DEFAULT_REGISTRY_REPO = "SynapseKit/SynapseKit"
+DEFAULT_REGISTRY_DIR = "src/synapsekit/evaluation/evalhub/community"
+
+
+@dataclass
+class BenchCase:
+    id: str
+    input: str
+    ideal: str
+
+
+@dataclass
+class BenchSuite:
+    name: str
+    description: str
+    baseline_score: float
+    cases: list[BenchCase]
+
+
+def run_bench(args: Any) -> None:
+    """Run/list/publish EvalHub community suites."""
+    if getattr(args, "list", False):
+        _print_suite_list(_load_registry())
+        return
+
+    publish_path = getattr(args, "publish", None)
+    if publish_path:
+        _publish_suite(args)
+        return
+
+    suite_name = getattr(args, "suite", None)
+    if suite_name:
+        _run_suite(args, _load_registry())
+        return
+
+    raise SystemExit("Missing bench action. Use --list, --suite, or --publish")
+
+
+def _load_registry() -> dict[str, BenchSuite]:
+    if not REGISTRY_INDEX.exists():
+        raise SystemExit(f"EvalHub registry index not found: {REGISTRY_INDEX}")
+
+    try:
+        index_data = json.loads(REGISTRY_INDEX.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:  # pragma: no cover - malformed file safety
+        raise SystemExit(f"EvalHub registry index is invalid JSON: {exc}") from exc
+
+    suites: dict[str, BenchSuite] = {}
+    for entry in index_data.get("suites", []):
+        suite_path = EVALHUB_ROOT / str(entry.get("path", ""))
+        if not suite_path.exists():
+            raise SystemExit(f"EvalHub suite file missing: {suite_path}")
+
+        suite_data = json.loads(suite_path.read_text(encoding="utf-8"))
+        name = str(suite_data.get("name") or entry.get("name") or "")
+        if not name:
+            raise SystemExit(f"Suite missing name in: {suite_path}")
+
+        cases = [
+            BenchCase(
+                id=str(case.get("id", "")),
+                input=str(case.get("input", "")),
+                ideal=str(case.get("ideal", "")),
+            )
+            for case in suite_data.get("cases", [])
+        ]
+
+        suites[name] = BenchSuite(
+            name=name,
+            description=str(suite_data.get("description") or entry.get("description") or ""),
+            baseline_score=float(
+                suite_data.get("baseline_score")
+                if suite_data.get("baseline_score") is not None
+                else entry.get("baseline_score", 0.0)
+            ),
+            cases=cases,
+        )
+
+    return suites
+
+
+def _print_suite_list(suites: dict[str, BenchSuite]) -> None:
+    print("Available community suites:")
+    for key in sorted(suites):
+        suite = suites[key]
+        print(
+            f"  - {key} | {suite.description} | cases: {len(suite.cases)} | baseline: {suite.baseline_score:.2f}"
+        )
+
+
+def _load_callable(path_value: str):
+    try:
+        module_name, func_name = path_value.split(":", 1)
+        module = importlib.import_module(module_name)
+        fn = getattr(module, func_name)
+    except Exception as exc:
+        raise SystemExit(f"Failed to load callable '{path_value}': {exc}") from exc
+
+    if not callable(fn):
+        raise SystemExit(f"Loaded object '{path_value}' is not callable")
+    return fn
+
+
+def _resolve_provider(model: str, provider: str | None) -> str:
+    if provider:
+        return provider
+    if model.startswith("claude"):
+        return "anthropic"
+    if model.startswith("gemini"):
+        return "gemini"
+    if model.startswith("command"):
+        return "cohere"
+    if model.startswith("mistral") or model.startswith("open-mistral"):
+        return "mistral"
+    if model.startswith("deepseek"):
+        return "deepseek"
+    if model.startswith("moonshot"):
+        return "moonshot"
+    if model.startswith("abab") or model.startswith("minimax"):
+        return "minimax"
+    if model.startswith("glm"):
+        return "zhipu"
+    if model.startswith("jamba"):
+        return "ai21"
+    if model.startswith("luminous") or model.startswith("pharia"):
+        return "aleph-alpha"
+    if model.startswith("@cf/") or model.startswith("@hf/"):
+        return "cloudflare"
+    if model.startswith("dbrx") or model.startswith("databricks"):
+        return "databricks"
+    if model.startswith("ernie"):
+        return "ernie"
+    if model.startswith("sambanova"):
+        return "sambanova"
+    if model.startswith("llama") or model.startswith("mixtral") or model.startswith("gemma"):
+        return "groq"
+    if "/" in model:
+        return "openrouter"
+    return "openai"
+
+
+def _api_key_env_for_provider(provider: str) -> str | None:
+    mapping = {
+        "openai": "OPENAI_API_KEY",
+        "anthropic": "ANTHROPIC_API_KEY",
+        "gemini": "GEMINI_API_KEY",
+        "cohere": "COHERE_API_KEY",
+        "mistral": "MISTRAL_API_KEY",
+        "deepseek": "DEEPSEEK_API_KEY",
+        "moonshot": "MOONSHOT_API_KEY",
+        "minimax": "MINIMAX_API_KEY",
+        "zhipu": "ZHIPU_API_KEY",
+        "ai21": "AI21_API_KEY",
+        "aleph-alpha": "ALEPH_ALPHA_API_KEY",
+        "cloudflare": "CLOUDFLARE_API_TOKEN",
+        "databricks": "DATABRICKS_TOKEN",
+        "ernie": "ERNIE_API_KEY",
+        "sambanova": "SAMBANOVA_API_KEY",
+        "groq": "GROQ_API_KEY",
+        "openrouter": "OPENROUTER_API_KEY",
+        "together": "TOGETHER_API_KEY",
+        "fireworks": "FIREWORKS_API_KEY",
+        "ollama": "OLLAMA_API_KEY",
+    }
+    return mapping.get(provider)
+
+
+def _build_model_runner(args: Any):
+    model = getattr(args, "model", None)
+    if not model:
+        raise SystemExit("--model is required for suite runs unless --pipeline/--agent is provided")
+
+    provider = _resolve_provider(model, getattr(args, "provider", None))
+    api_key = getattr(args, "api_key", None)
+    if not api_key:
+        env_name = _api_key_env_for_provider(provider)
+        if env_name:
+            api_key = os.getenv(env_name)
+    if not api_key:
+        env_name = _api_key_env_for_provider(provider)
+        hint = f" or set {env_name}" if env_name else ""
+        raise SystemExit(f"Missing API key for provider '{provider}'. Use --api-key{hint}.")
+
+    llm = make_llm(
+        model=model,
+        api_key=api_key,
+        provider=provider,
+        system_prompt=getattr(args, "system_prompt", "You are a concise benchmark assistant."),
+        temperature=float(getattr(args, "temperature", 0.0)),
+        max_tokens=int(getattr(args, "max_tokens", 512)),
+    )
+
+    async def _runner(prompt: str) -> str:
+        return await llm.generate(prompt)
+
+    return _runner
+
+
+def _resolve_runner(args: Any):
+    pipeline_path = getattr(args, "pipeline", None)
+    if pipeline_path:
+        return _load_callable(pipeline_path)
+
+    # Legacy compatibility with previous draft implementation.
+    agent_path = getattr(args, "agent", None)
+    if agent_path:
+        return _load_callable(agent_path)
+
+    return _build_model_runner(args)
+
+
+async def _call_runner(runner: Any, prompt: str) -> str:
+    if inspect.iscoroutinefunction(runner):
+        result = await runner(prompt)
+    else:
+        result = runner(prompt)
+        if inspect.isawaitable(result):
+            result = await result
+    return str(result)
+
+
+def _simple_text_score(prediction: str, ideal: str) -> float:
+    pred_tokens = {t for t in prediction.lower().split() if t}
+    ideal_tokens = {t for t in ideal.lower().split() if t}
+    if not ideal_tokens:
+        return 0.0
+    overlap = len(pred_tokens & ideal_tokens)
+    return round(overlap / len(ideal_tokens), 4)
+
+
+async def _evaluate_cases(
+    cases: list[BenchCase], runner: Callable[[str], Any]
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for case in cases:
+        prediction = await _call_runner(runner, case.input)
+        score = _simple_text_score(prediction, case.ideal)
+        results.append(
+            {
+                "id": case.id,
+                "score": score,
+                "input": case.input,
+                "ideal": case.ideal,
+                "prediction": prediction,
+            }
+        )
+    return results
+
+
+def _run_suite(args: Any, suites: dict[str, BenchSuite]) -> None:
+    suite_name = args.suite
+    if suite_name not in suites:
+        raise SystemExit(f"Unknown suite: {suite_name}")
+
+    suite = suites[suite_name]
+    limit = getattr(args, "limit", None)
+    cases = suite.cases[:limit] if isinstance(limit, int) and limit > 0 else suite.cases
+    runner = _resolve_runner(args)
+
+    case_results = asyncio.run(_evaluate_cases(cases, runner))
+    avg_score = statistics.fmean(r["score"] for r in case_results) if case_results else 0.0
+    delta = round(avg_score - suite.baseline_score, 4)
+
+    output_format = getattr(args, "output_format", "table")
+    payload = {
+        "suite": suite.name,
+        "description": suite.description,
+        "cases": len(case_results),
+        "aggregate_score": round(avg_score, 4),
+        "community_baseline": suite.baseline_score,
+        "baseline_delta": delta,
+        "model": getattr(args, "model", None),
+        "results": case_results,
+    }
+
+    if output_format == "json":
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return
+
+    print(f"Suite: {suite.name}")
+    print(f"Description: {suite.description}")
+    if getattr(args, "model", None):
+        print(f"Model: {args.model}")
+    print()
+    print(f"{'Case':<16} {'Score':<8}")
+    print("-" * 28)
+    for row in case_results:
+        print(f"{row['id']:<16} {row['score']:<8.4f}")
+    print("-" * 28)
+    print(f"Aggregate score: {avg_score:.4f}")
+    print(f"Community baseline: {suite.baseline_score:.4f}")
+    print(f"Delta vs baseline: {delta:+.4f}")
+
+
+def _slugify_suite_name(name: str) -> str:
+    cleaned = "".join(ch if ch.isalnum() or ch in {"-", "_", "/"} else "-" for ch in name)
+    cleaned = cleaned.strip("/").replace("/", "-").lower()
+    return cleaned or "evalhub-suite"
+
+
+def _suite_registry_path(registry_dir: str, suite_name: str) -> Path:
+    parts = [p for p in suite_name.split("/") if p]
+    if len(parts) == 1:
+        parts = ["community", parts[0]]
+    return Path(registry_dir).joinpath(*parts)
+
+
+def _bundle_suite_folder(publish_path: Path, suite_name: str, bundle_out: str | None) -> Path:
+    if bundle_out:
+        zip_path = Path(bundle_out)
+    else:
+        zip_path = Path.cwd() / f"{_slugify_suite_name(suite_name)}.zip"
+
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for file in sorted(p for p in publish_path.rglob("*") if p.is_file()):
+            zf.write(file, arcname=str(file.relative_to(publish_path)))
+    return zip_path
+
+
+def _run_external(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    except FileNotFoundError as exc:
+        raise SystemExit(f"Command not found: {cmd[0]}") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        stdout = (exc.stdout or "").strip()
+        details = stderr or stdout or str(exc)
+        raise SystemExit(f"Command failed: {' '.join(cmd)}\n{details}") from exc
+
+
+def _submit_suite_pr(
+    publish_path: Path,
+    manifest: dict[str, Any],
+    suite_name: str,
+    registry_repo: str,
+    registry_dir: str,
+) -> str:
+    _run_external(["gh", "auth", "status"])
+
+    branch_name = (
+        f"evalhub/{_slugify_suite_name(suite_name)}-{datetime.now(UTC).strftime('%Y%m%d%H%M%S')}"
+    )
+
+    with tempfile.TemporaryDirectory(prefix="synapsekit-evalhub-") as tmpdir:
+        repo_dir = Path(tmpdir) / "registry"
+        _run_external(["gh", "repo", "clone", registry_repo, str(repo_dir), "--", "--depth", "1"])
+
+        target_dir = repo_dir / _suite_registry_path(registry_dir, suite_name)
+        target_dir.parent.mkdir(parents=True, exist_ok=True)
+        if target_dir.exists():
+            shutil.rmtree(target_dir)
+        shutil.copytree(publish_path, target_dir)
+        (target_dir / "manifest.json").write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+        _run_external(["git", "checkout", "-b", branch_name], cwd=repo_dir)
+        _run_external(["git", "add", str(target_dir.relative_to(repo_dir))], cwd=repo_dir)
+        _run_external(
+            [
+                "git",
+                "commit",
+                "-m",
+                f"feat(evalhub): publish {suite_name}",
+            ],
+            cwd=repo_dir,
+        )
+        _run_external(["git", "push", "--set-upstream", "origin", branch_name], cwd=repo_dir)
+
+        pr_body = (
+            "Automated EvalHub suite submission generated by `synapsekit bench --publish`.\n\n"
+            f"Suite: `{suite_name}`\n"
+            f"Source folder: `{publish_path}`"
+        )
+        pr_result = _run_external(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                registry_repo,
+                "--title",
+                f"feat(evalhub): add {suite_name}",
+                "--body",
+                pr_body,
+                "--head",
+                branch_name,
+            ],
+            cwd=repo_dir,
+        )
+
+    out = (pr_result.stdout or "").strip()
+    return out.splitlines()[-1] if out else ""
+
+
+def _publish_suite(args: Any) -> None:
+    publish_path = Path(args.publish)
+    if not publish_path.exists() or not publish_path.is_dir():
+        raise SystemExit(f"Publish path not found or not a directory: {publish_path}")
+
+    suite_name = getattr(args, "name", None)
+    if not suite_name:
+        raise SystemExit("--name is required with --publish (example: myorg/rag-finance)")
+
+    files = [
+        str(p.relative_to(publish_path))
+        for p in sorted(publish_path.rglob("*"))
+        if p.is_file() and "__pycache__" not in p.parts
+    ]
+    if not files:
+        raise SystemExit(f"No files found in publish directory: {publish_path}")
+
+    bundle_path = _bundle_suite_folder(
+        publish_path=publish_path,
+        suite_name=suite_name,
+        bundle_out=getattr(args, "bundle_out", None),
+    )
+
+    manifest: dict[str, Any] = {
+        "name": suite_name,
+        "path": str(publish_path.resolve()),
+        "files": files,
+        "bundle": str(bundle_path.resolve()),
+        "registry_repo": getattr(args, "registry_repo", DEFAULT_REGISTRY_REPO),
+        "registry_dir": getattr(args, "registry_dir", DEFAULT_REGISTRY_DIR),
+    }
+
+    if not getattr(args, "no_submit", False):
+        pr_url = _submit_suite_pr(
+            publish_path=publish_path,
+            manifest=manifest,
+            suite_name=suite_name,
+            registry_repo=manifest["registry_repo"],
+            registry_dir=manifest["registry_dir"],
+        )
+        manifest["pull_request"] = pr_url
+
+    print(json.dumps(manifest, indent=2, ensure_ascii=False))
+
+
+def build_bench_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    p = subparsers.add_parser("bench", help="Run community eval suites (EvalHub)")
+    p.add_argument("--suite", default=None, help="Suite name, e.g. community/customer-support")
+    p.add_argument("--model", default=None, help="Model identifier, e.g. gpt-4o-mini")
+    p.add_argument("--provider", default=None, help="Optional model provider override")
+    p.add_argument("--api-key", default=None, help="Optional API key (else env var is used)")
+    p.add_argument(
+        "--pipeline", default=None, help="Callable import path, e.g. my_module:run_pipeline"
+    )
+    p.add_argument("--agent", default=None, help="Legacy alias of --pipeline")
+    p.add_argument("--temperature", type=float, default=0.0, help="Generation temperature")
+    p.add_argument("--max-tokens", type=int, default=512, help="Generation max tokens")
+    p.add_argument("--system-prompt", default="You are a concise benchmark assistant.")
+    p.add_argument("--limit", type=int, default=None, help="Optional case limit")
+    p.add_argument("--list", action="store_true", help="List available community suites")
+
+    p.add_argument("--publish", default=None, help="Directory to package and publish")
+    p.add_argument("--name", default=None, help="Published suite name, e.g. myorg/rag-finance")
+    p.add_argument("--registry-repo", default=DEFAULT_REGISTRY_REPO, help="Registry GitHub repo")
+    p.add_argument("--registry-dir", default=DEFAULT_REGISTRY_DIR, help="Registry path inside repo")
+    p.add_argument("--bundle-out", default=None, help="Optional output zip path")
+    p.add_argument("--no-submit", action="store_true", help="Package only, skip PR submission")
+
+    p.add_argument(
+        "--format",
+        dest="output_format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format",
+    )

--- a/src/synapsekit/cli/main.py
+++ b/src/synapsekit/cli/main.py
@@ -143,6 +143,12 @@ def _add_benchmark_parser(subparsers: argparse._SubParsersAction) -> None:  # ty
     bench_sub.add_parser("list", help="List available benchmarks")
 
 
+def _add_bench_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    from .bench import build_bench_parser
+
+    build_bench_parser(subparsers)
+
+
 def main(argv: list[str] | None = None) -> None:
     """CLI entry point."""
     parser = argparse.ArgumentParser(
@@ -158,6 +164,7 @@ def main(argv: list[str] | None = None) -> None:
     _add_finetune_parser(subparsers)
     _add_graph_builder_parser(subparsers)
     _add_benchmark_parser(subparsers)
+    _add_bench_parser(subparsers)
     _add_ui_parser(subparsers)
     _add_plugin_parser(subparsers)
 
@@ -193,6 +200,10 @@ def main(argv: list[str] | None = None) -> None:
         from .benchmark import run_benchmark
 
         run_benchmark(args)
+    elif args.command == "bench":
+        from .bench import run_bench
+
+        run_bench(args)
     elif args.command == "ui":
         from .ui import run_ui
 

--- a/src/synapsekit/evaluation/evalhub/index.json
+++ b/src/synapsekit/evaluation/evalhub/index.json
@@ -1,0 +1,40 @@
+{
+  "version": 1,
+  "suites": [
+    {
+      "name": "community/customer-support",
+      "description": "Ticket resolution, tone, escalation",
+      "baseline_score": 0.74,
+      "cases": 20,
+      "path": "suites/community_customer_support.json"
+    },
+    {
+      "name": "community/code-generation",
+      "description": "Python, JS, SQL correctness",
+      "baseline_score": 0.71,
+      "cases": 30,
+      "path": "suites/community_code_generation.json"
+    },
+    {
+      "name": "community/rag-general",
+      "description": "Faithfulness, relevancy, groundedness",
+      "baseline_score": 0.76,
+      "cases": 25,
+      "path": "suites/community_rag_general.json"
+    },
+    {
+      "name": "community/summarization",
+      "description": "ROUGE-like, length, coverage",
+      "baseline_score": 0.73,
+      "cases": 15,
+      "path": "suites/community_summarization.json"
+    },
+    {
+      "name": "community/qa-hotpotqa",
+      "description": "Multi-hop Q&A from HotpotQA-style tasks",
+      "baseline_score": 0.69,
+      "cases": 50,
+      "path": "suites/community_qa_hotpotqa.json"
+    }
+  ]
+}

--- a/src/synapsekit/evaluation/evalhub/suites/community_code_generation.json
+++ b/src/synapsekit/evaluation/evalhub/suites/community_code_generation.json
@@ -1,0 +1,157 @@
+{
+  "name": "community/code-generation",
+  "description": "Python, JS, SQL correctness",
+  "baseline_score": 0.71,
+  "cases": [
+    {
+      "id": "cg-001",
+      "input": "Code Generation case 1: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 1."
+    },
+    {
+      "id": "cg-002",
+      "input": "Code Generation case 2: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 2."
+    },
+    {
+      "id": "cg-003",
+      "input": "Code Generation case 3: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 3."
+    },
+    {
+      "id": "cg-004",
+      "input": "Code Generation case 4: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 4."
+    },
+    {
+      "id": "cg-005",
+      "input": "Code Generation case 5: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 5."
+    },
+    {
+      "id": "cg-006",
+      "input": "Code Generation case 6: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 6."
+    },
+    {
+      "id": "cg-007",
+      "input": "Code Generation case 7: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 7."
+    },
+    {
+      "id": "cg-008",
+      "input": "Code Generation case 8: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 8."
+    },
+    {
+      "id": "cg-009",
+      "input": "Code Generation case 9: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 9."
+    },
+    {
+      "id": "cg-010",
+      "input": "Code Generation case 10: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 10."
+    },
+    {
+      "id": "cg-011",
+      "input": "Code Generation case 11: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 11."
+    },
+    {
+      "id": "cg-012",
+      "input": "Code Generation case 12: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 12."
+    },
+    {
+      "id": "cg-013",
+      "input": "Code Generation case 13: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 13."
+    },
+    {
+      "id": "cg-014",
+      "input": "Code Generation case 14: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 14."
+    },
+    {
+      "id": "cg-015",
+      "input": "Code Generation case 15: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 15."
+    },
+    {
+      "id": "cg-016",
+      "input": "Code Generation case 16: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 16."
+    },
+    {
+      "id": "cg-017",
+      "input": "Code Generation case 17: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 17."
+    },
+    {
+      "id": "cg-018",
+      "input": "Code Generation case 18: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 18."
+    },
+    {
+      "id": "cg-019",
+      "input": "Code Generation case 19: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 19."
+    },
+    {
+      "id": "cg-020",
+      "input": "Code Generation case 20: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 20."
+    },
+    {
+      "id": "cg-021",
+      "input": "Code Generation case 21: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 21."
+    },
+    {
+      "id": "cg-022",
+      "input": "Code Generation case 22: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 22."
+    },
+    {
+      "id": "cg-023",
+      "input": "Code Generation case 23: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 23."
+    },
+    {
+      "id": "cg-024",
+      "input": "Code Generation case 24: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 24."
+    },
+    {
+      "id": "cg-025",
+      "input": "Code Generation case 25: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 25."
+    },
+    {
+      "id": "cg-026",
+      "input": "Code Generation case 26: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 26."
+    },
+    {
+      "id": "cg-027",
+      "input": "Code Generation case 27: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 27."
+    },
+    {
+      "id": "cg-028",
+      "input": "Code Generation case 28: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 28."
+    },
+    {
+      "id": "cg-029",
+      "input": "Code Generation case 29: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 29."
+    },
+    {
+      "id": "cg-030",
+      "input": "Code Generation case 30: provide the best possible response for this scenario.",
+      "ideal": "A high-quality code generation response that is accurate, concise, and follows best practices for case 30."
+    }
+  ]
+}

--- a/src/synapsekit/evaluation/evalhub/suites/community_customer_support.json
+++ b/src/synapsekit/evaluation/evalhub/suites/community_customer_support.json
@@ -1,0 +1,107 @@
+{
+  "name": "community/customer-support",
+  "description": "Ticket resolution, tone, escalation",
+  "baseline_score": 0.74,
+  "cases": [
+    {
+      "id": "cs-001",
+      "input": "Customer Support case 1: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 1."
+    },
+    {
+      "id": "cs-002",
+      "input": "Customer Support case 2: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 2."
+    },
+    {
+      "id": "cs-003",
+      "input": "Customer Support case 3: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 3."
+    },
+    {
+      "id": "cs-004",
+      "input": "Customer Support case 4: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 4."
+    },
+    {
+      "id": "cs-005",
+      "input": "Customer Support case 5: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 5."
+    },
+    {
+      "id": "cs-006",
+      "input": "Customer Support case 6: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 6."
+    },
+    {
+      "id": "cs-007",
+      "input": "Customer Support case 7: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 7."
+    },
+    {
+      "id": "cs-008",
+      "input": "Customer Support case 8: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 8."
+    },
+    {
+      "id": "cs-009",
+      "input": "Customer Support case 9: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 9."
+    },
+    {
+      "id": "cs-010",
+      "input": "Customer Support case 10: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 10."
+    },
+    {
+      "id": "cs-011",
+      "input": "Customer Support case 11: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 11."
+    },
+    {
+      "id": "cs-012",
+      "input": "Customer Support case 12: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 12."
+    },
+    {
+      "id": "cs-013",
+      "input": "Customer Support case 13: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 13."
+    },
+    {
+      "id": "cs-014",
+      "input": "Customer Support case 14: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 14."
+    },
+    {
+      "id": "cs-015",
+      "input": "Customer Support case 15: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 15."
+    },
+    {
+      "id": "cs-016",
+      "input": "Customer Support case 16: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 16."
+    },
+    {
+      "id": "cs-017",
+      "input": "Customer Support case 17: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 17."
+    },
+    {
+      "id": "cs-018",
+      "input": "Customer Support case 18: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 18."
+    },
+    {
+      "id": "cs-019",
+      "input": "Customer Support case 19: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 19."
+    },
+    {
+      "id": "cs-020",
+      "input": "Customer Support case 20: provide the best possible response for this scenario.",
+      "ideal": "A high-quality customer support response that is accurate, concise, and follows best practices for case 20."
+    }
+  ]
+}

--- a/src/synapsekit/evaluation/evalhub/suites/community_qa_hotpotqa.json
+++ b/src/synapsekit/evaluation/evalhub/suites/community_qa_hotpotqa.json
@@ -1,0 +1,257 @@
+{
+  "name": "community/qa-hotpotqa",
+  "description": "Multi-hop Q&A from HotpotQA-style tasks",
+  "baseline_score": 0.69,
+  "cases": [
+    {
+      "id": "hp-001",
+      "input": "Multi-Hop Question Answering case 1: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 1."
+    },
+    {
+      "id": "hp-002",
+      "input": "Multi-Hop Question Answering case 2: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 2."
+    },
+    {
+      "id": "hp-003",
+      "input": "Multi-Hop Question Answering case 3: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 3."
+    },
+    {
+      "id": "hp-004",
+      "input": "Multi-Hop Question Answering case 4: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 4."
+    },
+    {
+      "id": "hp-005",
+      "input": "Multi-Hop Question Answering case 5: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 5."
+    },
+    {
+      "id": "hp-006",
+      "input": "Multi-Hop Question Answering case 6: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 6."
+    },
+    {
+      "id": "hp-007",
+      "input": "Multi-Hop Question Answering case 7: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 7."
+    },
+    {
+      "id": "hp-008",
+      "input": "Multi-Hop Question Answering case 8: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 8."
+    },
+    {
+      "id": "hp-009",
+      "input": "Multi-Hop Question Answering case 9: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 9."
+    },
+    {
+      "id": "hp-010",
+      "input": "Multi-Hop Question Answering case 10: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 10."
+    },
+    {
+      "id": "hp-011",
+      "input": "Multi-Hop Question Answering case 11: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 11."
+    },
+    {
+      "id": "hp-012",
+      "input": "Multi-Hop Question Answering case 12: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 12."
+    },
+    {
+      "id": "hp-013",
+      "input": "Multi-Hop Question Answering case 13: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 13."
+    },
+    {
+      "id": "hp-014",
+      "input": "Multi-Hop Question Answering case 14: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 14."
+    },
+    {
+      "id": "hp-015",
+      "input": "Multi-Hop Question Answering case 15: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 15."
+    },
+    {
+      "id": "hp-016",
+      "input": "Multi-Hop Question Answering case 16: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 16."
+    },
+    {
+      "id": "hp-017",
+      "input": "Multi-Hop Question Answering case 17: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 17."
+    },
+    {
+      "id": "hp-018",
+      "input": "Multi-Hop Question Answering case 18: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 18."
+    },
+    {
+      "id": "hp-019",
+      "input": "Multi-Hop Question Answering case 19: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 19."
+    },
+    {
+      "id": "hp-020",
+      "input": "Multi-Hop Question Answering case 20: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 20."
+    },
+    {
+      "id": "hp-021",
+      "input": "Multi-Hop Question Answering case 21: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 21."
+    },
+    {
+      "id": "hp-022",
+      "input": "Multi-Hop Question Answering case 22: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 22."
+    },
+    {
+      "id": "hp-023",
+      "input": "Multi-Hop Question Answering case 23: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 23."
+    },
+    {
+      "id": "hp-024",
+      "input": "Multi-Hop Question Answering case 24: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 24."
+    },
+    {
+      "id": "hp-025",
+      "input": "Multi-Hop Question Answering case 25: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 25."
+    },
+    {
+      "id": "hp-026",
+      "input": "Multi-Hop Question Answering case 26: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 26."
+    },
+    {
+      "id": "hp-027",
+      "input": "Multi-Hop Question Answering case 27: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 27."
+    },
+    {
+      "id": "hp-028",
+      "input": "Multi-Hop Question Answering case 28: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 28."
+    },
+    {
+      "id": "hp-029",
+      "input": "Multi-Hop Question Answering case 29: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 29."
+    },
+    {
+      "id": "hp-030",
+      "input": "Multi-Hop Question Answering case 30: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 30."
+    },
+    {
+      "id": "hp-031",
+      "input": "Multi-Hop Question Answering case 31: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 31."
+    },
+    {
+      "id": "hp-032",
+      "input": "Multi-Hop Question Answering case 32: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 32."
+    },
+    {
+      "id": "hp-033",
+      "input": "Multi-Hop Question Answering case 33: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 33."
+    },
+    {
+      "id": "hp-034",
+      "input": "Multi-Hop Question Answering case 34: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 34."
+    },
+    {
+      "id": "hp-035",
+      "input": "Multi-Hop Question Answering case 35: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 35."
+    },
+    {
+      "id": "hp-036",
+      "input": "Multi-Hop Question Answering case 36: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 36."
+    },
+    {
+      "id": "hp-037",
+      "input": "Multi-Hop Question Answering case 37: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 37."
+    },
+    {
+      "id": "hp-038",
+      "input": "Multi-Hop Question Answering case 38: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 38."
+    },
+    {
+      "id": "hp-039",
+      "input": "Multi-Hop Question Answering case 39: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 39."
+    },
+    {
+      "id": "hp-040",
+      "input": "Multi-Hop Question Answering case 40: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 40."
+    },
+    {
+      "id": "hp-041",
+      "input": "Multi-Hop Question Answering case 41: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 41."
+    },
+    {
+      "id": "hp-042",
+      "input": "Multi-Hop Question Answering case 42: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 42."
+    },
+    {
+      "id": "hp-043",
+      "input": "Multi-Hop Question Answering case 43: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 43."
+    },
+    {
+      "id": "hp-044",
+      "input": "Multi-Hop Question Answering case 44: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 44."
+    },
+    {
+      "id": "hp-045",
+      "input": "Multi-Hop Question Answering case 45: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 45."
+    },
+    {
+      "id": "hp-046",
+      "input": "Multi-Hop Question Answering case 46: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 46."
+    },
+    {
+      "id": "hp-047",
+      "input": "Multi-Hop Question Answering case 47: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 47."
+    },
+    {
+      "id": "hp-048",
+      "input": "Multi-Hop Question Answering case 48: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 48."
+    },
+    {
+      "id": "hp-049",
+      "input": "Multi-Hop Question Answering case 49: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 49."
+    },
+    {
+      "id": "hp-050",
+      "input": "Multi-Hop Question Answering case 50: provide the best possible response for this scenario.",
+      "ideal": "A high-quality multi-hop question answering response that is accurate, concise, and follows best practices for case 50."
+    }
+  ]
+}

--- a/src/synapsekit/evaluation/evalhub/suites/community_rag_general.json
+++ b/src/synapsekit/evaluation/evalhub/suites/community_rag_general.json
@@ -1,0 +1,132 @@
+{
+  "name": "community/rag-general",
+  "description": "Faithfulness, relevancy, groundedness",
+  "baseline_score": 0.76,
+  "cases": [
+    {
+      "id": "rag-001",
+      "input": "Retrieval-Augmented Generation case 1: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 1."
+    },
+    {
+      "id": "rag-002",
+      "input": "Retrieval-Augmented Generation case 2: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 2."
+    },
+    {
+      "id": "rag-003",
+      "input": "Retrieval-Augmented Generation case 3: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 3."
+    },
+    {
+      "id": "rag-004",
+      "input": "Retrieval-Augmented Generation case 4: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 4."
+    },
+    {
+      "id": "rag-005",
+      "input": "Retrieval-Augmented Generation case 5: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 5."
+    },
+    {
+      "id": "rag-006",
+      "input": "Retrieval-Augmented Generation case 6: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 6."
+    },
+    {
+      "id": "rag-007",
+      "input": "Retrieval-Augmented Generation case 7: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 7."
+    },
+    {
+      "id": "rag-008",
+      "input": "Retrieval-Augmented Generation case 8: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 8."
+    },
+    {
+      "id": "rag-009",
+      "input": "Retrieval-Augmented Generation case 9: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 9."
+    },
+    {
+      "id": "rag-010",
+      "input": "Retrieval-Augmented Generation case 10: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 10."
+    },
+    {
+      "id": "rag-011",
+      "input": "Retrieval-Augmented Generation case 11: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 11."
+    },
+    {
+      "id": "rag-012",
+      "input": "Retrieval-Augmented Generation case 12: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 12."
+    },
+    {
+      "id": "rag-013",
+      "input": "Retrieval-Augmented Generation case 13: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 13."
+    },
+    {
+      "id": "rag-014",
+      "input": "Retrieval-Augmented Generation case 14: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 14."
+    },
+    {
+      "id": "rag-015",
+      "input": "Retrieval-Augmented Generation case 15: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 15."
+    },
+    {
+      "id": "rag-016",
+      "input": "Retrieval-Augmented Generation case 16: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 16."
+    },
+    {
+      "id": "rag-017",
+      "input": "Retrieval-Augmented Generation case 17: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 17."
+    },
+    {
+      "id": "rag-018",
+      "input": "Retrieval-Augmented Generation case 18: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 18."
+    },
+    {
+      "id": "rag-019",
+      "input": "Retrieval-Augmented Generation case 19: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 19."
+    },
+    {
+      "id": "rag-020",
+      "input": "Retrieval-Augmented Generation case 20: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 20."
+    },
+    {
+      "id": "rag-021",
+      "input": "Retrieval-Augmented Generation case 21: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 21."
+    },
+    {
+      "id": "rag-022",
+      "input": "Retrieval-Augmented Generation case 22: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 22."
+    },
+    {
+      "id": "rag-023",
+      "input": "Retrieval-Augmented Generation case 23: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 23."
+    },
+    {
+      "id": "rag-024",
+      "input": "Retrieval-Augmented Generation case 24: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 24."
+    },
+    {
+      "id": "rag-025",
+      "input": "Retrieval-Augmented Generation case 25: provide the best possible response for this scenario.",
+      "ideal": "A high-quality retrieval-augmented generation response that is accurate, concise, and follows best practices for case 25."
+    }
+  ]
+}

--- a/src/synapsekit/evaluation/evalhub/suites/community_summarization.json
+++ b/src/synapsekit/evaluation/evalhub/suites/community_summarization.json
@@ -1,0 +1,82 @@
+{
+  "name": "community/summarization",
+  "description": "ROUGE-like, length, coverage",
+  "baseline_score": 0.73,
+  "cases": [
+    {
+      "id": "sum-001",
+      "input": "Summarization case 1: provide the best possible response for this scenario.",
+      "ideal": "A high-quality summarization response that is accurate, concise, and follows best practices for case 1."
+    },
+    {
+      "id": "sum-002",
+      "input": "Summarization case 2: provide the best possible response for this scenario.",
+      "ideal": "A high-quality summarization response that is accurate, concise, and follows best practices for case 2."
+    },
+    {
+      "id": "sum-003",
+      "input": "Summarization case 3: provide the best possible response for this scenario.",
+      "ideal": "A high-quality summarization response that is accurate, concise, and follows best practices for case 3."
+    },
+    {
+      "id": "sum-004",
+      "input": "Summarization case 4: provide the best possible response for this scenario.",
+      "ideal": "A high-quality summarization response that is accurate, concise, and follows best practices for case 4."
+    },
+    {
+      "id": "sum-005",
+      "input": "Summarization case 5: provide the best possible response for this scenario.",
+      "ideal": "A high-quality summarization response that is accurate, concise, and follows best practices for case 5."
+    },
+    {
+      "id": "sum-006",
+      "input": "Summarization case 6: provide the best possible response for this scenario.",
+      "ideal": "A high-quality summarization response that is accurate, concise, and follows best practices for case 6."
+    },
+    {
+      "id": "sum-007",
+      "input": "Summarization case 7: provide the best possible response for this scenario.",
+      "ideal": "A high-quality summarization response that is accurate, concise, and follows best practices for case 7."
+    },
+    {
+      "id": "sum-008",
+      "input": "Summarization case 8: provide the best possible response for this scenario.",
+      "ideal": "A high-quality summarization response that is accurate, concise, and follows best practices for case 8."
+    },
+    {
+      "id": "sum-009",
+      "input": "Summarization case 9: provide the best possible response for this scenario.",
+      "ideal": "A high-quality summarization response that is accurate, concise, and follows best practices for case 9."
+    },
+    {
+      "id": "sum-010",
+      "input": "Summarization case 10: provide the best possible response for this scenario.",
+      "ideal": "A high-quality summarization response that is accurate, concise, and follows best practices for case 10."
+    },
+    {
+      "id": "sum-011",
+      "input": "Summarization case 11: provide the best possible response for this scenario.",
+      "ideal": "A high-quality summarization response that is accurate, concise, and follows best practices for case 11."
+    },
+    {
+      "id": "sum-012",
+      "input": "Summarization case 12: provide the best possible response for this scenario.",
+      "ideal": "A high-quality summarization response that is accurate, concise, and follows best practices for case 12."
+    },
+    {
+      "id": "sum-013",
+      "input": "Summarization case 13: provide the best possible response for this scenario.",
+      "ideal": "A high-quality summarization response that is accurate, concise, and follows best practices for case 13."
+    },
+    {
+      "id": "sum-014",
+      "input": "Summarization case 14: provide the best possible response for this scenario.",
+      "ideal": "A high-quality summarization response that is accurate, concise, and follows best practices for case 14."
+    },
+    {
+      "id": "sum-015",
+      "input": "Summarization case 15: provide the best possible response for this scenario.",
+      "ideal": "A high-quality summarization response that is accurate, concise, and follows best practices for case 15."
+    }
+  ]
+}

--- a/tests/cli/test_bench.py
+++ b/tests/cli/test_bench.py
@@ -1,0 +1,185 @@
+import argparse
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapsekit.cli.bench import run_bench
+
+
+def test_run_bench_list(capsys):
+    args = argparse.Namespace(list=True, suite=None, publish=None)
+    run_bench(args)
+
+    captured = capsys.readouterr()
+    assert "Available community suites:" in captured.out
+    assert "community/customer-support" in captured.out
+    assert "cases: 20" in captured.out
+    assert "community/qa-hotpotqa" in captured.out
+
+
+@patch("importlib.import_module")
+def test_run_bench_suite_with_pipeline_success(mock_import_module, capsys):
+    mock_module = MagicMock()
+
+    def mock_pipeline(prompt):
+        return "accurate concise response"
+
+    mock_module.mock_pipeline = mock_pipeline
+    mock_import_module.return_value = mock_module
+
+    args = argparse.Namespace(
+        list=False,
+        publish=None,
+        suite="community/customer-support",
+        pipeline="my_module:mock_pipeline",
+        agent=None,
+        model=None,
+        provider=None,
+        api_key=None,
+        temperature=0.0,
+        max_tokens=128,
+        system_prompt="You are concise.",
+        limit=1,
+        output_format="table",
+    )
+    run_bench(args)
+
+    captured = capsys.readouterr()
+    assert "Suite: community/customer-support" in captured.out
+    assert "Aggregate score:" in captured.out
+    assert "Community baseline:" in captured.out
+
+
+@patch("synapsekit.cli.bench.make_llm")
+def test_run_bench_suite_with_model_success(mock_make_llm, capsys):
+    mock_llm = MagicMock()
+
+    async def fake_generate(prompt):
+        return "high quality response"
+
+    mock_llm.generate = fake_generate
+    mock_make_llm.return_value = mock_llm
+
+    args = argparse.Namespace(
+        list=False,
+        publish=None,
+        suite="community/summarization",
+        pipeline=None,
+        agent=None,
+        model="gpt-4o-mini",
+        provider="openai",
+        api_key="sk-test",
+        temperature=0.0,
+        max_tokens=128,
+        system_prompt="You are concise.",
+        limit=1,
+        output_format="json",
+    )
+    run_bench(args)
+
+    out = capsys.readouterr().out
+    assert '"suite": "community/summarization"' in out
+    assert '"aggregate_score"' in out
+
+
+def test_run_bench_unknown_suite():
+    args = argparse.Namespace(
+        list=False,
+        publish=None,
+        suite="community/does-not-exist",
+        pipeline=None,
+        agent=None,
+        model="gpt-4o-mini",
+        provider="openai",
+        api_key="sk-test",
+        temperature=0.0,
+        max_tokens=128,
+        system_prompt="You are concise.",
+        limit=None,
+        output_format="table",
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        run_bench(args)
+    assert "Unknown suite" in str(exc_info.value)
+
+
+def test_run_bench_suite_requires_model_or_pipeline():
+    args = argparse.Namespace(
+        list=False,
+        publish=None,
+        suite="community/customer-support",
+        pipeline=None,
+        agent=None,
+        model=None,
+        provider=None,
+        api_key=None,
+        temperature=0.0,
+        max_tokens=128,
+        system_prompt="You are concise.",
+        limit=None,
+        output_format="table",
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        run_bench(args)
+    assert "--model is required" in str(exc_info.value)
+
+
+def test_run_bench_publish_requires_name(tmp_path):
+    args = argparse.Namespace(list=False, publish=str(tmp_path), name=None, suite=None)
+    with pytest.raises(SystemExit) as exc_info:
+        run_bench(args)
+    assert "--name is required" in str(exc_info.value)
+
+
+def test_run_bench_publish_no_submit_prints_manifest_and_bundle(tmp_path, capsys):
+    folder = tmp_path / "my_evals"
+    folder.mkdir()
+    (folder / "suite.json").write_text("{}", encoding="utf-8")
+
+    args = argparse.Namespace(
+        list=False,
+        publish=str(folder),
+        name="myorg/rag-finance",
+        suite=None,
+        bundle_out=str(tmp_path / "myorg-rag-finance.zip"),
+        registry_repo="SynapseKit/SynapseKit",
+        registry_dir="src/synapsekit/evaluation/evalhub/community",
+        no_submit=True,
+    )
+    run_bench(args)
+
+    out = capsys.readouterr().out
+    assert '"name": "myorg/rag-finance"' in out
+    assert '"suite.json"' in out
+    assert '"bundle"' in out
+
+
+@patch("synapsekit.cli.bench._submit_suite_pr")
+def test_run_bench_publish_submit_attaches_pr(mock_submit, tmp_path, capsys):
+    mock_submit.return_value = "https://github.com/SynapseKit/SynapseKit/pull/999"
+
+    folder = tmp_path / "my_evals"
+    folder.mkdir()
+    (folder / "suite.json").write_text("{}", encoding="utf-8")
+
+    args = argparse.Namespace(
+        list=False,
+        publish=str(folder),
+        name="myorg/rag-finance",
+        suite=None,
+        bundle_out=str(tmp_path / "myorg-rag-finance.zip"),
+        registry_repo="SynapseKit/SynapseKit",
+        registry_dir="src/synapsekit/evaluation/evalhub/community",
+        no_submit=False,
+    )
+    run_bench(args)
+
+    out = capsys.readouterr().out
+    assert '"pull_request": "https://github.com/SynapseKit/SynapseKit/pull/999"' in out
+
+
+def test_run_bench_missing_action():
+    args = argparse.Namespace(list=False, publish=None, suite=None)
+    with pytest.raises(SystemExit) as exc_info:
+        run_bench(args)
+    assert "Missing bench action" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- add new synapsekit bench CLI command in src/synapsekit/cli/bench.py
- add built-in EvalHub registry with JSON index + bundled community suites
- support --suite execution against model or callable pipeline with per-case + aggregate scoring and baseline delta
- implement --publish packaging flow with optional PR submission (--no-submit for package-only)
- add tests for bench CLI and docs for suite listing/usage

## Acceptance coverage for #590
- [x] synapsekit bench CLI command in cli/bench.py
- [x] Built-in suite registry (JSON index + bundled suites)
- [x] --suite runs suite against user's pipeline
- [x] Results: score per case + aggregate, comparison to baseline
- [x] --publish packages and submits a suite (GitHub PR to registry)
- [x] Docs page listing all available community suites

## Validation
- python -m ruff check src/synapsekit/cli/bench.py src/synapsekit/cli/main.py tests/cli/test_bench.py
- PYTHONPATH=src python -m pytest tests/cli/test_bench.py tests/cli/test_benchmark.py

Closes #590