### PR TITLE
Discord: live GitHub stats in #stats channel

### DIFF
--- a/.github/workflows/discord-stats.yml
+++ b/.github/workflows/discord-stats.yml
@@ -1,0 +1,97 @@
+name: Update Discord stats
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update #stats pinned message
+        env:
+          DISCORD_STATS_WEBHOOK: ${{ secrets.DISCORD_STATS_WEBHOOK }}
+          DISCORD_STATS_MESSAGE_ID: ${{ secrets.DISCORD_STATS_MESSAGE_ID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DISCORD_STATS_WEBHOOK:-}" ] || [ -z "${DISCORD_STATS_MESSAGE_ID:-}" ]; then
+            echo "Missing DISCORD_STATS_WEBHOOK or DISCORD_STATS_MESSAGE_ID; skipping."
+            exit 0
+          fi
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+          import datetime
+          from urllib.error import HTTPError
+
+          WEBHOOK = os.environ["DISCORD_STATS_WEBHOOK"]
+          MESSAGE_ID = os.environ["DISCORD_STATS_MESSAGE_ID"]
+          GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
+
+          def get_json(url, headers=None):
+              req = urllib.request.Request(url, headers=headers or {})
+              try:
+                  with urllib.request.urlopen(req) as r:
+                      return json.load(r)
+              except HTTPError as e:
+                  if headers and "Authorization" in headers and e.code in (401, 403):
+                      headers = {k: v for k, v in headers.items() if k != "Authorization"}
+                      req2 = urllib.request.Request(url, headers=headers)
+                      with urllib.request.urlopen(req2) as r:
+                          return json.load(r)
+                  raise
+
+          def fmt(v):
+              return f"{v:,}" if isinstance(v, int) else "N/A"
+
+          gh_headers = {
+              "Accept": "application/vnd.github+json",
+              "User-Agent": "SynapseKit-Discord-Stats",
+          }
+          if GITHUB_TOKEN:
+              gh_headers["Authorization"] = f"Bearer {GITHUB_TOKEN}"
+
+          repo = get_json("https://api.github.com/repos/SynapseKit/SynapseKit", gh_headers)
+          stars = repo.get("stargazers_count")
+          forks = repo.get("forks_count")
+
+          issues = get_json(
+              "https://api.github.com/search/issues?q=repo:SynapseKit/SynapseKit+type:issue+state:open",
+              gh_headers,
+          ).get("total_count")
+
+          pypi_stats = get_json("https://pypistats.org/api/packages/synapsekit/recent")
+          downloads = pypi_stats.get("data", {}).get("last_month")
+
+          pypi_info = get_json("https://pypi.org/pypi/synapsekit/json")
+          version = pypi_info.get("info", {}).get("version", "N/A")
+
+          timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+
+          message = (
+              "📦 synapsekit on PyPI\n"
+              f"⭐ Stars: {fmt(stars)}      🍴 Forks: {fmt(forks)}\n"
+              f"📥 Downloads (30d): {fmt(downloads)}\n"
+              f"🐛 Open issues: {fmt(issues)}\n"
+              f"🏷 Latest version: v{version}\n\n"
+              f"Last updated: {timestamp}"
+          )
+
+          payload = json.dumps({"content": message}).encode("utf-8")
+          url = f"{WEBHOOK}/messages/{MESSAGE_ID}"
+          req = urllib.request.Request(
+              url,
+              data=payload,
+              method="PATCH",
+              headers={"Content-Type": "application/json"},
+          )
+          with urllib.request.urlopen(req) as r:
+              print("Discord PATCH status:", r.status)
+          PY


### PR DESCRIPTION
## Summary
- Add scheduled workflow to update a pinned Discord #stats message with GitHub stars/forks/issues and PyPI downloads/version.
- Uses GitHub + PyPI APIs and PATCHes a Discord webhook message.

Closes #397

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / internal improvement
- [ ] Dependency / tooling update

## Changes
- Add `.github/workflows/discord-stats.yml` with 6-hour cron + workflow_dispatch
- Fetch GitHub repo stats, open issue count, PyPI downloads, and latest version
- Patch the pinned Discord webhook message with a formatted stats block

## Testing
- [ ] All existing tests pass (`uv run pytest tests/ -q`)
- [ ] New tests added for new behaviour
- [x] No API keys or secrets in the code

## Documentation
- [ ] Docstrings updated (if public API changed)
- [ ] synapsekit-docs updated (if new feature)
- [ ] CHANGELOG.md updated

## Notes for reviewer
- Requires repo secrets: `DISCORD_STATS_WEBHOOK`, `DISCORD_STATS_MESSAGE_ID`
