### PR TITLE
chore(tests): sync version strings to 1.7.0

### DIFF
--- a/tests/test_v060_features.py
+++ b/tests/test_v060_features.py
@@ -516,4 +516,4 @@ def test_tool_schemas():
 def test_version():
     import synapsekit
 
-    assert synapsekit.__version__ == "1.6.0"
+    assert synapsekit.__version__ == "1.7.0"

--- a/tests/test_v065_features.py
+++ b/tests/test_v065_features.py
@@ -15,7 +15,7 @@ import pytest
 def test_version():
     import synapsekit
 
-    assert synapsekit.__version__ == "1.6.0"
+    assert synapsekit.__version__ == "1.7.0"
 
 
 # ------------------------------------------------------------------ #

--- a/tests/test_v066_features.py
+++ b/tests/test_v066_features.py
@@ -14,7 +14,7 @@ import pytest
 def test_version():
     import synapsekit
 
-    assert synapsekit.__version__ == "1.6.0"
+    assert synapsekit.__version__ == "1.7.0"
 
 
 # ------------------------------------------------------------------ #

--- a/tests/test_v068_features.py
+++ b/tests/test_v068_features.py
@@ -18,7 +18,7 @@ import pytest
 def test_version():
     import synapsekit
 
-    assert synapsekit.__version__ == "1.6.0"
+    assert synapsekit.__version__ == "1.7.0"
 
 
 # ------------------------------------------------------------------ #

--- a/tests/test_v069_features.py
+++ b/tests/test_v069_features.py
@@ -15,7 +15,7 @@ import pytest
 def test_version():
     import synapsekit
 
-    assert synapsekit.__version__ == "1.6.0"
+    assert synapsekit.__version__ == "1.7.0"
 
 
 # ================================================================== #

--- a/tests/test_v070_features.py
+++ b/tests/test_v070_features.py
@@ -35,7 +35,7 @@ class MockLLM:
 def test_version():
     import synapsekit
 
-    assert synapsekit.__version__ == "1.6.0"
+    assert synapsekit.__version__ == "1.7.0"
 
 
 # ------------------------------------------------------------------ #

--- a/tests/test_v120_features.py
+++ b/tests/test_v120_features.py
@@ -836,7 +836,7 @@ class TestCLIMain:
 
         main(["--version"])
         output = capsys.readouterr().out
-        assert "1.6.0" in output
+        assert "1.7.0" in output
 
     def test_no_command(self):
         from synapsekit.cli.main import main
@@ -894,4 +894,4 @@ class TestTopLevelImports:
     def test_version_bumped(self):
         import synapsekit
 
-        assert synapsekit.__version__ == "1.6.0"
+        assert synapsekit.__version__ == "1.7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -11439,7 +11439,7 @@ wheels = [
 
 [[package]]
 name = "synapsekit"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -11583,6 +11583,7 @@ confluence = [
 ]
 cron = [
     { name = "croniter" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 discord = [
     { name = "discord-py" },
@@ -11853,6 +11854,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "tzdata" },
 ]
 
 [package.metadata]
@@ -12032,6 +12034,7 @@ requires-dist = [
     { name = "tavily-python", marker = "extra == 'tavily'", specifier = ">=0.3" },
     { name = "tiktoken", marker = "extra == 'tiktoken'", specifier = ">=0.12" },
     { name = "transformers", marker = "extra == 'transformers'", specifier = ">=4.0" },
+    { name = "tzdata", marker = "sys_platform == 'win32' and extra == 'cron'", specifier = ">=2024.1" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'all'", specifier = ">=0.29" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'graph-ui'", specifier = ">=0.29" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'serve'", specifier = ">=0.29" },
@@ -12066,6 +12069,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "ruff", specifier = ">=0.9" },
+    { name = "tzdata", specifier = ">=2024.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes stale version assertions in older feature test files that were still checking for `1.6.0` after the package was bumped to `1.7.0` in the previous release.

Closes #622

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / internal improvement
- [ ] Dependency / tooling update

## Changes
- Updated `__version__` assertions from `"1.6.0"` to `"1.7.0"` in `test_v060_features.py`, `test_v065_features.py`, `test_v066_features.py`, `test_v068_features.py`,`test_v069_features.py`, and `test_v070_features.py` 
- Updated `test_version_flag` and `test_version_bumped` in `test_v120_features.py` to expect `"1.7.0"`
- The uv.lock changes also resolve tzdata into the lock it was already declared in pyproject.toml (cron extra + dev deps) but the lock hadn't been updated to reflect it.

## Testing
- [x] All existing tests pass (`uv run pytest tests/ -q`)
- [ ] New tests added for new behaviour
- [x] No API keys or secrets in the code