### PR TITLE
feat(rag): add SelfHealingRAG

### DIFF
--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -234,6 +234,7 @@ from .prompts.hub import PromptHub
 from .prompts.template import ChatPromptTemplate, FewShotPromptTemplate, PromptTemplate
 from .rag.facade import RAG
 from .rag.pipeline import RAGConfig, RAGPipeline
+from .rag.self_healing import SelfHealingRAG
 from .retrieval.adaptive import AdaptiveRAGRetriever
 from .retrieval.base import VectorStore
 from .retrieval.cohere_reranker import CohereReranker
@@ -275,6 +276,7 @@ __version__ = "1.6.0"
 __all__ = [
     # Facade
     "RAG",
+    "SelfHealingRAG",
     # Pipeline
     "RAGPipeline",
     "RAGConfig",

--- a/src/synapsekit/rag/__init__.py
+++ b/src/synapsekit/rag/__init__.py
@@ -1,4 +1,5 @@
 from .facade import RAG
 from .pipeline import RAGConfig, RAGPipeline
+from .self_healing import SelfHealingRAG
 
-__all__ = ["RAG", "RAGConfig", "RAGPipeline"]
+__all__ = ["RAG", "RAGConfig", "RAGPipeline", "SelfHealingRAG"]

--- a/src/synapsekit/rag/self_healing.py
+++ b/src/synapsekit/rag/self_healing.py
@@ -187,7 +187,9 @@ class SelfHealingRAG:
             raise AttributeError(f"Strategy {type(strategy).__name__} has no retrieve method")
 
         try:
-            return cast(list[str], await retrieve(query, top_k=top_k, metadata_filter=metadata_filter))
+            return cast(
+                list[str], await retrieve(query, top_k=top_k, metadata_filter=metadata_filter)
+            )
         except TypeError:
             # Some retrievers don't accept metadata_filter
             return cast(list[str], await retrieve(query, top_k=top_k))

--- a/src/synapsekit/rag/self_healing.py
+++ b/src/synapsekit/rag/self_healing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Protocol
+from typing import Protocol, cast
 
 from .._compat import run_sync
 from ..evaluation.faithfulness import FaithfulnessMetric
@@ -141,9 +141,17 @@ class SelfHealingRAG:
                     metric_result.score,
                     self._quality_threshold,
                 )
-            except Exception as exc:
+            except Exception:
                 logger.exception("SelfHealingRAG attempt failed with %s", last_strategy)
                 if attempt >= max_attempts - 1:
+                    self._last_report = SelfHealingReport(
+                        success=False,
+                        attempts=max_attempts,
+                        retries=max(0, max_attempts - 1),
+                        strategy=last_strategy,
+                        scores=scores,
+                        threshold=self._quality_threshold,
+                    )
                     raise
 
         # No attempt met the threshold; return the last answer produced.
@@ -179,10 +187,10 @@ class SelfHealingRAG:
             raise AttributeError(f"Strategy {type(strategy).__name__} has no retrieve method")
 
         try:
-            return await retrieve(query, top_k=top_k, metadata_filter=metadata_filter)
+            return cast(list[str], await retrieve(query, top_k=top_k, metadata_filter=metadata_filter))
         except TypeError:
             # Some retrievers don't accept metadata_filter
-            return await retrieve(query, top_k=top_k)
+            return cast(list[str], await retrieve(query, top_k=top_k))
 
     async def _generate_answer(self, query: str, chunks: list[str]) -> str:
         if chunks:

--- a/src/synapsekit/rag/self_healing.py
+++ b/src/synapsekit/rag/self_healing.py
@@ -1,0 +1,219 @@
+"""Self-healing RAG: retry with alternate retrieval strategies on low-quality answers."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from .._compat import run_sync
+from ..evaluation.faithfulness import FaithfulnessMetric
+from ..llm.base import BaseLLM
+from ..memory.conversation import ConversationMemory
+from ..observability.tracer import TokenTracer
+
+logger = logging.getLogger(__name__)
+
+
+class RetrievalStrategy(Protocol):
+    async def retrieve(
+        self,
+        query: str,
+        top_k: int = 5,
+        metadata_filter: dict | None = None,
+    ) -> list[str]: ...
+
+
+@dataclass
+class SelfHealingReport:
+    success: bool
+    attempts: int
+    retries: int
+    strategy: str | None
+    scores: list[float] = field(default_factory=list)
+    threshold: float = 0.0
+
+
+class SelfHealingRAG:
+    """Retry retrieval strategies when faithfulness is below a threshold.
+
+    Example::
+
+        rag = SelfHealingRAG(
+            llm=llm,
+            strategies=[
+                HybridSearchRetriever(vectorstore=vs),
+                CRAGRetriever(retriever=retriever, llm=llm),
+            ],
+            quality_threshold=0.75,
+            max_retries=2,
+        )
+
+        answer = await rag.ask("Complex question...")
+    """
+
+    def __init__(
+        self,
+        *,
+        llm: BaseLLM,
+        strategies: Sequence[RetrievalStrategy],
+        quality_threshold: float = 0.75,
+        max_retries: int = 2,
+        system_prompt: str = "Answer using only the provided context. If the context does not contain the answer, say so.",
+        retrieval_top_k: int = 5,
+        memory: ConversationMemory | None = None,
+        tracer: TokenTracer | None = None,
+        metric: FaithfulnessMetric | None = None,
+    ) -> None:
+        if not strategies:
+            raise ValueError("strategies must not be empty")
+        if max_retries < 0:
+            raise ValueError("max_retries must be >= 0")
+
+        self._llm = llm
+        self._strategies = list(strategies)
+        self._quality_threshold = quality_threshold
+        self._max_retries = max_retries
+        self._system_prompt = system_prompt
+        self._retrieval_top_k = retrieval_top_k
+        self._memory = memory or ConversationMemory()
+        self._tracer = tracer
+        self._metric = metric or FaithfulnessMetric(llm)
+        self._last_report: SelfHealingReport | None = None
+
+    @property
+    def last_report(self) -> SelfHealingReport | None:
+        return self._last_report
+
+    @property
+    def memory(self) -> ConversationMemory:
+        return self._memory
+
+    async def ask(
+        self,
+        query: str,
+        *,
+        top_k: int | None = None,
+        metadata_filter: dict | None = None,
+    ) -> str:
+        k = top_k or self._retrieval_top_k
+        max_attempts = min(len(self._strategies), 1 + self._max_retries)
+        scores: list[float] = []
+        last_answer = ""
+        last_strategy: str | None = None
+
+        for attempt in range(max_attempts):
+            strategy = self._strategies[attempt]
+            last_strategy = type(strategy).__name__
+
+            try:
+                chunks = await self._retrieve(strategy, query, k, metadata_filter)
+                last_answer = await self._generate_answer(query, chunks)
+                metric_result = await self._metric.evaluate(
+                    question=query,
+                    answer=last_answer,
+                    contexts=chunks,
+                )
+                scores.append(metric_result.score)
+
+                if metric_result.score >= self._quality_threshold:
+                    self._commit_answer(query, last_answer)
+                    self._last_report = SelfHealingReport(
+                        success=True,
+                        attempts=attempt + 1,
+                        retries=max(0, attempt),
+                        strategy=last_strategy,
+                        scores=scores,
+                        threshold=self._quality_threshold,
+                    )
+                    logger.info(
+                        "SelfHealingRAG success with %s after %s retries (score=%.3f)",
+                        last_strategy,
+                        max(0, attempt),
+                        metric_result.score,
+                    )
+                    return last_answer
+
+                logger.info(
+                    "SelfHealingRAG retry: %s faithfulness %.3f < %.3f",
+                    last_strategy,
+                    metric_result.score,
+                    self._quality_threshold,
+                )
+            except Exception as exc:
+                logger.exception("SelfHealingRAG attempt failed with %s", last_strategy)
+                if attempt >= max_attempts - 1:
+                    raise
+
+        # No attempt met the threshold; return the last answer produced.
+        if last_answer:
+            self._commit_answer(query, last_answer)
+        self._last_report = SelfHealingReport(
+            success=False,
+            attempts=max_attempts,
+            retries=max(0, max_attempts - 1),
+            strategy=last_strategy,
+            scores=scores,
+            threshold=self._quality_threshold,
+        )
+        logger.info(
+            "SelfHealingRAG exhausted strategies after %s retries; last=%s",
+            max(0, max_attempts - 1),
+            last_strategy,
+        )
+        return last_answer
+
+    def ask_sync(self, query: str, **kw) -> str:
+        return run_sync(self.ask(query, **kw))
+
+    async def _retrieve(
+        self,
+        strategy: RetrievalStrategy,
+        query: str,
+        top_k: int,
+        metadata_filter: dict | None,
+    ) -> list[str]:
+        retrieve = getattr(strategy, "retrieve", None)
+        if retrieve is None or not callable(retrieve):
+            raise AttributeError(f"Strategy {type(strategy).__name__} has no retrieve method")
+
+        try:
+            return await retrieve(query, top_k=top_k, metadata_filter=metadata_filter)
+        except TypeError:
+            # Some retrievers don't accept metadata_filter
+            return await retrieve(query, top_k=top_k)
+
+    async def _generate_answer(self, query: str, chunks: list[str]) -> str:
+        if chunks:
+            tagged = [f"<document>\n{chunk}\n</document>" for chunk in chunks]
+            context = "\n\n".join(tagged)
+        else:
+            context = "No context available."
+
+        history = self._memory.format_context()
+        messages: list[dict] = [
+            {"role": "system", "content": self._system_prompt},
+        ]
+        if history:
+            messages.append({"role": "user", "content": f"Previous conversation:\n{history}"})
+            messages.append({"role": "assistant", "content": "Understood."})
+        messages.append({"role": "user", "content": f"Context:\n{context}\n\nQuestion: {query}"})
+
+        tracer = self._tracer
+        t0 = tracer.start_timer() if tracer else 0.0
+        answer = await self._llm.generate_with_messages(messages)
+
+        if tracer:
+            used = self._llm.tokens_used
+            tracer.record(
+                input_tokens=used["input"],
+                output_tokens=used["output"],
+                latency_ms=tracer.elapsed_ms(t0),
+            )
+
+        return answer
+
+    def _commit_answer(self, query: str, answer: str) -> None:
+        self._memory.add("user", query)
+        self._memory.add("assistant", answer)

--- a/tests/rag/test_self_healing.py
+++ b/tests/rag/test_self_healing.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from synapsekit.rag.self_healing import SelfHealingRAG
+
+
+class _Strategy:
+    def __init__(self, chunks):
+        self.retrieve = AsyncMock(return_value=chunks)
+
+
+@pytest.mark.asyncio
+async def test_self_healing_single_strategy_success():
+    llm = MagicMock()
+    llm.tokens_used = {"input": 1, "output": 1}
+    llm.generate_with_messages = AsyncMock(return_value="answer")
+
+    metric = MagicMock()
+    metric.evaluate = AsyncMock(return_value=MagicMock(score=0.9))
+
+    rag = SelfHealingRAG(
+        llm=llm,
+        strategies=[_Strategy(["ctx"])],
+        quality_threshold=0.75,
+        max_retries=2,
+        metric=metric,
+    )
+
+    answer = await rag.ask("q")
+    assert answer == "answer"
+    assert rag.last_report is not None
+    assert rag.last_report.success is True
+    assert rag.last_report.retries == 0
+
+
+@pytest.mark.asyncio
+async def test_self_healing_fallback_triggered():
+    llm = MagicMock()
+    llm.tokens_used = {"input": 1, "output": 1}
+    llm.generate_with_messages = AsyncMock(side_effect=["bad", "good"])
+
+    metric = MagicMock()
+    metric.evaluate = AsyncMock(
+        side_effect=[MagicMock(score=0.2), MagicMock(score=0.8)]
+    )
+
+    primary = _Strategy(["ctx1"])
+    fallback = _Strategy(["ctx2"])
+
+    rag = SelfHealingRAG(
+        llm=llm,
+        strategies=[primary, fallback],
+        quality_threshold=0.75,
+        max_retries=2,
+        metric=metric,
+    )
+
+    answer = await rag.ask("q")
+    assert answer == "good"
+    assert rag.last_report is not None
+    assert rag.last_report.success is True
+    assert rag.last_report.retries == 1
+
+
+@pytest.mark.asyncio
+async def test_self_healing_max_retries_cap():
+    llm = MagicMock()
+    llm.tokens_used = {"input": 1, "output": 1}
+    llm.generate_with_messages = AsyncMock(return_value="ans")
+
+    metric = MagicMock()
+    metric.evaluate = AsyncMock(return_value=MagicMock(score=0.1))
+
+    strategies = [_Strategy(["ctx1"]), _Strategy(["ctx2"]), _Strategy(["ctx3"])]
+
+    rag = SelfHealingRAG(
+        llm=llm,
+        strategies=strategies,
+        quality_threshold=0.9,
+        max_retries=1,
+        metric=metric,
+    )
+
+    answer = await rag.ask("q")
+    assert answer == "ans"
+    assert rag.last_report is not None
+    # max_retries=1 => at most 2 attempts
+    assert rag.last_report.attempts == 2
+    assert rag.last_report.success is False

--- a/tests/rag/test_self_healing.py
+++ b/tests/rag/test_self_healing.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from synapsekit.rag.self_healing import SelfHealingRAG
 
@@ -42,9 +43,7 @@ async def test_self_healing_fallback_triggered():
     llm.generate_with_messages = AsyncMock(side_effect=["bad", "good"])
 
     metric = MagicMock()
-    metric.evaluate = AsyncMock(
-        side_effect=[MagicMock(score=0.2), MagicMock(score=0.8)]
-    )
+    metric.evaluate = AsyncMock(side_effect=[MagicMock(score=0.2), MagicMock(score=0.8)])
 
     primary = _Strategy(["ctx1"])
     fallback = _Strategy(["ctx2"])

--- a/tests/rag/test_self_healing_integration.py
+++ b/tests/rag/test_self_healing_integration.py
@@ -1,27 +1,32 @@
-import pytest
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
 from synapsekit.rag.self_healing import SelfHealingRAG
-from synapsekit.evaluation.faithfulness import FaithfulnessMetric
+
 
 class _Strategy:
     def __init__(self, chunks):
         self.retrieve = AsyncMock(return_value=chunks)
+
 
 @pytest.mark.asyncio
 async def test_self_healing_real_metric_integration():
     llm = MagicMock()
     # Mock for _generate_answer
     llm.generate_with_messages = AsyncMock(return_value="The capital of France is Paris.")
-    
+
     # Mock for FaithfulnessMetric.evaluate
     # It calls llm.generate twice: once for claims, once for support check
-    llm.generate = AsyncMock(side_effect=[
-        "1. The capital of France is Paris.", # claims response
-        "YES" # check response
-    ])
+    llm.generate = AsyncMock(
+        side_effect=[
+            "1. The capital of France is Paris.",  # claims response
+            "YES",  # check response
+        ]
+    )
 
     strategy = _Strategy(["Paris is the capital of France."])
-    
+
     rag = SelfHealingRAG(
         llm=llm,
         strategies=[strategy],
@@ -30,5 +35,6 @@ async def test_self_healing_real_metric_integration():
 
     answer = await rag.ask("What is the capital of France?")
     assert answer == "The capital of France is Paris."
+    assert rag.last_report is not None
     assert rag.last_report.success is True
     assert rag.last_report.scores[0] == 1.0

--- a/tests/rag/test_self_healing_integration.py
+++ b/tests/rag/test_self_healing_integration.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from synapsekit.rag.self_healing import SelfHealingRAG
+from synapsekit.evaluation.faithfulness import FaithfulnessMetric
+
+class _Strategy:
+    def __init__(self, chunks):
+        self.retrieve = AsyncMock(return_value=chunks)
+
+@pytest.mark.asyncio
+async def test_self_healing_real_metric_integration():
+    llm = MagicMock()
+    # Mock for _generate_answer
+    llm.generate_with_messages = AsyncMock(return_value="The capital of France is Paris.")
+    
+    # Mock for FaithfulnessMetric.evaluate
+    # It calls llm.generate twice: once for claims, once for support check
+    llm.generate = AsyncMock(side_effect=[
+        "1. The capital of France is Paris.", # claims response
+        "YES" # check response
+    ])
+
+    strategy = _Strategy(["Paris is the capital of France."])
+    
+    rag = SelfHealingRAG(
+        llm=llm,
+        strategies=[strategy],
+        quality_threshold=0.8,
+    )
+
+    answer = await rag.ask("What is the capital of France?")
+    assert answer == "The capital of France is Paris."
+    assert rag.last_report.success is True
+    assert rag.last_report.scores[0] == 1.0


### PR DESCRIPTION
## Summary
- Add SelfHealingRAG wrapper that retries retrieval strategies when faithfulness is low
- Track retries/strategy outcome and expose last_report
- Add tests for success, fallback, and retry cap

## Tests
- uv run pytest

Closes #596
