### PR TITLE
Make fallback chain empty responses configurable

### DIFF
--- a/src/synapsekit/llm/fallback_chain.py
+++ b/src/synapsekit/llm/fallback_chain.py
@@ -15,6 +15,7 @@ class FallbackChainConfig:
 
     models: list[BaseLLM]
     min_response_length: int = 1
+    fallback_on_empty: bool = True
 
 
 class FallbackChain(BaseLLM):
@@ -49,7 +50,10 @@ class FallbackChain(BaseLLM):
                     tokens.append(token)
                 full = "".join(tokens)
                 if len(full.strip()) < min_len:
-                    continue
+                    if self._chain_config.fallback_on_empty:
+                        continue
+                    self._used_model = llm
+                    return
                 self._used_model = llm
                 for token in tokens:
                     yield token
@@ -70,7 +74,10 @@ class FallbackChain(BaseLLM):
             try:
                 result = await llm.generate(prompt, **kw)
                 if len(result.strip()) < min_len:
-                    continue
+                    if self._chain_config.fallback_on_empty:
+                        continue
+                    self._used_model = llm
+                    return result
                 self._used_model = llm
                 return result
             except Exception as exc:

--- a/tests/llm/test_cache_retry.py
+++ b/tests/llm/test_cache_retry.py
@@ -223,3 +223,46 @@ def test_llmconfig_defaults():
     assert config.cache_maxsize == 128
     assert config.max_retries == 0
     assert config.retry_delay == 1.0
+
+
+# ------------------------------------------------------------------ #
+# FallbackChain empty response handling
+# ------------------------------------------------------------------ #
+
+
+class _FixedResponseLLM(BaseLLM):
+    def __init__(self, response: str, model: str):
+        super().__init__(LLMConfig(model=model, api_key="", provider="test"))
+        self.response = response
+        self.call_count = 0
+
+    async def stream(self, prompt: str, **kw):
+        self.call_count += 1
+        if self.response:
+            yield self.response
+
+
+class TestFallbackChainEmptyResponses:
+    async def test_empty_response_falls_back_by_default(self):
+        from synapsekit.llm.fallback_chain import FallbackChain, FallbackChainConfig
+
+        empty = _FixedResponseLLM("", "empty")
+        backup = _FixedResponseLLM("backup", "backup")
+        chain = FallbackChain(FallbackChainConfig(models=[empty, backup]))
+
+        assert await chain.generate("prompt") == "backup"
+        assert chain.used_model is backup
+        assert empty.call_count == 1
+        assert backup.call_count == 1
+
+    async def test_empty_response_can_be_accepted(self):
+        from synapsekit.llm.fallback_chain import FallbackChain, FallbackChainConfig
+
+        empty = _FixedResponseLLM("", "empty")
+        backup = _FixedResponseLLM("backup", "backup")
+        chain = FallbackChain(FallbackChainConfig(models=[empty, backup], fallback_on_empty=False))
+
+        assert await chain.generate("prompt") == ""
+        assert chain.used_model is empty
+        assert empty.call_count == 1
+        assert backup.call_count == 0


### PR DESCRIPTION
## Summary

Adds an explicit `fallback_on_empty` option to `FallbackChainConfig` so chains can either keep the existing behavior of trying the next model on empty or too-short responses, or intentionally accept an empty first response when that is desired.

Closes #703

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / internal improvement
- [ ] Dependency / tooling update

## Changes

- Added `fallback_on_empty` to the fallback chain configuration with a backward-compatible default.
- Added regression coverage for both default fallback behavior and explicitly accepting empty responses.

## Testing

- [ ] All existing tests pass (`uv run pytest tests/ -q`)
- [x] New tests added for new behaviour
- [x] No API keys or secrets in the code

Targeted checks run:
- `PYTHONPATH=src python3 -m pytest tests/llm/test_cache_retry.py -q` — 21 passed
- `python3 -m ruff check src/synapsekit/llm/fallback_chain.py tests/llm/test_cache_retry.py`
- `python3 -m ruff format --check src/synapsekit/llm/fallback_chain.py tests/llm/test_cache_retry.py`
- `git diff --check`

## Documentation

- [x] Docstrings updated (if public API changed)
- [ ] [synapsekit-docs](https://github.com/SynapseKit/synapsekit-docs) updated (if new feature)
- [ ] CHANGELOG.md updated

## Notes for reviewer

This preserves the previous fallback behavior by default while making the empty-response policy explicit for callers that need to accept an intentionally blank result.
