### PR TITLE
feat(retrieval): complete FederatedRetriever implementation

### DIFF
--- a/src/synapsekit/retrieval/federated.py
+++ b/src/synapsekit/retrieval/federated.py
@@ -124,19 +124,10 @@ class FederatedRetriever:
                 top_k=top_k,
                 metadata_filter=metadata_filter,
             )
-            return [
-                _Result(
-                    text=r.get("text", ""),
-                    score=r.get("score"),
-                    metadata=r.get("metadata") or {},
-                    source=name,
-                )
-                for r in raw
-                if r.get("text")
-            ]
+            return self._coerce_results(raw, source=name)
 
         raw = await retriever.retrieve(query, top_k=top_k, metadata_filter=metadata_filter)
-        return [_Result(text=t, score=None, metadata={}, source=name) for t in raw]
+        return self._coerce_results(raw, source=name)
 
     async def _fetch_remote(
         self,
@@ -169,20 +160,7 @@ class FederatedRetriever:
             data = resp.json()
 
         results = data.get("results", data)
-        out: list[_Result] = []
-        for r in results:
-            text = r.get("text") if isinstance(r, dict) else None
-            if not text:
-                continue
-            out.append(
-                _Result(
-                    text=text,
-                    score=r.get("score") if isinstance(r, dict) else None,
-                    metadata=r.get("metadata") if isinstance(r, dict) else {},
-                    source=name,
-                )
-            )
-        return out
+        return self._coerce_results(results, source=name)
 
     def _fuse(self, results: list[list[_Result]], top_k: int) -> list[_Result]:
         if self._fusion == "interleave":
@@ -272,3 +250,53 @@ class FederatedRetriever:
         if (candidate.score or 0.0) > (current.score or 0.0):
             return candidate
         return current
+
+    def _coerce_results(self, raw: list[Any], source: str | None) -> list[_Result]:
+        results: list[_Result] = []
+        for item in raw:
+            coerced = self._coerce_result(item, source=source)
+            if coerced is not None:
+                results.append(coerced)
+        return results
+
+    def _coerce_result(self, item: Any, source: str | None) -> _Result | None:
+        text: str | None = None
+        score: float | None = None
+        metadata: dict | None = {}
+
+        if isinstance(item, str):
+            text = item
+        elif isinstance(item, dict):
+            text = item.get("text")
+            raw_score = item.get("score")
+            if isinstance(raw_score, (int, float)):
+                score = float(raw_score)
+            metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+
+            document = item.get("document")
+            if (not text) and hasattr(document, "text"):
+                text = getattr(document, "text", None)
+                doc_metadata = getattr(document, "metadata", None)
+                if not metadata and isinstance(doc_metadata, dict):
+                    metadata = doc_metadata
+        elif hasattr(item, "text"):
+            text = getattr(item, "text", None)
+            raw_score = getattr(item, "score", None)
+            if isinstance(raw_score, (int, float)):
+                score = float(raw_score)
+            item_metadata = getattr(item, "metadata", None)
+            metadata = item_metadata if isinstance(item_metadata, dict) else {}
+        elif isinstance(item, tuple) and item and isinstance(item[0], str):
+            text = item[0]
+            if len(item) > 1 and isinstance(item[1], (int, float)):
+                score = float(item[1])
+
+        if not isinstance(text, str) or not text:
+            return None
+
+        return _Result(
+            text=text,
+            score=score,
+            metadata=metadata or {},
+            source=source,
+        )

--- a/src/synapsekit/retrieval/federated.py
+++ b/src/synapsekit/retrieval/federated.py
@@ -262,7 +262,7 @@ class FederatedRetriever:
     def _coerce_result(self, item: Any, source: str | None) -> _Result | None:
         text: str | None = None
         score: float | None = None
-        metadata: dict | None = {}
+        metadata: dict = {}
 
         if isinstance(item, str):
             text = item
@@ -271,7 +271,8 @@ class FederatedRetriever:
             raw_score = item.get("score")
             if isinstance(raw_score, (int, float)):
                 score = float(raw_score)
-            metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+            raw_meta = item.get("metadata")
+            metadata = raw_meta if isinstance(raw_meta, dict) else {}
 
             document = item.get("document")
             if (not text) and hasattr(document, "text"):

--- a/tests/retrieval/test_federated.py
+++ b/tests/retrieval/test_federated.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 
 import pytest
 
@@ -21,6 +22,14 @@ class _MockRetriever:
             {"text": t, "score": s, "metadata": {"id": i}}
             for i, (t, s) in enumerate(self._results[:top_k])
         ]
+
+
+class _DocumentOnlyRetriever:
+    def __init__(self, docs):
+        self._docs = docs
+
+    async def retrieve(self, query, top_k=5, metadata_filter=None):
+        return self._docs[:top_k]
 
 
 @pytest.mark.asyncio
@@ -63,6 +72,43 @@ async def test_federated_interleave():
 
 
 @pytest.mark.asyncio
+async def test_federated_score_fusion():
+    a = _MockRetriever([("shared", 10.0), ("local a", 5.0)])
+    b = _MockRetriever([("shared", 0.8), ("local b", 0.2)])
+
+    retriever = FederatedRetriever(
+        sources=[
+            {"name": "a", "retriever": a},
+            {"name": "b", "retriever": b},
+        ],
+        fusion="score",
+        top_k=3,
+    )
+
+    results = await retriever.retrieve("query")
+    assert results == ["shared", "local a", "local b"]
+
+
+@pytest.mark.asyncio
+async def test_federated_accepts_document_only_retrievers():
+    from synapsekit.loaders.base import Document
+
+    docs = [
+        Document(text="hr policy", metadata={"dept": "hr"}),
+        Document(text="eng policy", metadata={"dept": "eng"}),
+    ]
+    retriever = FederatedRetriever(
+        sources=[{"name": "docs", "retriever": _DocumentOnlyRetriever(docs)}],
+        fusion="rrf",
+        top_k=2,
+    )
+
+    results = await retriever.retrieve_with_scores("query")
+    assert [r["text"] for r in results] == ["hr policy", "eng policy"]
+    assert results[0]["metadata"]["dept"] == "hr"
+
+
+@pytest.mark.asyncio
 async def test_federated_timeout_returns_partial():
     class _SlowRetriever:
         async def retrieve_with_scores(self, query, top_k=5, metadata_filter=None):
@@ -82,3 +128,66 @@ async def test_federated_timeout_returns_partial():
 
     results = await retriever.retrieve("query")
     assert results == ["doc a"]
+
+
+@pytest.mark.asyncio
+async def test_federated_remote_source_standard_protocol(monkeypatch):
+    httpx = pytest.importorskip("httpx")
+
+    captured: dict[str, object] = {}
+
+    def handler(request):
+        captured["authorization"] = request.headers.get("Authorization")
+        captured["body"] = json.loads(request.content.decode())
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "text": "remote policy",
+                        "score": 0.85,
+                        "metadata": {"dept": "hr"},
+                    }
+                ]
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    original_client = httpx.AsyncClient
+
+    def _client_factory(*args, **kwargs):
+        return original_client(*args, transport=transport, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _client_factory)
+
+    retriever = FederatedRetriever(
+        sources=[
+            {
+                "name": "remote",
+                "url": "https://federated.invalid/retrieve",
+                "api_key": "sekret",
+            }
+        ],
+        fusion="score",
+        top_k=1,
+    )
+
+    results = await retriever.retrieve_with_scores(
+        "vacation policy",
+        metadata_filter={"department": "hr"},
+    )
+
+    assert captured["authorization"] == "Bearer sekret"
+    assert captured["body"] == {
+        "query": "vacation policy",
+        "top_k": 1,
+        "metadata_filter": {"department": "hr"},
+    }
+    assert results == [
+        {
+            "text": "remote policy",
+            "score": 0.85,
+            "metadata": {"dept": "hr"},
+            "source": "remote",
+        }
+    ]

--- a/tests/retrieval/test_federated.py
+++ b/tests/retrieval/test_federated.py
@@ -121,9 +121,7 @@ async def test_federated_accepts_tuple_results():
     )
 
     results = await retriever.retrieve_with_scores("query")
-    assert results == [
-        {"text": "tuple doc", "score": 0.42, "metadata": {}, "source": "tuple"}
-    ]
+    assert results == [{"text": "tuple doc", "score": 0.42, "metadata": {}, "source": "tuple"}]
 
 
 @pytest.mark.asyncio

--- a/tests/retrieval/test_federated.py
+++ b/tests/retrieval/test_federated.py
@@ -109,6 +109,24 @@ async def test_federated_accepts_document_only_retrievers():
 
 
 @pytest.mark.asyncio
+async def test_federated_accepts_tuple_results():
+    class _TupleRetriever:
+        async def retrieve(self, query, top_k=5, metadata_filter=None):
+            return [("tuple doc", 0.42), ("other", 0.1)]
+
+    retriever = FederatedRetriever(
+        sources=[{"name": "tuple", "retriever": _TupleRetriever()}],
+        fusion="rrf",
+        top_k=1,
+    )
+
+    results = await retriever.retrieve_with_scores("query")
+    assert results == [
+        {"text": "tuple doc", "score": 0.42, "metadata": {}, "source": "tuple"}
+    ]
+
+
+@pytest.mark.asyncio
 async def test_federated_timeout_returns_partial():
     class _SlowRetriever:
         async def retrieve_with_scores(self, query, top_k=5, metadata_filter=None):

--- a/tests/test_v060_features.py
+++ b/tests/test_v060_features.py
@@ -516,4 +516,4 @@ def test_tool_schemas():
 def test_version():
     import synapsekit
 
-    assert synapsekit.__version__ == "1.6.0"
+    assert synapsekit.__version__ == "1.7.0"

--- a/tests/test_v065_features.py
+++ b/tests/test_v065_features.py
@@ -15,7 +15,7 @@ import pytest
 def test_version():
     import synapsekit
 
-    assert synapsekit.__version__ == "1.6.0"
+    assert synapsekit.__version__ == "1.7.0"
 
 
 # ------------------------------------------------------------------ #

--- a/tests/test_v066_features.py
+++ b/tests/test_v066_features.py
@@ -14,7 +14,7 @@ import pytest
 def test_version():
     import synapsekit
 
-    assert synapsekit.__version__ == "1.6.0"
+    assert synapsekit.__version__ == "1.7.0"
 
 
 # ------------------------------------------------------------------ #

--- a/tests/test_v068_features.py
+++ b/tests/test_v068_features.py
@@ -18,7 +18,7 @@ import pytest
 def test_version():
     import synapsekit
 
-    assert synapsekit.__version__ == "1.6.0"
+    assert synapsekit.__version__ == "1.7.0"
 
 
 # ------------------------------------------------------------------ #

--- a/tests/test_v069_features.py
+++ b/tests/test_v069_features.py
@@ -15,7 +15,7 @@ import pytest
 def test_version():
     import synapsekit
 
-    assert synapsekit.__version__ == "1.6.0"
+    assert synapsekit.__version__ == "1.7.0"
 
 
 # ================================================================== #

--- a/tests/test_v070_features.py
+++ b/tests/test_v070_features.py
@@ -35,7 +35,7 @@ class MockLLM:
 def test_version():
     import synapsekit
 
-    assert synapsekit.__version__ == "1.6.0"
+    assert synapsekit.__version__ == "1.7.0"
 
 
 # ------------------------------------------------------------------ #

--- a/tests/test_v120_features.py
+++ b/tests/test_v120_features.py
@@ -836,7 +836,7 @@ class TestCLIMain:
 
         main(["--version"])
         output = capsys.readouterr().out
-        assert "1.6.0" in output
+        assert "1.7.0" in output
 
     def test_no_command(self):
         from synapsekit.cli.main import main
@@ -894,4 +894,4 @@ class TestTopLevelImports:
     def test_version_bumped(self):
         import synapsekit
 
-        assert synapsekit.__version__ == "1.6.0"
+        assert synapsekit.__version__ == "1.7.0"


### PR DESCRIPTION
## Summary
- normalize federated source outputs into a shared internal result shape
- support document-only local retrievers while preserving metadata and source info
- add coverage for score fusion, remote HTTP retrieval protocol, and document-based local sources

## Test Plan
- `uv run pytest tests/retrieval/test_federated.py -q`
- `uv run ruff check src/synapsekit/retrieval/federated.py tests/retrieval/test_federated.py`
- `uv run mypy src/synapsekit/retrieval/federated.py`
- `uv run deptry .` *(currently reports pre-existing repo-wide DEP003 issues unrelated to this PR)*

Closes #595
