### PR TITLE
feat: OTEL-native observability metrics + helm chart

### DIFF
--- a/assets/helm/synapsekit-observability/Chart.yaml
+++ b/assets/helm/synapsekit-observability/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: synapsekit-observability
+description: Helm chart for Prometheus + Grafana (SynapseKit observability).
+type: application
+version: 0.1.0
+appVersion: "1.0"

--- a/assets/helm/synapsekit-observability/README.md
+++ b/assets/helm/synapsekit-observability/README.md
@@ -1,0 +1,32 @@
+# SynapseKit Observability Helm Chart
+
+Deploy Prometheus + Grafana with a preloaded SynapseKit dashboard.
+
+## Install
+
+```bash
+helm install synapsekit-observability ./assets/helm/synapsekit-observability
+```
+
+## Configure
+
+Update `values.yaml` if your SynapseKit metrics service is different:
+
+```yaml
+synapsekitMetrics:
+  service:
+    name: synapsekit-metrics
+    port: 8000
+```
+
+Prometheus scrapes the configured service. Grafana is pre-provisioned with:
+- Prometheus datasource
+- SynapseKit dashboard (from `assets/grafana/synapsekit-observe-dashboard.json`)
+
+## Access
+
+```bash
+kubectl port-forward svc/synapsekit-observability-grafana 3000:3000
+```
+
+Open http://localhost:3000 (admin/admin by default).

--- a/assets/helm/synapsekit-observability/templates/_helpers.tpl
+++ b/assets/helm/synapsekit-observability/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "synapsekit-observability.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "synapsekit-observability.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "synapsekit-observability.name" . -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/assets/helm/synapsekit-observability/templates/grafana-dashboard-configmap.yaml
+++ b/assets/helm/synapsekit-observability/templates/grafana-dashboard-configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "synapsekit-observability.fullname" . }}-grafana-dashboard
+  labels:
+    app.kubernetes.io/name: {{ include "synapsekit-observability.name" . }}
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: synapsekit
+        orgId: 1
+        folder: "SynapseKit"
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards
+  synapsekit-observe-dashboard.json: |
+    {{- .Files.Get "assets/grafana/synapsekit-observe-dashboard.json" | nindent 4 }}

--- a/assets/helm/synapsekit-observability/templates/grafana-datasource-configmap.yaml
+++ b/assets/helm/synapsekit-observability/templates/grafana-datasource-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "synapsekit-observability.fullname" . }}-grafana-datasource
+  labels:
+    app.kubernetes.io/name: {{ include "synapsekit-observability.name" . }}
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://{{ include "synapsekit-observability.fullname" . }}-prometheus:{{ .Values.prometheus.service.port }}
+        isDefault: true

--- a/assets/helm/synapsekit-observability/templates/grafana-deployment.yaml
+++ b/assets/helm/synapsekit-observability/templates/grafana-deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "synapsekit-observability.fullname" . }}-grafana
+  labels:
+    app.kubernetes.io/name: {{ include "synapsekit-observability.name" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: grafana
+      app.kubernetes.io/name: {{ include "synapsekit-observability.name" . }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: grafana
+        app.kubernetes.io/name: {{ include "synapsekit-observability.name" . }}
+    spec:
+      containers:
+        - name: grafana
+          image: {{ .Values.grafana.image }}
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              value: {{ .Values.grafana.adminUser | quote }}
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              value: {{ .Values.grafana.adminPassword | quote }}
+          ports:
+            - containerPort: 3000
+          volumeMounts:
+            - name: grafana-datasource
+              mountPath: /etc/grafana/provisioning/datasources
+            - name: grafana-dashboard
+              mountPath: /etc/grafana/provisioning/dashboards
+            - name: grafana-dashboard-json
+              mountPath: /var/lib/grafana/dashboards
+      volumes:
+        - name: grafana-datasource
+          configMap:
+            name: {{ include "synapsekit-observability.fullname" . }}-grafana-datasource
+        - name: grafana-dashboard
+          configMap:
+            name: {{ include "synapsekit-observability.fullname" . }}-grafana-dashboard
+            items:
+              - key: dashboards.yaml
+                path: dashboards.yaml
+        - name: grafana-dashboard-json
+          configMap:
+            name: {{ include "synapsekit-observability.fullname" . }}-grafana-dashboard
+            items:
+              - key: synapsekit-observe-dashboard.json
+                path: synapsekit-observe-dashboard.json

--- a/assets/helm/synapsekit-observability/templates/grafana-service.yaml
+++ b/assets/helm/synapsekit-observability/templates/grafana-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "synapsekit-observability.fullname" . }}-grafana
+  labels:
+    app.kubernetes.io/name: {{ include "synapsekit-observability.name" . }}
+spec:
+  type: {{ .Values.grafana.service.type }}
+  ports:
+    - port: {{ .Values.grafana.service.port }}
+      targetPort: 3000
+      name: http
+  selector:
+    app.kubernetes.io/component: grafana
+    app.kubernetes.io/name: {{ include "synapsekit-observability.name" . }}

--- a/assets/helm/synapsekit-observability/templates/prometheus-configmap.yaml
+++ b/assets/helm/synapsekit-observability/templates/prometheus-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "synapsekit-observability.fullname" . }}-prometheus
+  labels:
+    app.kubernetes.io/name: {{ include "synapsekit-observability.name" . }}
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: {{ .Values.prometheus.scrapeInterval }}
+    scrape_configs:
+    {{- if .Values.prometheus.scrape.enabled }}
+      {{- toYaml .Values.prometheus.scrape.targets | nindent 6 }}
+    {{- end }}

--- a/assets/helm/synapsekit-observability/templates/prometheus-deployment.yaml
+++ b/assets/helm/synapsekit-observability/templates/prometheus-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "synapsekit-observability.fullname" . }}-prometheus
+  labels:
+    app.kubernetes.io/name: {{ include "synapsekit-observability.name" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: prometheus
+      app.kubernetes.io/name: {{ include "synapsekit-observability.name" . }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: prometheus
+        app.kubernetes.io/name: {{ include "synapsekit-observability.name" . }}
+    spec:
+      containers:
+        - name: prometheus
+          image: {{ .Values.prometheus.image }}
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: prometheus-config
+              mountPath: /etc/prometheus
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: {{ include "synapsekit-observability.fullname" . }}-prometheus

--- a/assets/helm/synapsekit-observability/templates/prometheus-service.yaml
+++ b/assets/helm/synapsekit-observability/templates/prometheus-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "synapsekit-observability.fullname" . }}-prometheus
+  labels:
+    app.kubernetes.io/name: {{ include "synapsekit-observability.name" . }}
+spec:
+  type: {{ .Values.prometheus.service.type }}
+  ports:
+    - port: {{ .Values.prometheus.service.port }}
+      targetPort: 9090
+      name: http
+  selector:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/name: {{ include "synapsekit-observability.name" . }}

--- a/assets/helm/synapsekit-observability/templates/synapsekit-metrics-service.yaml
+++ b/assets/helm/synapsekit-observability/templates/synapsekit-metrics-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.synapsekitMetrics.service.name }}
+  labels:
+    app.kubernetes.io/name: {{ include "synapsekit-observability.name" . }}
+spec:
+  type: {{ .Values.synapsekitMetrics.service.type }}
+  ports:
+    - port: {{ .Values.synapsekitMetrics.service.port }}
+      targetPort: {{ .Values.synapsekitMetrics.service.port }}
+      name: http
+  selector:
+    app: synapsekit

--- a/assets/helm/synapsekit-observability/values.yaml
+++ b/assets/helm/synapsekit-observability/values.yaml
@@ -1,0 +1,29 @@
+prometheus:
+  image: prom/prometheus:v2.52.0
+  scrapeInterval: 15s
+  service:
+    type: ClusterIP
+    port: 9090
+  scrape:
+    enabled: true
+    targets:
+      - job_name: synapsekit
+        static_configs:
+          - targets:
+              - synapsekit-metrics.default.svc.cluster.local:8000
+
+grafana:
+  image: grafana/grafana:11.2.0
+  service:
+    type: ClusterIP
+    port: 3000
+  adminUser: admin
+  adminPassword: admin
+  dashboards:
+    enabled: true
+
+synapsekitMetrics:
+  service:
+    name: synapsekit-metrics
+    type: ClusterIP
+    port: 8000

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -28,6 +28,34 @@ rag = RAG(model="gpt-4o-mini", api_key="sk-...")
 answer = await rag.ask("What is the main topic?")
 ```
 
+## Export to Grafana in 5 minutes
+
+1) Start Prometheus + Grafana (see the Helm chart below or your own stack).
+2) Enable metrics and expose a `/metrics` endpoint:
+
+```python
+from synapsekit.observability import PrometheusMetrics
+import synapsekit.observe as observe
+
+metrics = PrometheusMetrics(start_server=True, port=8000)
+observe.configure(
+    exporter="otlp",
+    endpoint="http://localhost:4317",
+    metrics=metrics,
+)
+```
+
+3) In Grafana, add Prometheus as a data source.
+4) Import `assets/grafana/synapsekit-observe-dashboard.json`.
+
+## Prometheus metrics
+
+SynapseKit emits the following metrics when enabled:
+
+- `synapsekit_cost_usd_total` (counter)
+- `synapsekit_tokens_total` (counter)
+- `synapsekit_latency_seconds` (histogram)
+
 ## Exporters
 
 Supported exporter names:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ ernie = ["erniebot>=0.5"]
 minimax = ["httpx>=0.27"]
 serve = ["fastapi>=0.110", "uvicorn[standard]>=0.29"]
 graph-ui = ["fastapi>=0.110", "uvicorn[standard]>=0.29"]
-observe = []
+observe = ["prometheus-client>=0.20"]
 postgres = ["psycopg[binary]>=3.1", "asyncpg>=0.29"]
 pgvector = ["psycopg[binary]>=3.1", "pgvector>=0.2"]
 wolfram = ["wolframalpha>=5.0"]
@@ -398,7 +398,7 @@ snowflake-connector-python = "snowflake"
 "opensearch-py" = "opensearchpy"
 
 [tool.deptry.per_rule_ignores]
-DEP001 = ["sqlalchemy", "pydantic", "aiohttp", "opentelemetry", "whisper", "botocore", "aiomcache", "nest_asyncio", "huggingface_hub", "serpapi", "weaviate", "uvicorn", "starlette", "tomli", "pyttsx3", "faster_whisper", "sounddevice", "soundfile", "aiokafka", "typesense"]
+DEP001 = ["sqlalchemy", "pydantic", "aiohttp", "opentelemetry", "whisper", "botocore", "aiomcache", "nest_asyncio", "huggingface_hub", "serpapi", "weaviate", "uvicorn", "starlette", "tomli", "pyttsx3", "faster_whisper", "sounddevice", "soundfile", "aiokafka", "typesense", "prometheus_client"]
 DEP002 = ["numpy", "rank-bm25", "beautifulsoup4", "lxml", "pillow", "pyasn1", "faiss-cpu", "google-generativeai", "tavily-python", "youtube-search-python", "psycopg", "google-search-results", "discord.py", "google-auth", "weaviate-client", "pymilvus", "lancedb", "pgvector", "slack-sdk", "supabase", "pymongo", "azure-storage-blob", "elasticsearch", "tzdata"]
 DEP003 = ["sqlalchemy", "botocore", "nest_asyncio", "opentelemetry", "starlette", "uvicorn"]
 DEP004 = ["pydantic"]

--- a/src/synapsekit/observability/__init__.py
+++ b/src/synapsekit/observability/__init__.py
@@ -2,6 +2,7 @@ from .audit_log import AuditEntry, AuditLog
 from .budget_guard import BudgetExceededError, BudgetGuard, BudgetLimit, CircuitState
 from .cost_tracker import CostRecord, CostTracker
 from .distributed import DistributedTracer, TraceSpan
+from .metrics import PrometheusMetrics
 from .otel import OTelExporter, Span, TracingMiddleware
 from .tracer import TokenTracer
 from .ui import TracingUI
@@ -22,4 +23,5 @@ __all__ = [
     "TraceSpan",
     "TracingMiddleware",
     "TracingUI",
+    "PrometheusMetrics",
 ]

--- a/src/synapsekit/observability/metrics.py
+++ b/src/synapsekit/observability/metrics.py
@@ -3,19 +3,25 @@
 from __future__ import annotations
 
 from contextlib import suppress
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
-try:  # pragma: no cover - avoid circular import at runtime
-    from ..observe.spans import SpanAttributes
-except Exception:  # pragma: no cover
-    SpanAttributes = None  # type: ignore[assignment]
+if TYPE_CHECKING:  # pragma: no cover
+    from prometheus_client import Counter, Histogram, CollectorRegistry
 
 try:  # pragma: no cover - optional dependency
-    from prometheus_client import CollectorRegistry, Counter, Histogram, start_http_server
+    from prometheus_client import (
+        CollectorRegistry as PromCollectorRegistry,
+        Counter as PromCounter,
+        Histogram as PromHistogram,
+        start_http_server as prom_start_http_server,
+    )
 
     _PROMETHEUS_AVAILABLE = True
 except Exception:  # pragma: no cover - optional dependency
-    Counter = Histogram = CollectorRegistry = start_http_server = None  # type: ignore[assignment]
+    PromCollectorRegistry = None  # type: ignore[assignment,misc]
+    PromCounter = None  # type: ignore[assignment,misc]
+    PromHistogram = None  # type: ignore[assignment,misc]
+    prom_start_http_server = None  # type: ignore[assignment,misc]
     _PROMETHEUS_AVAILABLE = False
 
 
@@ -40,25 +46,30 @@ class PrometheusMetrics:
     ) -> None:
         self.enabled = bool(enabled) and _PROMETHEUS_AVAILABLE
         self._namespace = namespace
-        self._registry = registry or (CollectorRegistry() if self.enabled else None)
+        self._registry: "CollectorRegistry" | None = registry
+        if self._registry is None and self.enabled and PromCollectorRegistry is not None:
+            self._registry = PromCollectorRegistry()
         self._server_started = False
+        self._cost_counter: "Counter" | None = None
+        self._token_counter: "Counter" | None = None
+        self._latency_hist: "Histogram" | None = None
 
         if self.enabled:
-            self._cost_counter = Counter(
+            self._cost_counter = PromCounter(
                 "cost_usd_total",
                 "Total LLM cost in USD.",
                 ["model", "provider"],
                 namespace=self._namespace,
                 registry=self._registry,
             )
-            self._token_counter = Counter(
+            self._token_counter = PromCounter(
                 "tokens_total",
                 "Total LLM tokens.",
                 ["model", "provider"],
                 namespace=self._namespace,
                 registry=self._registry,
             )
-            self._latency_hist = Histogram(
+            self._latency_hist = PromHistogram(
                 "latency_seconds",
                 "LLM latency in seconds.",
                 ["model", "provider"],
@@ -66,10 +77,6 @@ class PrometheusMetrics:
                 registry=self._registry,
                 buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
             )
-        else:
-            self._cost_counter = None
-            self._token_counter = None
-            self._latency_hist = None
 
         if start_server and self.enabled:
             self.start_http_server(host=host, port=port)
@@ -77,9 +84,9 @@ class PrometheusMetrics:
     def start_http_server(self, *, host: str = "0.0.0.0", port: int = 8000) -> None:
         if not self.enabled or self._server_started:
             return
-        if start_http_server is None:
+        if prom_start_http_server is None or self._registry is None:
             return
-        start_http_server(port, addr=host, registry=self._registry)
+        prom_start_http_server(port, addr=host, registry=self._registry)
         self._server_started = True
 
     def record_llm(

--- a/src/synapsekit/observability/metrics.py
+++ b/src/synapsekit/observability/metrics.py
@@ -8,8 +8,14 @@ from typing import Any
 try:  # pragma: no cover - optional dependency
     from prometheus_client import (
         CollectorRegistry as PromCollectorRegistry,
+    )
+    from prometheus_client import (
         Counter as PromCounter,
+    )
+    from prometheus_client import (
         Histogram as PromHistogram,
+    )
+    from prometheus_client import (
         start_http_server as prom_start_http_server,
     )
 

--- a/src/synapsekit/observability/metrics.py
+++ b/src/synapsekit/observability/metrics.py
@@ -1,0 +1,138 @@
+"""Prometheus metrics exporter for SynapseKit observability."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import Any
+
+try:  # pragma: no cover - avoid circular import at runtime
+    from ..observe.spans import SpanAttributes
+except Exception:  # pragma: no cover
+    SpanAttributes = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    from prometheus_client import CollectorRegistry, Counter, Histogram, start_http_server
+
+    _PROMETHEUS_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    Counter = Histogram = CollectorRegistry = start_http_server = None  # type: ignore[assignment]
+    _PROMETHEUS_AVAILABLE = False
+
+
+class PrometheusMetrics:
+    """Prometheus metrics for LLM cost, tokens, and latency.
+
+    Metrics:
+      - synapsekit_cost_usd_total
+      - synapsekit_tokens_total
+      - synapsekit_latency_seconds (histogram)
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = True,
+        namespace: str = "synapsekit",
+        registry: Any | None = None,
+        start_server: bool = False,
+        host: str = "0.0.0.0",
+        port: int = 8000,
+    ) -> None:
+        self.enabled = bool(enabled) and _PROMETHEUS_AVAILABLE
+        self._namespace = namespace
+        self._registry = registry or (CollectorRegistry() if self.enabled else None)
+        self._server_started = False
+
+        if self.enabled:
+            self._cost_counter = Counter(
+                "cost_usd_total",
+                "Total LLM cost in USD.",
+                ["model", "provider"],
+                namespace=self._namespace,
+                registry=self._registry,
+            )
+            self._token_counter = Counter(
+                "tokens_total",
+                "Total LLM tokens.",
+                ["model", "provider"],
+                namespace=self._namespace,
+                registry=self._registry,
+            )
+            self._latency_hist = Histogram(
+                "latency_seconds",
+                "LLM latency in seconds.",
+                ["model", "provider"],
+                namespace=self._namespace,
+                registry=self._registry,
+                buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
+            )
+        else:
+            self._cost_counter = None
+            self._token_counter = None
+            self._latency_hist = None
+
+        if start_server and self.enabled:
+            self.start_http_server(host=host, port=port)
+
+    def start_http_server(self, *, host: str = "0.0.0.0", port: int = 8000) -> None:
+        if not self.enabled or self._server_started:
+            return
+        if start_http_server is None:
+            return
+        start_http_server(port, addr=host, registry=self._registry)
+        self._server_started = True
+
+    def record_llm(
+        self,
+        *,
+        model: str,
+        provider: str,
+        cost_usd: float | None,
+        total_tokens: int | None,
+        latency_ms: float | None,
+    ) -> None:
+        if not self.enabled:
+            return
+        if model is None:
+            model = "unknown"
+        if provider is None:
+            provider = "unknown"
+        labels = {"model": str(model), "provider": str(provider)}
+
+        if cost_usd is not None and self._cost_counter is not None:
+            with suppress(Exception):
+                self._cost_counter.labels(**labels).inc(float(cost_usd))
+
+        if total_tokens is not None and self._token_counter is not None:
+            with suppress(Exception):
+                self._token_counter.labels(**labels).inc(int(total_tokens))
+
+        if latency_ms is not None and self._latency_hist is not None:
+            with suppress(Exception):
+                self._latency_hist.labels(**labels).observe(float(latency_ms) / 1000.0)
+
+    def record_span(self, span: Any) -> None:
+        if not self.enabled or span is None:
+            return
+        if getattr(span, "name", None) != "llm.generate":
+            return
+
+        attrs = getattr(span, "attributes", {}) or {}
+        model = attrs.get("llm.model") or "unknown"
+        provider = attrs.get("llm.provider") or "unknown"
+        total_tokens = attrs.get("llm.total_tokens")
+        if total_tokens is None:
+            prompt = attrs.get("llm.prompt_tokens")
+            completion = attrs.get("llm.completion_tokens")
+            if prompt is not None or completion is not None:
+                total_tokens = int(prompt or 0) + int(completion or 0)
+        cost_usd = attrs.get("llm.cost_usd")
+        latency_ms = attrs.get("llm.latency_ms")
+
+        self.record_llm(
+            model=str(model),
+            provider=str(provider),
+            cost_usd=float(cost_usd) if cost_usd is not None else None,
+            total_tokens=int(total_tokens) if total_tokens is not None else None,
+            latency_ms=float(latency_ms) if latency_ms is not None else None,
+        )

--- a/src/synapsekit/observe/__init__.py
+++ b/src/synapsekit/observe/__init__.py
@@ -25,6 +25,7 @@ from .runtime import (
     is_enabled,
     record_exception,
     reset,
+    set_metrics,
     start_span,
     trace,
 )
@@ -235,6 +236,7 @@ __all__ = [
     "is_enabled",
     "record_exception",
     "reset",
+    "set_metrics",
     "start_span",
     "trace",
 ]

--- a/src/synapsekit/observe/exporters/common.py
+++ b/src/synapsekit/observe/exporters/common.py
@@ -25,5 +25,8 @@ class BufferedSpanExporter:
     def clear(self) -> None:
         self.spans.clear()
 
+    def after_export(self, span: ObserveSpan) -> None:
+        return None
+
     def export_dicts(self) -> list[dict]:
         return [span.to_dict() for span in self.spans]

--- a/src/synapsekit/observe/runtime.py
+++ b/src/synapsekit/observe/runtime.py
@@ -34,7 +34,8 @@ class SpanExporter(Protocol):
 
     def export_dicts(self) -> list[dict[str, Any]]: ...
 
-    def after_export(self, span: ObserveSpan) -> None: pass
+    def after_export(self, span: ObserveSpan) -> None:
+        pass
 
 
 @dataclass

--- a/src/synapsekit/observe/runtime.py
+++ b/src/synapsekit/observe/runtime.py
@@ -34,7 +34,7 @@ class SpanExporter(Protocol):
 
     def export_dicts(self) -> list[dict[str, Any]]: ...
 
-    def after_export(self, span: ObserveSpan) -> None: ...
+    def after_export(self, span: ObserveSpan) -> None: pass
 
 
 @dataclass

--- a/src/synapsekit/observe/runtime.py
+++ b/src/synapsekit/observe/runtime.py
@@ -6,7 +6,7 @@ import random
 import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from .exporters import (
     ConsoleExporter,
@@ -15,6 +15,9 @@ from .exporters import (
     LangfuseExporter,
     OTLPExporter,
 )
+
+if TYPE_CHECKING:
+    from ..observability.metrics import PrometheusMetrics
 
 REDACTED = "[REDACTED]"
 
@@ -30,6 +33,8 @@ class SpanExporter(Protocol):
     def clear(self) -> None: ...
 
     def export_dicts(self) -> list[dict[str, Any]]: ...
+
+    def after_export(self, span: ObserveSpan) -> None: ...
 
 
 @dataclass
@@ -96,6 +101,9 @@ class InMemoryExporter:
     def export(self, span: ObserveSpan) -> None:
         self.spans.append(span)
 
+    def after_export(self, span: ObserveSpan) -> None:
+        return None
+
     def clear(self) -> None:
         self.spans.clear()
 
@@ -108,6 +116,7 @@ class _ObserveState:
     config: ObserveConfig = field(default_factory=ObserveConfig)
     exporter: SpanExporter = field(default_factory=InMemoryExporter)
     enabled: bool = False
+    metrics: PrometheusMetrics | None = None
 
 
 _STATE = _ObserveState()
@@ -155,6 +164,7 @@ def configure(
     cost_tracking: bool = True,
     sample_rate: float = 1.0,
     redact_keys: list[str] | tuple[str, ...] | None = None,
+    metrics: PrometheusMetrics | None = None,
 ) -> SpanExporter:
     config = ObserveConfig(
         exporter=exporter,
@@ -173,6 +183,7 @@ def configure(
         endpoint=endpoint,
     )
     _STATE.enabled = True
+    _STATE.metrics = metrics
     return _STATE.exporter
 
 
@@ -180,6 +191,7 @@ def reset() -> None:
     _STATE.exporter.clear()
     _STATE.enabled = False
     _STATE.config = ObserveConfig()
+    _STATE.metrics = None
     _CURRENT_SPAN.set(None)
 
 
@@ -193,6 +205,10 @@ def get_config() -> ObserveConfig:
 
 def get_exporter() -> SpanExporter:
     return _STATE.exporter
+
+
+def set_metrics(metrics: PrometheusMetrics | None) -> None:
+    _STATE.metrics = metrics
 
 
 def clear_exported_spans() -> None:
@@ -276,6 +292,9 @@ def end_span(
         span._context_token = None
     if span.parent is None:
         _STATE.exporter.export(span)
+        _STATE.exporter.after_export(span)
+        if _STATE.metrics is not None:
+            _STATE.metrics.record_span(span)
 
 
 def record_exception(span: ObserveSpan | None, exc: Exception) -> None:

--- a/tests/observability/test_prometheus_metrics.py
+++ b/tests/observability/test_prometheus_metrics.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import synapsekit.observe as observe
+from synapsekit.observability.metrics import PrometheusMetrics
+
+
+class TestPrometheusMetrics:
+    def test_prometheus_metrics_records_from_span(self):
+        metrics = PrometheusMetrics(enabled=False)
+        observe.configure(metrics=metrics)
+
+        span = observe.start_span(
+            "llm.generate",
+            {
+                "llm.model": "gpt-4o-mini",
+                "llm.provider": "openai",
+                "llm.total_tokens": 12,
+                "llm.cost_usd": 0.0012,
+                "llm.latency_ms": 25.0,
+            },
+        )
+        observe.end_span(span)
+
+        # No crash, metrics disabled => no-ops
+        assert True


### PR DESCRIPTION
## Summary
- add Prometheus metrics exporter hooked into observe spans
- document Grafana export quickstart
- add Helm chart for Prometheus/Grafana + dashboard provisioning

## Testing
- python -c "import sys,pytest; sys.path.insert(0, r'E:\\My Github\\SynapseKit\\src'); raise SystemExit(pytest.main(['tests/observability']))"
- python -m ruff check src tests

fixes: #695 

