### PR TITLE
feat(llm): Added the CostQualityRouter 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ video = ["openai>=1.0"]
 voice = ["openai>=1.0"]
 voice-local = ["pyttsx3>=2.90", "faster-whisper>=1.0"]
 voice-stream = ["sounddevice>=0.4", "soundfile>=0.12"]
-cron = ["croniter>=2.0"]
+cron = ["croniter>=2.0", "tzdata>=2024.1; sys_platform == 'win32'"]
 excel = ["openpyxl>=3.1"]
 pptx = ["python-pptx>=0.6"]
 docx = ["python-docx>=1.0"]
@@ -230,6 +230,7 @@ dev = [
     "lxml>=6.0.2",
     "beautifulsoup4>=4.14.3",
     "fastapi>=0.135.1",
+    "tzdata>=2024.1",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -377,6 +377,6 @@ snowflake-connector-python = "snowflake"
 
 [tool.deptry.per_rule_ignores]
 DEP001 = ["sqlalchemy", "pydantic", "aiohttp", "opentelemetry", "whisper", "botocore", "aiomcache", "nest_asyncio", "huggingface_hub", "serpapi", "weaviate", "uvicorn", "starlette", "tomli", "pyttsx3", "faster_whisper", "sounddevice", "soundfile", "aiokafka", "typesense"]
-DEP002 = ["numpy", "rank-bm25", "beautifulsoup4", "lxml", "faiss-cpu", "google-generativeai", "tavily-python", "youtube-search-python", "psycopg", "google-search-results", "discord.py", "google-auth", "weaviate-client", "pymilvus", "lancedb", "pgvector", "slack-sdk", "supabase", "pymongo", "azure-storage-blob", "elasticsearch"]
+DEP002 = ["numpy", "rank-bm25", "beautifulsoup4", "lxml", "faiss-cpu", "google-generativeai", "tavily-python", "youtube-search-python", "psycopg", "google-search-results", "discord.py", "google-auth", "weaviate-client", "pymilvus", "lancedb", "pgvector", "slack-sdk", "supabase", "pymongo", "azure-storage-blob", "elasticsearch", "tzdata"]
 DEP003 = ["sqlalchemy", "botocore", "nest_asyncio", "opentelemetry", "starlette", "uvicorn"]
 DEP004 = ["pydantic"]

--- a/src/synapsekit/llm/__init__.py
+++ b/src/synapsekit/llm/__init__.py
@@ -1,5 +1,6 @@
 from ._cache import AsyncLRUCache
 from .base import BaseLLM, LLMConfig
+from .cost_quality_router import CostQualityRouter
 from .cost_router import QUALITY_TABLE, CostRouter, CostRouterConfig, RouterModelSpec
 from .fallback_chain import FallbackChain, FallbackChainConfig
 from .structured import generate_structured
@@ -18,6 +19,7 @@ __all__ = [
     "CerebrasLLM",
     "CloudflareLLM",
     "CohereLLM",
+    "CostQualityRouter",
     "CostRouter",
     "CostRouterConfig",
     "DatabricksLLM",

--- a/src/synapsekit/llm/cost_quality_router.py
+++ b/src/synapsekit/llm/cost_quality_router.py
@@ -77,11 +77,14 @@ class CostQualityRouter(BaseLLM):
         self._evaluator_loaded = True
         if not self._eval_suite:
             return None
+        mod_path: str
+        attr: str | None
         if ":" in self._eval_suite:
             mod_path, attr = self._eval_suite.rsplit(":", 1)
         else:
             parts = self._eval_suite.rsplit(".", 1)
-            mod_path, attr = (parts[0], parts[1]) if len(parts) == 2 else (parts[0], None)
+            mod_path = parts[0]
+            attr = parts[1] if len(parts) == 2 else None
         try:
             mod = importlib.import_module(mod_path)
             self._evaluator = getattr(mod, attr) if attr else mod
@@ -137,8 +140,7 @@ class CostQualityRouter(BaseLLM):
                 continue
             meets_quality = s["avg_quality"] >= self._quality_threshold
             within_budget = (
-                self._budget_per_call_usd is None
-                or s["avg_cost"] <= self._budget_per_call_usd
+                self._budget_per_call_usd is None or s["avg_cost"] <= self._budget_per_call_usd
             )
             if meets_quality and within_budget:
                 group_a.append(llm)
@@ -147,8 +149,8 @@ class CostQualityRouter(BaseLLM):
             else:
                 group_c.append(llm)
 
-        key_cost = lambda l: self._stats[l.config.model]["avg_cost"]  # noqa: E731
-        key_quality = lambda l: self._stats[l.config.model]["avg_quality"]  # noqa: E731
+        key_cost = lambda m: self._stats[m.config.model]["avg_cost"]  # noqa: E731
+        key_quality = lambda m: self._stats[m.config.model]["avg_quality"]  # noqa: E731
         group_a.sort(key=key_cost)
         group_b.sort(key=key_cost)
         group_c.sort(key=key_quality, reverse=True)
@@ -288,9 +290,11 @@ class CostQualityRouter(BaseLLM):
                 if om != model
             )
             if not dominated:
-                frontier.append({
-                    "model": model,
-                    "cost": s["avg_cost"],
-                    "quality": s["avg_quality"],
-                })
+                frontier.append(
+                    {
+                        "model": model,
+                        "cost": s["avg_cost"],
+                        "quality": s["avg_quality"],
+                    }
+                )
         return frontier

--- a/src/synapsekit/llm/cost_quality_router.py
+++ b/src/synapsekit/llm/cost_quality_router.py
@@ -125,9 +125,12 @@ class CostQualityRouter(BaseLLM):
         """Return candidates ordered for exploitation.
 
         Priority:
-          1. Meets quality threshold AND within budget  — cheapest first
+          1. Unseen (calls == 0) OR meets quality threshold AND within budget — cheapest first
           2. Meets quality threshold but over budget    — cheapest first (quality-over-budget fallback)
-          3. Below threshold or unseen                  — highest quality first (last resort)
+          3. Below threshold                            — highest quality first (last resort)
+
+        Unseen models land in group_a so early exploitation gives them a chance
+        to accumulate stats rather than burying them behind proven-bad models.
         """
         group_a: list[BaseLLM] = []
         group_b: list[BaseLLM] = []
@@ -136,7 +139,7 @@ class CostQualityRouter(BaseLLM):
         for llm in self._candidates:
             s = self._stats[llm.config.model]
             if s["calls"] == 0:
-                group_c.append(llm)
+                group_a.append(llm)
                 continue
             meets_quality = s["avg_quality"] >= self._quality_threshold
             within_budget = (
@@ -149,8 +152,12 @@ class CostQualityRouter(BaseLLM):
             else:
                 group_c.append(llm)
 
-        key_cost = lambda m: self._stats[m.config.model]["avg_cost"]  # noqa: E731
-        key_quality = lambda m: self._stats[m.config.model]["avg_quality"]  # noqa: E731
+        def key_cost(m: BaseLLM) -> float:
+            return self._stats[m.config.model]["avg_cost"]
+
+        def key_quality(m: BaseLLM) -> float:
+            return self._stats[m.config.model]["avg_quality"]
+
         group_a.sort(key=key_cost)
         group_b.sort(key=key_cost)
         group_c.sort(key=key_quality, reverse=True)

--- a/src/synapsekit/llm/cost_quality_router.py
+++ b/src/synapsekit/llm/cost_quality_router.py
@@ -1,0 +1,296 @@
+"""CostQualityRouter — learning-based routing: explore then exploit on observed cost/quality."""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from ..observability.tracer import COST_TABLE
+from .base import BaseLLM, LLMConfig
+
+
+class CostQualityRouter(BaseLLM):
+    """Route requests to the cheapest model meeting a learned quality threshold.
+
+    Phase 1 — Exploration: round-robin across all candidates for ``explore_n`` calls,
+    collecting real cost and quality measurements.
+
+    Phase 2 — Exploitation: route to the cheapest model whose observed ``avg_quality``
+    meets ``quality_threshold``.  Falls back to the highest-quality model when none
+    qualify, and respects ``budget_per_call_usd`` when provided.
+
+    Example::
+
+        router = CostQualityRouter(
+            candidates=[cheap_llm, expensive_llm],
+            quality_threshold=0.85,
+            budget_per_call_usd=0.01,
+            explore_n=50,
+        )
+        answer = await router.call("Summarise this document")
+        print(router.stats())
+    """
+
+    def __init__(
+        self,
+        candidates: list[BaseLLM],
+        eval_suite: str | None = None,
+        quality_threshold: float = 0.8,
+        budget_per_call_usd: float | None = None,
+        explore_n: int = 50,
+    ) -> None:
+        super().__init__(LLMConfig(model="__cq_router__", api_key="", provider="openai"))
+        self._candidates = candidates
+        self._eval_suite = eval_suite
+        self._quality_threshold = quality_threshold
+        self._budget_per_call_usd = budget_per_call_usd
+        self._explore_n = explore_n
+
+        self._calls = 0
+        self._mode = "explore"
+
+        # Keyed by model name; private _total_quality/_quality_calls drive the running avg.
+        self._stats: dict[str, dict[str, Any]] = {
+            llm.config.model: {
+                "calls": 0,
+                "avg_cost": 0.0,
+                "avg_quality": 0.0,
+                "_total_quality": 0.0,
+                "_quality_calls": 0,
+            }
+            for llm in candidates
+        }
+
+        self._explore_index = 0
+        self._evaluator: Any = None
+        self._evaluator_loaded = False
+
+    # ------------------------------------------------------------------ #
+    # Eval suite integration
+    # ------------------------------------------------------------------ #
+
+    def _load_evaluator(self) -> Any:
+        """Lazily import the eval_suite object (supports ``"pkg.mod:attr"`` or ``"pkg.mod.attr"``)."""
+        if self._evaluator_loaded:
+            return self._evaluator
+        self._evaluator_loaded = True
+        if not self._eval_suite:
+            return None
+        if ":" in self._eval_suite:
+            mod_path, attr = self._eval_suite.rsplit(":", 1)
+        else:
+            parts = self._eval_suite.rsplit(".", 1)
+            mod_path, attr = (parts[0], parts[1]) if len(parts) == 2 else (parts[0], None)
+        try:
+            mod = importlib.import_module(mod_path)
+            self._evaluator = getattr(mod, attr) if attr else mod
+        except Exception:
+            self._evaluator = None
+        return self._evaluator
+
+    async def _evaluate_quality(self, prompt: str, response: str) -> float | None:
+        """Call the eval suite and return a score in [0, 1], or None if unavailable."""
+        evaluator = self._load_evaluator()
+        if evaluator is None:
+            return None
+        try:
+            result = await evaluator.evaluate(question=prompt, answer=response)
+            if hasattr(result, "mean_score"):
+                score = result.mean_score
+            elif isinstance(result, dict):
+                score = result.get("score")
+            elif isinstance(result, (int, float)):
+                score = float(result)
+            else:
+                return None
+            return float(score) if score is not None else None
+        except Exception:
+            return None
+
+    # ------------------------------------------------------------------ #
+    # Model selection
+    # ------------------------------------------------------------------ #
+
+    def _select_explore(self) -> BaseLLM:
+        """Round-robin selection during exploration."""
+        llm = self._candidates[self._explore_index % len(self._candidates)]
+        self._explore_index += 1
+        return llm
+
+    def _exploit_ordering(self) -> list[BaseLLM]:
+        """Return candidates ordered for exploitation.
+
+        Priority:
+          1. Meets quality threshold AND within budget  — cheapest first
+          2. Meets quality threshold but over budget    — cheapest first (quality-over-budget fallback)
+          3. Below threshold or unseen                  — highest quality first (last resort)
+        """
+        group_a: list[BaseLLM] = []
+        group_b: list[BaseLLM] = []
+        group_c: list[BaseLLM] = []
+
+        for llm in self._candidates:
+            s = self._stats[llm.config.model]
+            if s["calls"] == 0:
+                group_c.append(llm)
+                continue
+            meets_quality = s["avg_quality"] >= self._quality_threshold
+            within_budget = (
+                self._budget_per_call_usd is None
+                or s["avg_cost"] <= self._budget_per_call_usd
+            )
+            if meets_quality and within_budget:
+                group_a.append(llm)
+            elif meets_quality:
+                group_b.append(llm)
+            else:
+                group_c.append(llm)
+
+        key_cost = lambda l: self._stats[l.config.model]["avg_cost"]  # noqa: E731
+        key_quality = lambda l: self._stats[l.config.model]["avg_quality"]  # noqa: E731
+        group_a.sort(key=key_cost)
+        group_b.sort(key=key_cost)
+        group_c.sort(key=key_quality, reverse=True)
+
+        return group_a + group_b + group_c
+
+    # ------------------------------------------------------------------ #
+    # Cost measurement
+    # ------------------------------------------------------------------ #
+
+    def _measure_cost(self, llm: BaseLLM, prev_in: int, prev_out: int) -> float:
+        """Compute USD cost for the tokens consumed since the snapshot."""
+        pricing = COST_TABLE.get(llm.config.model)
+        if not pricing:
+            return 0.0
+        delta_in = max(0, llm._input_tokens - prev_in)
+        delta_out = max(0, llm._output_tokens - prev_out)
+        return delta_in * pricing["input"] + delta_out * pricing["output"]
+
+    # ------------------------------------------------------------------ #
+    # Stats update
+    # ------------------------------------------------------------------ #
+
+    def _update_stats(self, model: str, cost: float, quality: float | None) -> None:
+        """Update running averages for cost and (optionally) quality."""
+        s = self._stats[model]
+        n = s["calls"]
+        s["avg_cost"] = (s["avg_cost"] * n + cost) / (n + 1)
+        if quality is not None:
+            s["_total_quality"] += quality
+            s["_quality_calls"] += 1
+            s["avg_quality"] = s["_total_quality"] / s["_quality_calls"]
+        s["calls"] = n + 1
+
+    # ------------------------------------------------------------------ #
+    # Core public API
+    # ------------------------------------------------------------------ #
+
+    async def call(self, prompt: str) -> str:
+        """Route ``prompt`` to the best available model and return the response."""
+        return await self.generate(prompt)
+
+    async def generate(self, prompt: str, **kw: Any) -> str:  # type: ignore[override]
+        """Select model, call, measure cost/quality, update stats, return response."""
+        self._calls += 1
+        is_explore = self._calls <= self._explore_n
+        self._mode = "explore" if is_explore else "exploit"
+
+        if is_explore:
+            primary = self._select_explore()
+            ordered = [primary] + [c for c in self._candidates if c is not primary]
+        else:
+            ordered = self._exploit_ordering()
+
+        last_exc: Exception | None = None
+        for llm in ordered:
+            try:
+                prev_in = llm._input_tokens
+                prev_out = llm._output_tokens
+                response = await llm.generate(prompt, **kw)
+                if response is None:
+                    response = ""
+                cost = self._measure_cost(llm, prev_in, prev_out)
+                quality = await self._evaluate_quality(prompt, response)
+                self._update_stats(llm.config.model, cost, quality)
+                return response
+            except Exception as exc:
+                last_exc = exc
+
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError("No candidate models available")
+
+    async def stream(self, prompt: str, **kw: Any) -> AsyncGenerator[str, None]:  # type: ignore[override]
+        """Stream from the selected model, updating stats after completion."""
+        self._calls += 1
+        is_explore = self._calls <= self._explore_n
+        self._mode = "explore" if is_explore else "exploit"
+
+        if is_explore:
+            llm = self._select_explore()
+        else:
+            ordering = self._exploit_ordering()
+            llm = ordering[0] if ordering else self._candidates[0]
+
+        prev_in = llm._input_tokens
+        prev_out = llm._output_tokens
+        tokens: list[str] = []
+        try:
+            async for token in llm.stream(prompt, **kw):
+                tokens.append(token)
+                yield token
+        except Exception:
+            return
+
+        response = "".join(tokens)
+        cost = self._measure_cost(llm, prev_in, prev_out)
+        quality = await self._evaluate_quality(prompt, response)
+        self._update_stats(llm.config.model, cost, quality)
+
+    # ------------------------------------------------------------------ #
+    # Stats / Pareto frontier
+    # ------------------------------------------------------------------ #
+
+    def stats(self) -> dict[str, Any]:
+        """Return per-model stats and the Pareto frontier.
+
+        Returns::
+
+            {
+                "models": {
+                    model_name: {"avg_cost": float, "avg_quality": float, "calls": int}
+                },
+                "frontier": [{"model": str, "cost": float, "quality": float}, ...]
+            }
+
+        A model is on the Pareto frontier if no other model is both cheaper
+        and higher quality.
+        """
+        models_info = {
+            model: {
+                "avg_cost": s["avg_cost"],
+                "avg_quality": s["avg_quality"],
+                "calls": s["calls"],
+            }
+            for model, s in self._stats.items()
+        }
+        return {"models": models_info, "frontier": self._pareto_frontier()}
+
+    def _pareto_frontier(self) -> list[dict[str, Any]]:
+        active = [(m, s) for m, s in self._stats.items() if s["calls"] > 0]
+        frontier = []
+        for model, s in active:
+            dominated = any(
+                os["avg_cost"] < s["avg_cost"] and os["avg_quality"] > s["avg_quality"]
+                for om, os in active
+                if om != model
+            )
+            if not dominated:
+                frontier.append({
+                    "model": model,
+                    "cost": s["avg_cost"],
+                    "quality": s["avg_quality"],
+                })
+        return frontier

--- a/tests/llm/test_cost_quality_router.py
+++ b/tests/llm/test_cost_quality_router.py
@@ -1,0 +1,728 @@
+"""Tests for CostQualityRouter — learning-based explore/exploit routing."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from synapsekit.llm.base import BaseLLM, LLMConfig
+from synapsekit.llm.cost_quality_router import CostQualityRouter
+
+
+# ------------------------------------------------------------------ #
+# Helpers
+# ------------------------------------------------------------------ #
+
+
+class MockLLM(BaseLLM):
+    """Controllable LLM stub — overrides generate() and stream() directly."""
+
+    def __init__(
+        self,
+        model_name: str,
+        response: str = "ok",
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        fail: bool = False,
+    ) -> None:
+        super().__init__(LLMConfig(model=model_name, api_key="", provider="openai"))
+        self._mock_response = response
+        self._mock_input = input_tokens
+        self._mock_output = output_tokens
+        self._mock_fail = fail
+        self.call_count = 0
+
+    async def generate(self, prompt: str, **kw: Any) -> str:
+        if self._mock_fail:
+            raise RuntimeError(f"{self.config.model} failed")
+        self.call_count += 1
+        self._input_tokens += self._mock_input
+        self._output_tokens += self._mock_output
+        return self._mock_response
+
+    async def stream(self, prompt: str, **kw: Any) -> AsyncGenerator[str, None]:
+        if self._mock_fail:
+            raise RuntimeError(f"{self.config.model} failed")
+        self.call_count += 1
+        self._input_tokens += self._mock_input
+        self._output_tokens += self._mock_output
+        yield self._mock_response
+
+
+def _pre_fill(router: CostQualityRouter, model: str, calls: int, avg_cost: float, avg_quality: float) -> None:
+    """Manually populate router stats to simulate completed exploration."""
+    router._stats[model] = {
+        "calls": calls,
+        "avg_cost": avg_cost,
+        "avg_quality": avg_quality,
+        "_total_quality": avg_quality * calls,
+        "_quality_calls": calls,
+    }
+
+
+# ------------------------------------------------------------------ #
+# 1. Exploration phase
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_exploration_uses_all_candidates():
+    """All candidates are used during the exploration phase (round-robin)."""
+    llm_a = MockLLM("model-a")
+    llm_b = MockLLM("model-b")
+    llm_c = MockLLM("model-c")
+    router = CostQualityRouter(candidates=[llm_a, llm_b, llm_c], explore_n=9)
+
+    for _ in range(9):  # all within explore window (_calls 1-9 <= 9)
+        await router.call("prompt")
+
+    assert router._mode == "explore"
+    assert llm_a.call_count > 0
+    assert llm_b.call_count > 0
+    assert llm_c.call_count > 0
+
+
+@pytest.mark.asyncio
+async def test_exploration_round_robin_order():
+    """Exploration cycles through candidates in round-robin order."""
+    llm_a = MockLLM("model-a")
+    llm_b = MockLLM("model-b")
+    router = CostQualityRouter(candidates=[llm_a, llm_b], explore_n=100)
+
+    for _ in range(6):
+        await router.call("prompt")
+
+    assert llm_a.call_count == 3
+    assert llm_b.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_exploration_stats_updated():
+    """Stats are updated for each call during exploration."""
+    llm = MockLLM("model-a", input_tokens=100, output_tokens=50)
+    router = CostQualityRouter(candidates=[llm], explore_n=5)
+
+    await router.call("prompt")
+    await router.call("prompt")
+
+    s = router._stats["model-a"]
+    assert s["calls"] == 2
+    # model-a not in COST_TABLE → cost stays 0.0
+    assert s["avg_cost"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_exploration_mode_flag():
+    """_mode is 'explore' during exploration and 'exploit' after."""
+    llm_a = MockLLM("model-a")
+    llm_b = MockLLM("model-b")
+    router = CostQualityRouter(candidates=[llm_a, llm_b], explore_n=3)
+
+    await router.call("p")
+    assert router._mode == "explore"
+
+    await router.call("p")
+    await router.call("p")
+    assert router._mode == "explore"
+
+    await router.call("p")  # call 4 > explore_n=3 → exploit
+    assert router._mode == "exploit"
+
+
+# ------------------------------------------------------------------ #
+# 2. Exploitation — cheapest valid model selected
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_exploitation_selects_cheapest_model():
+    """Exploit mode picks the cheapest model that meets the quality threshold."""
+    llm_cheap = MockLLM("gpt-4o-mini")
+    llm_expensive = MockLLM("gpt-4o")
+    router = CostQualityRouter(
+        candidates=[llm_cheap, llm_expensive],
+        quality_threshold=0.80,
+        explore_n=0,
+    )
+    _pre_fill(router, "gpt-4o-mini", 5, avg_cost=0.0001, avg_quality=0.85)
+    _pre_fill(router, "gpt-4o", 5, avg_cost=0.01, avg_quality=0.95)
+
+    await router.call("prompt")
+
+    assert llm_cheap.call_count == 1
+    assert llm_expensive.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_exploitation_prefers_lower_cost_among_equal_quality():
+    """Among models with equal quality, the cheaper one is preferred."""
+    llm_a = MockLLM("gpt-4o-mini")
+    llm_b = MockLLM("gpt-4o")
+    router = CostQualityRouter(
+        candidates=[llm_a, llm_b],
+        quality_threshold=0.80,
+        explore_n=0,
+    )
+    _pre_fill(router, "gpt-4o-mini", 5, avg_cost=0.0001, avg_quality=0.90)
+    _pre_fill(router, "gpt-4o", 5, avg_cost=0.05, avg_quality=0.90)
+
+    await router.call("prompt")
+
+    assert llm_a.call_count == 1
+    assert llm_b.call_count == 0
+
+
+# ------------------------------------------------------------------ #
+# 3. Quality threshold enforcement
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_threshold_excludes_low_quality_models():
+    """Models below quality_threshold are not selected during exploitation."""
+    llm_high = MockLLM("gpt-4o")
+    llm_low = MockLLM("gpt-4o-mini")
+    router = CostQualityRouter(
+        candidates=[llm_high, llm_low],
+        quality_threshold=0.90,
+        explore_n=0,
+    )
+    _pre_fill(router, "gpt-4o", 5, avg_cost=0.01, avg_quality=0.95)
+    _pre_fill(router, "gpt-4o-mini", 5, avg_cost=0.0001, avg_quality=0.70)
+
+    await router.call("prompt")
+
+    assert llm_high.call_count == 1
+    assert llm_low.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_threshold_fallback_when_none_qualify():
+    """When no model meets the threshold, router falls back to highest-quality model."""
+    llm_best = MockLLM("model-best")
+    llm_worst = MockLLM("model-worst")
+    router = CostQualityRouter(
+        candidates=[llm_best, llm_worst],
+        quality_threshold=0.99,  # impossible threshold
+        explore_n=0,
+    )
+    _pre_fill(router, "model-best", 5, avg_cost=0.01, avg_quality=0.85)
+    _pre_fill(router, "model-worst", 5, avg_cost=0.001, avg_quality=0.50)
+
+    await router.call("prompt")
+
+    assert llm_best.call_count == 1
+    assert llm_worst.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_threshold_zero_accepts_all_models():
+    """quality_threshold=0.0 accepts any model (cheapest wins)."""
+    llm_cheap = MockLLM("gpt-4o-mini")
+    llm_expensive = MockLLM("gpt-4o")
+    router = CostQualityRouter(
+        candidates=[llm_cheap, llm_expensive],
+        quality_threshold=0.0,
+        explore_n=0,
+    )
+    _pre_fill(router, "gpt-4o-mini", 5, avg_cost=0.0001, avg_quality=0.0)
+    _pre_fill(router, "gpt-4o", 5, avg_cost=0.05, avg_quality=0.0)
+
+    await router.call("prompt")
+
+    assert llm_cheap.call_count == 1
+    assert llm_expensive.call_count == 0
+
+
+# ------------------------------------------------------------------ #
+# 4. Fallback on failure
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_fallback_on_primary_failure_explore():
+    """When the selected model fails during exploration, router retries with the next one."""
+    llm_fail = MockLLM("model-fail", fail=True)
+    llm_ok = MockLLM("model-ok")
+    router = CostQualityRouter(candidates=[llm_fail, llm_ok], explore_n=100)
+
+    result = await router.call("prompt")
+
+    assert result == "ok"
+    assert llm_ok.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_fallback_on_primary_failure_exploit():
+    """When exploit-selected model fails, router falls back to the next candidate."""
+    llm_fail = MockLLM("gpt-4o-mini", fail=True)
+    llm_ok = MockLLM("gpt-4o")
+    router = CostQualityRouter(
+        candidates=[llm_fail, llm_ok],
+        quality_threshold=0.0,
+        explore_n=0,
+    )
+    _pre_fill(router, "gpt-4o-mini", 5, avg_cost=0.0001, avg_quality=0.90)
+    _pre_fill(router, "gpt-4o", 5, avg_cost=0.01, avg_quality=0.95)
+
+    result = await router.call("prompt")
+
+    assert result == "ok"
+    assert llm_ok.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_raises_when_all_candidates_fail():
+    """RuntimeError propagates when every candidate fails."""
+    llm_a = MockLLM("model-a", fail=True)
+    llm_b = MockLLM("model-b", fail=True)
+    router = CostQualityRouter(candidates=[llm_a, llm_b], explore_n=100)
+
+    with pytest.raises(RuntimeError):
+        await router.call("prompt")
+
+
+@pytest.mark.asyncio
+async def test_fallback_does_not_update_stats_for_failed_call():
+    """Failed model calls are not counted in stats."""
+    llm_fail = MockLLM("model-fail", fail=True)
+    llm_ok = MockLLM("model-ok")
+    router = CostQualityRouter(candidates=[llm_fail, llm_ok], explore_n=100)
+
+    await router.call("prompt")
+
+    assert router._stats["model-fail"]["calls"] == 0
+    assert router._stats["model-ok"]["calls"] == 1
+
+
+# ------------------------------------------------------------------ #
+# 5. Budget constraint
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_budget_skips_over_budget_model():
+    """Models whose avg_cost exceeds budget_per_call_usd are skipped."""
+    llm_cheap = MockLLM("gpt-4o-mini")
+    llm_expensive = MockLLM("gpt-4o")
+    router = CostQualityRouter(
+        candidates=[llm_cheap, llm_expensive],
+        quality_threshold=0.80,
+        budget_per_call_usd=0.001,
+        explore_n=0,
+    )
+    _pre_fill(router, "gpt-4o-mini", 5, avg_cost=0.0001, avg_quality=0.85)
+    _pre_fill(router, "gpt-4o", 5, avg_cost=0.05, avg_quality=0.95)
+
+    await router.call("prompt")
+
+    assert llm_cheap.call_count == 1
+    assert llm_expensive.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_budget_uses_over_budget_as_fallback_when_necessary():
+    """When all quality-meeting models exceed budget, the cheapest of them is used anyway."""
+    llm_a = MockLLM("gpt-4o-mini")
+    llm_b = MockLLM("gpt-4o")
+    router = CostQualityRouter(
+        candidates=[llm_a, llm_b],
+        quality_threshold=0.80,
+        budget_per_call_usd=0.000001,  # impossibly tight
+        explore_n=0,
+    )
+    _pre_fill(router, "gpt-4o-mini", 5, avg_cost=0.001, avg_quality=0.85)
+    _pre_fill(router, "gpt-4o", 5, avg_cost=0.05, avg_quality=0.95)
+
+    result = await router.call("prompt")
+
+    # Router should not crash; cheaper over-budget model is used as fallback
+    assert result == "ok"
+    assert llm_a.call_count + llm_b.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_budget_none_ignores_cost_constraint():
+    """When budget_per_call_usd is None, no budget filtering is applied."""
+    llm_a = MockLLM("gpt-4o-mini")
+    llm_b = MockLLM("gpt-4o")
+    router = CostQualityRouter(
+        candidates=[llm_a, llm_b],
+        quality_threshold=0.80,
+        budget_per_call_usd=None,
+        explore_n=0,
+    )
+    _pre_fill(router, "gpt-4o-mini", 5, avg_cost=0.0001, avg_quality=0.85)
+    _pre_fill(router, "gpt-4o", 5, avg_cost=999.0, avg_quality=0.95)
+
+    await router.call("prompt")
+
+    # Without budget constraint, cheapest within threshold wins
+    assert llm_a.call_count == 1
+    assert llm_b.call_count == 0
+
+
+# ------------------------------------------------------------------ #
+# 6. Pareto frontier correctness
+# ------------------------------------------------------------------ #
+
+
+def test_pareto_frontier_excludes_dominated_model():
+    """Model dominated by another (cheaper AND higher quality) is not on frontier."""
+    llm_a = MockLLM("model-a")  # dominated
+    llm_b = MockLLM("model-b")  # cheaper, higher quality than a
+    llm_c = MockLLM("model-c")  # high quality, but more expensive than b
+    router = CostQualityRouter(candidates=[llm_a, llm_b, llm_c], explore_n=100)
+
+    # model-a: cost=0.10, quality=0.70 — dominated by model-b (cheaper, higher quality)
+    _pre_fill(router, "model-a", 3, avg_cost=0.10, avg_quality=0.70)
+    _pre_fill(router, "model-b", 3, avg_cost=0.01, avg_quality=0.80)
+    _pre_fill(router, "model-c", 3, avg_cost=0.05, avg_quality=0.95)
+
+    result = router.stats()
+    frontier_models = {f["model"] for f in result["frontier"]}
+
+    assert "model-a" not in frontier_models
+    assert "model-b" in frontier_models
+    assert "model-c" in frontier_models
+
+
+def test_pareto_frontier_all_on_frontier():
+    """Models trading off cost vs quality are all on the Pareto frontier."""
+    llm_a = MockLLM("model-a")  # cheap, low quality
+    llm_b = MockLLM("model-b")  # expensive, high quality
+    router = CostQualityRouter(candidates=[llm_a, llm_b], explore_n=100)
+
+    _pre_fill(router, "model-a", 3, avg_cost=0.001, avg_quality=0.70)
+    _pre_fill(router, "model-b", 3, avg_cost=0.10, avg_quality=0.95)
+
+    result = router.stats()
+    frontier_models = {f["model"] for f in result["frontier"]}
+
+    assert "model-a" in frontier_models
+    assert "model-b" in frontier_models
+
+
+def test_pareto_frontier_empty_when_no_calls():
+    """Frontier is empty before any calls have been made."""
+    llm_a = MockLLM("model-a")
+    llm_b = MockLLM("model-b")
+    router = CostQualityRouter(candidates=[llm_a, llm_b], explore_n=10)
+
+    result = router.stats()
+
+    assert result["frontier"] == []
+
+
+def test_pareto_frontier_structure():
+    """stats() returns the documented schema."""
+    llm = MockLLM("model-a")
+    router = CostQualityRouter(candidates=[llm], explore_n=100)
+    _pre_fill(router, "model-a", 2, avg_cost=0.001, avg_quality=0.80)
+
+    result = router.stats()
+
+    assert "models" in result
+    assert "frontier" in result
+    assert "model-a" in result["models"]
+    m = result["models"]["model-a"]
+    assert set(m.keys()) == {"avg_cost", "avg_quality", "calls"}
+    assert isinstance(result["frontier"], list)
+    if result["frontier"]:
+        f = result["frontier"][0]
+        assert set(f.keys()) == {"model", "cost", "quality"}
+
+
+def test_pareto_frontier_single_model_always_on_frontier():
+    """A single model with calls is always on its own frontier."""
+    llm = MockLLM("model-a")
+    router = CostQualityRouter(candidates=[llm], explore_n=100)
+    _pre_fill(router, "model-a", 1, avg_cost=0.01, avg_quality=0.85)
+
+    result = router.stats()
+
+    assert len(result["frontier"]) == 1
+    assert result["frontier"][0]["model"] == "model-a"
+
+
+# ------------------------------------------------------------------ #
+# 7. No eval suite
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_no_eval_suite_router_still_works():
+    """Router operates normally without an eval suite; quality stays at 0.0."""
+    llm = MockLLM("model-a")
+    router = CostQualityRouter(candidates=[llm], eval_suite=None, explore_n=5)
+
+    result = await router.call("prompt")
+
+    assert result == "ok"
+    s = router._stats["model-a"]
+    assert s["calls"] == 1
+    assert s["avg_quality"] == 0.0
+    assert s["_quality_calls"] == 0
+
+
+@pytest.mark.asyncio
+async def test_no_eval_suite_does_not_update_quality():
+    """avg_quality remains 0.0 across multiple calls when no eval suite is set."""
+    llm = MockLLM("model-a")
+    router = CostQualityRouter(candidates=[llm], eval_suite=None, explore_n=10)
+
+    for _ in range(5):
+        await router.call("prompt")
+
+    assert router._stats["model-a"]["avg_quality"] == 0.0
+    assert router._stats["model-a"]["calls"] == 5
+
+
+# ------------------------------------------------------------------ #
+# 8. Eval suite integration
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_eval_suite_updates_avg_quality():
+    """Quality score from eval suite is reflected in model stats."""
+    llm = MockLLM("model-a")
+    router = CostQualityRouter(candidates=[llm], eval_suite="fake.suite", explore_n=10)
+
+    mock_result = MagicMock()
+    mock_result.mean_score = 0.85
+    mock_evaluator = MagicMock()
+    mock_evaluator.evaluate = AsyncMock(return_value=mock_result)
+    router._evaluator = mock_evaluator
+    router._evaluator_loaded = True
+
+    await router.call("prompt")
+
+    s = router._stats["model-a"]
+    assert s["avg_quality"] == pytest.approx(0.85)
+    assert s["_quality_calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_eval_suite_running_average():
+    """avg_quality is correctly maintained as a running average across calls."""
+    llm = MockLLM("model-a")
+    router = CostQualityRouter(candidates=[llm], eval_suite="fake.suite", explore_n=10)
+
+    scores = [0.80, 0.90, 1.00]
+    call_idx = 0
+
+    async def fake_evaluate(question, answer):
+        nonlocal call_idx
+        result = MagicMock()
+        result.mean_score = scores[call_idx]
+        call_idx += 1
+        return result
+
+    mock_evaluator = MagicMock()
+    mock_evaluator.evaluate = fake_evaluate
+    router._evaluator = mock_evaluator
+    router._evaluator_loaded = True
+
+    for _ in range(3):
+        await router.call("prompt")
+
+    expected = sum(scores) / len(scores)
+    assert router._stats["model-a"]["avg_quality"] == pytest.approx(expected)
+
+
+@pytest.mark.asyncio
+async def test_eval_suite_error_does_not_crash_router():
+    """If the eval suite raises an exception, quality is None and the call still succeeds."""
+    llm = MockLLM("model-a")
+    router = CostQualityRouter(candidates=[llm], eval_suite="bad.suite", explore_n=10)
+
+    mock_evaluator = MagicMock()
+    mock_evaluator.evaluate = AsyncMock(side_effect=RuntimeError("eval crashed"))
+    router._evaluator = mock_evaluator
+    router._evaluator_loaded = True
+
+    result = await router.call("prompt")
+
+    assert result == "ok"
+    assert router._stats["model-a"]["avg_quality"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_eval_suite_dict_score_format():
+    """Evaluator returning a dict with 'score' key is supported."""
+    llm = MockLLM("model-a")
+    router = CostQualityRouter(candidates=[llm], eval_suite="fake.suite", explore_n=10)
+
+    mock_evaluator = MagicMock()
+    mock_evaluator.evaluate = AsyncMock(return_value={"score": 0.75})
+    router._evaluator = mock_evaluator
+    router._evaluator_loaded = True
+
+    await router.call("prompt")
+
+    assert router._stats["model-a"]["avg_quality"] == pytest.approx(0.75)
+
+
+@pytest.mark.asyncio
+async def test_eval_suite_float_return_format():
+    """Evaluator returning a plain float is supported."""
+    llm = MockLLM("model-a")
+    router = CostQualityRouter(candidates=[llm], eval_suite="fake.suite", explore_n=10)
+
+    mock_evaluator = MagicMock()
+    mock_evaluator.evaluate = AsyncMock(return_value=0.92)
+    router._evaluator = mock_evaluator
+    router._evaluator_loaded = True
+
+    await router.call("prompt")
+
+    assert router._stats["model-a"]["avg_quality"] == pytest.approx(0.92)
+
+
+# ------------------------------------------------------------------ #
+# 9. Cost tracking
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_cost_tracked_from_cost_table():
+    """Cost is calculated from COST_TABLE when model is known."""
+    from synapsekit.observability.tracer import COST_TABLE
+
+    model = "gpt-4o-mini"
+    pricing = COST_TABLE[model]
+    in_tokens, out_tokens = 1000, 500
+    expected_cost = in_tokens * pricing["input"] + out_tokens * pricing["output"]
+
+    llm = MockLLM(model, input_tokens=in_tokens, output_tokens=out_tokens)
+    router = CostQualityRouter(candidates=[llm], explore_n=5)
+
+    await router.call("prompt")
+
+    assert router._stats[model]["avg_cost"] == pytest.approx(expected_cost)
+
+
+@pytest.mark.asyncio
+async def test_cost_zero_for_unknown_model():
+    """Models not in COST_TABLE default to 0.0 cost."""
+    llm = MockLLM("unknown-model-xyz", input_tokens=500, output_tokens=200)
+    router = CostQualityRouter(candidates=[llm], explore_n=5)
+
+    await router.call("prompt")
+
+    assert router._stats["unknown-model-xyz"]["avg_cost"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_cost_running_average():
+    """avg_cost is a running mean across multiple calls."""
+    from synapsekit.observability.tracer import COST_TABLE
+
+    model = "gpt-4o-mini"
+    pricing = COST_TABLE[model]
+    in_tok, out_tok = 100, 50
+    per_call = in_tok * pricing["input"] + out_tok * pricing["output"]
+
+    llm = MockLLM(model, input_tokens=in_tok, output_tokens=out_tok)
+    router = CostQualityRouter(candidates=[llm], explore_n=10)
+
+    for _ in range(3):
+        await router.call("prompt")
+
+    assert router._stats[model]["avg_cost"] == pytest.approx(per_call)
+
+
+# ------------------------------------------------------------------ #
+# 10. Edge cases
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_single_candidate_always_used():
+    """With one candidate the router always uses it."""
+    llm = MockLLM("model-a")
+    router = CostQualityRouter(candidates=[llm], explore_n=5)
+
+    for _ in range(10):
+        await router.call("prompt")
+
+    assert llm.call_count == 10
+
+
+@pytest.mark.asyncio
+async def test_explore_n_zero_immediately_exploits():
+    """explore_n=0 means the very first call is in exploit mode."""
+    llm_cheap = MockLLM("gpt-4o-mini")
+    llm_expensive = MockLLM("gpt-4o")
+    router = CostQualityRouter(
+        candidates=[llm_cheap, llm_expensive],
+        quality_threshold=0.0,
+        explore_n=0,
+    )
+    _pre_fill(router, "gpt-4o-mini", 5, avg_cost=0.0001, avg_quality=0.80)
+    _pre_fill(router, "gpt-4o", 5, avg_cost=0.05, avg_quality=0.90)
+
+    await router.call("prompt")
+
+    assert router._mode == "exploit"
+    assert llm_cheap.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_response_none_handled_gracefully():
+    """Router coerces None response to empty string without crashing."""
+
+    class NoneResponseLLM(BaseLLM):
+        async def generate(self, prompt: str, **kw: Any) -> str:
+            return None  # type: ignore[return-value]
+
+        async def stream(self, prompt: str, **kw: Any) -> AsyncGenerator[str, None]:
+            yield ""
+
+    llm = NoneResponseLLM(LLMConfig(model="none-model", api_key="", provider="openai"))
+    router = CostQualityRouter(candidates=[llm], explore_n=5)
+
+    result = await router.call("prompt")
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_stream_yields_tokens_and_updates_stats():
+    """stream() yields all tokens and updates stats after completion."""
+    llm = MockLLM("model-a")
+    router = CostQualityRouter(candidates=[llm], explore_n=5)
+
+    collected = []
+    async for token in router.stream("prompt"):
+        collected.append(token)
+
+    assert collected == ["ok"]
+    assert router._stats["model-a"]["calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_call_method_delegates_to_generate():
+    """call() is an alias for generate()."""
+    llm = MockLLM("model-a")
+    router = CostQualityRouter(candidates=[llm], explore_n=5)
+
+    r1 = await router.call("prompt")
+    r2 = await router.generate("prompt")
+
+    assert r1 == r2 == "ok"
+    assert llm.call_count == 2
+
+
+# ------------------------------------------------------------------ #
+# 11. Package import guard
+# ------------------------------------------------------------------ #
+
+
+def test_cost_quality_router_import_from_package():
+    from synapsekit.llm import CostQualityRouter
+
+    assert CostQualityRouter is not None

--- a/tests/llm/test_cost_quality_router.py
+++ b/tests/llm/test_cost_quality_router.py
@@ -11,7 +11,6 @@ import pytest
 from synapsekit.llm.base import BaseLLM, LLMConfig
 from synapsekit.llm.cost_quality_router import CostQualityRouter
 
-
 # ------------------------------------------------------------------ #
 # Helpers
 # ------------------------------------------------------------------ #
@@ -52,7 +51,9 @@ class MockLLM(BaseLLM):
         yield self._mock_response
 
 
-def _pre_fill(router: CostQualityRouter, model: str, calls: int, avg_cost: float, avg_quality: float) -> None:
+def _pre_fill(
+    router: CostQualityRouter, model: str, calls: int, avg_cost: float, avg_quality: float
+) -> None:
     """Manually populate router stats to simulate completed exploration."""
     router._stats[model] = {
         "calls": calls,

--- a/uv.lock
+++ b/uv.lock
@@ -871,6 +871,43 @@ wheels = [
 ]
 
 [[package]]
+name = "cassandra-driver"
+version = "3.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "geomet" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/26/8806d0949422b560029a040e7a628d92addd612726468c3fb546354a43a4/cassandra_driver-3.30.0.tar.gz", hash = "sha256:7e4cfd6ec3023576ed0ffa34882d9778e4bacfd918048ae9139ccdd00628ed85", size = 4242039, upload-time = "2026-04-16T05:04:59.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/01/b13641332953702238b5cdf80340a117b384070fc1cc582030d7dffbde14/cassandra_driver-3.30.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2637644eac9274e46b0c2a7f729158bdf8582b6842dc48e18297211dd3ee1fec", size = 7612055, upload-time = "2026-04-16T05:01:56.997Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/52/1361729ce8e5ded444b11e00eee19df09e040d46236c7df7cded51913c7a/cassandra_driver-3.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6a5c8982f2b9eb4e789fc12cdd930b1e1511b6d046dde31d0703f855745556a3", size = 7367328, upload-time = "2026-04-16T05:02:06.188Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c6/b4d5b01e10570dfb3394ebf7af40acbe435caaf246553992a459d42caca6/cassandra_driver-3.30.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a0679ebcfdcecb3763c690b5bc6a517e0c0803f7bc88e0a6c793e5e421b558a", size = 7587311, upload-time = "2026-04-16T05:02:16.909Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/83/d5868bc1ea2ffd392dea683589c4dd64363f619ba2d36de802f9ed38775f/cassandra_driver-3.30.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e12dfcd3f0074c16f4bfe650242edb406b935864373ae86160e09e3f5e437e84", size = 7837314, upload-time = "2026-04-16T05:02:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e9/ac4f81d96cc9df0ba457ca5f447b405f730de8f343422662f4719ae23619/cassandra_driver-3.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1d64cbdce764c33e284d339b9a749736d68971edf8b537888f2d13c4b0d1313f", size = 6955273, upload-time = "2026-04-16T05:02:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8b/f75fe284ee184b54ba55b2cd69d2ba156e6a8fc88b322e28e2ecbaa6065a/cassandra_driver-3.30.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5c6cbb396ad6fe456efc799d3b8b6bda360ffc06552c5be2ce1a88ac381a305c", size = 7415263, upload-time = "2026-04-16T05:02:38.441Z" },
+    { url = "https://files.pythonhosted.org/packages/92/f6/67a0e6f937e85131c5e528d3c74e63b1fb041f0d6351eb7b7d5a403ae149/cassandra_driver-3.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8d5e3575ec01d8c043b56ff25de6f61ff4c9ed5cb3ea4c3d9df98def71ba710c", size = 7252160, upload-time = "2026-04-16T05:02:45.14Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/48691b5bed702bbe4db3acb00c1a3cc585e18bd70dadb12a5cf0697c6159/cassandra_driver-3.30.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff2e9fbdc1be54c1d041ea3f7d09812442f334be14bb5ad7aede175544765d25", size = 7586952, upload-time = "2026-04-16T05:02:52.99Z" },
+    { url = "https://files.pythonhosted.org/packages/61/56/74b01c48acf401de3f38054bdfcbb493770e13dd2ddbb4735783045f1e3b/cassandra_driver-3.30.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:385134eba72f048707cd800de0a61cf3c23246113edffe9bc6bc2eb86282d26b", size = 7832995, upload-time = "2026-04-16T05:03:01.344Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/da/25f3542b1b7221c12e323eae591015e2e816fd543e6538cfc29d2c6ff059/cassandra_driver-3.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:0c28a8e84917acebecbaed39844047c2f135739c3627dd7b9f8541af33e11df3", size = 6965120, upload-time = "2026-04-16T05:03:08.538Z" },
+    { url = "https://files.pythonhosted.org/packages/89/46/8fc42a2c836ec525f9313e6bdffbada2911d8501ff008e5d22ebdbaa4895/cassandra_driver-3.30.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:212af4d8ff934c30538f4bdf7da61f14dc9a30349f6cac2161c8125e56fad928", size = 7751805, upload-time = "2026-04-16T05:03:15.913Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e3/8c3c02380334697c629de2db560d67e44461401175887e7a36374e30bcad/cassandra_driver-3.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:61d7eeb17d8f76d5b4a9b1239145250f2a9f7bf949c30e2cc36196b5a0523ce1", size = 7576768, upload-time = "2026-04-16T05:03:23.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/5d/ead64522236077f4a63974ed4f193f26e35f85132751154f9aa839680dc5/cassandra_driver-3.30.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83a9148d408a3dbb48ea1802d643d60fa53cd69dc7b9a244511ecf5b917e4f53", size = 7330139, upload-time = "2026-04-16T05:03:30.567Z" },
+    { url = "https://files.pythonhosted.org/packages/13/fe/bbed363953eee1774842806527e377a79f0cbfb52887b6379c856ff8fedf/cassandra_driver-3.30.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f4225082a11d9529416c223553ab38a29c4e65da6646b40159c554480dc002c", size = 7581659, upload-time = "2026-04-16T05:03:37.811Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/60/c776d0d9d6b92bd2f15720db51313af8a194272f725d3fda8827258b728b/cassandra_driver-3.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:6d449f49ce866ac20a1c3d80b1f9245ecdfd1e67b843dccd3d6eccdfe519c02e", size = 6795314, upload-time = "2026-04-16T05:03:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e8/32c6063738ce418403750575a1a1f73609c313766849cb930699d607fc8d/cassandra_driver-3.30.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d2f9e00127f70dff42d4ef932df8a6b81170c2861d4e75c8b13f4b4816b4450c", size = 7738805, upload-time = "2026-04-16T05:03:51.875Z" },
+    { url = "https://files.pythonhosted.org/packages/48/2c/b88c3747c63eeb36b1ebb46a50734b2490eb05f87944ec907563f861bb76/cassandra_driver-3.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8c4acd28791854c23ca68be50a7a750c9413ba80fec0ca5c27c2be05f6f3fe0a", size = 7568531, upload-time = "2026-04-16T05:03:59.122Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c0/f44f3fdb7c40cddad7b58cc8102387ae8ee4da793ed5899d4a231989fbea/cassandra_driver-3.30.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:289e86c81be2543cb9055600c0819850db921e6e138a84e5c88ec160662c7207", size = 7324591, upload-time = "2026-04-16T05:04:06.501Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/54466eff67b69653c83d5bcf3972e42a52b2e881f9a3ee7ca8b996943caf/cassandra_driver-3.30.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d73c0429813045ba86b92fc033fbcfd495aa10e9d4a40fe30b6e9dfe8b5d3ab4", size = 7575795, upload-time = "2026-04-16T05:04:13.645Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/0d/ff571cb27e56d8112bc3f4a5e807da54c8b875264e038e791e06ddcc1817/cassandra_driver-3.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:17fb53587c9fc6a27b5c4a89b4f3d9169be43fc572d6f3f67494aa74708be936", size = 6798091, upload-time = "2026-04-16T05:04:20.145Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c0/a8b52c18959d96d313450cdfa97f66d4b67327814671df65a7a2e7fca64f/cassandra_driver-3.30.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c64e20bf46b49f8ef64569208d4a395b0928c27d5960559922a2d13471924d0d", size = 7736773, upload-time = "2026-04-16T05:04:27.315Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/a7aae33ef0a74616210b2cff18a5efba3db99f1c5bb7e2a5a31aeabb8558/cassandra_driver-3.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:923a6e1c3fa5f98f846a028b1a7207ec9e7d8cfa54ea47a507d41122efa2f54f", size = 7562347, upload-time = "2026-04-16T05:04:34.5Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/bed3930f4a726b3783fea179a88cd16b95d968ec8fc1af9d5193d26cfc39/cassandra_driver-3.30.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1b4aa6c7706dec839134adb6a2094d90c5f6f35efa08028ed6aae6e67c8643e", size = 7382080, upload-time = "2026-04-16T05:04:41.48Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/9b/8cd9c03474bac374b0cda4124c7c4d2f6b2b5f7942b028f82222daf54fcb/cassandra_driver-3.30.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:137498e2a9b6f578d1902e1af8a988e50b8fe134c76a176f1b8a774e906bc66c", size = 7590242, upload-time = "2026-04-16T05:04:48.477Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/29/aed0ee68f724b9fecc9cebfcae44f331b5dd2e010415f4be2d6e64d77226/cassandra_driver-3.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:136b46437b9902673264e101cdaab309d3e40607bff34430bda86b785badc6e4", size = 6787116, upload-time = "2026-04-16T05:04:55.349Z" },
+]
+
+[[package]]
 name = "catalogue"
 version = "2.0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -2288,6 +2325,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a7/b2/4140c69c6a66432916b26158687e821ba631a4c9273c474343badf84d3ba/future-1.0.0.tar.gz", hash = "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05", size = 1228490, upload-time = "2024-02-21T11:52:38.461Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/71/ae30dadffc90b9006d77af76b393cb9dfbfc9629f339fc1574a1c52e6806/future-1.0.0-py3-none-any.whl", hash = "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216", size = 491326, upload-time = "2024-02-21T11:52:35.956Z" },
+]
+
+[[package]]
+name = "geomet"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/8c/dde022aa6747b114f6b14a7392871275dea8867e2bd26cddb80cc6d66620/geomet-1.1.0.tar.gz", hash = "sha256:51e92231a0ef6aaa63ac20c443377ba78a303fd2ecd179dc3567de79f3c11605", size = 28732, upload-time = "2023-11-14T15:43:36.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/90/3bc780df088d439714af8295196a4332a26559ae66fd99865e36f92efa9e/geomet-1.1.0-py3-none-any.whl", hash = "sha256:4372fe4e286a34acc6f2e9308284850bd8c4aa5bc12065e2abbd4995900db12f", size = 31522, upload-time = "2023-11-14T15:43:35.305Z" },
 ]
 
 [[package]]
@@ -11515,7 +11564,7 @@ browser = [
     { name = "playwright" },
 ]
 cassandra = [
-    { name = "astrapy" },
+    { name = "cassandra-driver" },
 ]
 chroma = [
     { name = "chromadb" },
@@ -11538,6 +11587,7 @@ confluence = [
 ]
 cron = [
     { name = "croniter" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 discord = [
     { name = "discord-py" },
@@ -11797,6 +11847,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "tzdata" },
 ]
 
 [package.metadata]
@@ -11812,7 +11863,6 @@ requires-dist = [
     { name = "arxiv", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "arxiv", marker = "extra == 'arxiv'", specifier = ">=2.0" },
     { name = "astrapy", marker = "extra == 'all'", specifier = ">=1.0" },
-    { name = "astrapy", marker = "extra == 'cassandra'", specifier = ">=1.0" },
     { name = "asyncpg", marker = "extra == 'all'", specifier = ">=0.29" },
     { name = "asyncpg", marker = "extra == 'postgres'", specifier = ">=0.29" },
     { name = "atlassian-python-api", marker = "extra == 'all'", specifier = ">=3.0" },
@@ -11828,6 +11878,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34" },
     { name = "boto3", marker = "extra == 'dynamodb'", specifier = ">=1.34" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.34" },
+    { name = "cassandra-driver", marker = "extra == 'cassandra'", specifier = ">=3.28" },
     { name = "chromadb", marker = "extra == 'all'", specifier = ">=0.5" },
     { name = "chromadb", marker = "extra == 'chroma'", specifier = ">=0.5" },
     { name = "clickhouse-connect", marker = "extra == 'all'", specifier = ">=0.7" },
@@ -11971,6 +12022,7 @@ requires-dist = [
     { name = "supabase", marker = "extra == 'supabase'", specifier = ">=2.0" },
     { name = "tavily-python", marker = "extra == 'all'", specifier = ">=0.3" },
     { name = "tavily-python", marker = "extra == 'tavily'", specifier = ">=0.3" },
+    { name = "tzdata", marker = "sys_platform == 'win32' and extra == 'cron'", specifier = ">=2024.1" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'all'", specifier = ">=0.29" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'graph-ui'", specifier = ">=0.29" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'serve'", specifier = ">=0.29" },
@@ -11985,7 +12037,7 @@ requires-dist = [
     { name = "youtube-transcript-api", marker = "extra == 'all'", specifier = ">=0.6" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube-transcript'", specifier = ">=0.6" },
 ]
-provides-extras = ["openai", "anthropic", "semantic", "colbert", "pdf", "wikipedia", "arxiv", "html", "web", "chroma", "faiss", "qdrant", "pinecone", "weaviate", "milvus", "lancedb", "sqlite-vec", "cassandra", "clickhouse", "duckdb-vector", "marqo", "opensearch", "vespa", "replicate", "ollama", "lmstudio", "vllm", "ai21", "cohere", "mistral", "gemini", "bedrock", "gcal-tool", "aws-lambda", "rss", "groq", "audio", "video", "voice", "voice-local", "voice-stream", "cron", "excel", "pptx", "docx", "yaml", "teams", "http", "search", "huggingface", "google-search", "tavily", "youtube", "mcp", "redis", "memcached", "vertex", "cloudflare", "aleph-alpha", "llamacpp", "gpt4all", "ernie", "minimax", "serve", "graph-ui", "postgres", "pgvector", "wolfram", "dynamodb", "discord", "gcs", "bigquery", "gdrive", "git", "gsheets", "jira", "hubspot", "sql", "snowflake", "mongodb", "mongodb-vector", "salesforce", "azure", "s3", "onedrive", "slack", "supabase", "notion", "confluence", "dropbox", "rtf", "epub", "parquet", "elasticsearch", "browser", "youtube-transcript", "airtable", "all"]
+provides-extras = ["openai", "anthropic", "semantic", "colbert", "pdf", "wikipedia", "arxiv", "html", "web", "chroma", "faiss", "qdrant", "pinecone", "weaviate", "milvus", "lancedb", "sqlite-vec", "cassandra", "clickhouse", "duckdb-vector", "marqo", "opensearch", "vespa", "replicate", "ollama", "lmstudio", "vllm", "ai21", "cohere", "mistral", "gemini", "bedrock", "gcal-tool", "aws-lambda", "rss", "groq", "audio", "video", "voice", "voice-local", "voice-stream", "cron", "excel", "pptx", "docx", "yaml", "teams", "http", "search", "huggingface", "google-search", "tavily", "youtube", "mcp", "redis", "memcached", "vertex", "cloudflare", "aleph-alpha", "llamacpp", "gpt4all", "ernie", "minimax", "serve", "graph-ui", "observe", "postgres", "pgvector", "wolfram", "dynamodb", "discord", "gcs", "bigquery", "gdrive", "git", "gsheets", "jira", "hubspot", "sql", "snowflake", "mongodb", "mongodb-vector", "salesforce", "azure", "s3", "onedrive", "slack", "supabase", "notion", "confluence", "dropbox", "rtf", "epub", "parquet", "elasticsearch", "browser", "youtube-transcript", "airtable", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -12003,6 +12055,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "ruff", specifier = ">=0.9" },
+    { name = "tzdata", specifier = ">=2024.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds `CostQualityRouter` — a learning-based LLM router that round-robins across candidates during exploration, then routes to the cheapest model meeting a learned quality threshold during exploitation. Supports budget-per-call constraints, external eval-suite integration, and exposes a Pareto frontier over the candidate pool.

Closes #589 

## Type of change

- [x] New feature

## Changes

- `src/synapsekit/llm/cost_quality_router.py` — new `CostQualityRouter` class (explore/exploit routing, cost tracking, quality tracking, Pareto frontier, eval-suite integration via string import path)
- `src/synapsekit/llm/__init__.py` — eager import + `__all__` entry so `from synapsekit.llm import CostQualityRouter` works
- `tests/llm/test_cost_quality_router.py` — 37 tests covering exploration,exploitation, quality threshold, fallback, budget, Pareto frontier, eval suite formats, cost tracking, edge cases, and package import guard

## Testing

- [x] All existing tests pass (`uv run pytest tests/ -q`)
- [x] New tests added for new behaviour
- [x] No API keys or secrets in the code