### PR TITLE
feat: add benchmark harness (pytest-benchmark + asv)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,40 @@
+name: Benchmarks
+
+on:
+  push:
+    tags: ["v*"]
+  schedule:
+    - cron: "0 2 * * *"
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --group dev --group bench
+
+      - name: Cache benchmark baselines
+        uses: actions/cache@v4
+        with:
+          path: .benchmarks
+          key: benchmarks-${{ runner.os }}-${{ github.ref_name }}
+          restore-keys: |
+            benchmarks-${{ runner.os }}-
+
+      - name: Run benchmarks
+        run: make bench
+
+      - name: Compare (fail on >10% regression)
+        run: |
+          if [ -d ".benchmarks" ]; then
+            make bench-compare
+          else
+            echo "No baseline cache found; skipping compare."
+          fi
+
+      - name: Upload JSON artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-json
+          path: benchmarks/benchmark.json

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: install lint format format-check typecheck test deptry check help
+.PHONY: install lint format format-check typecheck test deptry check bench bench-compare help
 
 install: ## Install dependencies (dev group)
 	uv sync --group dev
@@ -22,5 +22,12 @@ test: ## Run test suite
 
 deptry: ## Check for dependency issues
 	deptry src/
+
+bench: ## Run micro-benchmarks
+	PYTHONHASHSEED=0 uv run pytest benchmarks/ -c benchmarks/pytest.ini
+	uv run python benchmarks/report.py benchmarks/benchmark.json
+
+bench-compare: ## Compare against saved baseline (fail >10% regression)
+	PYTHONHASHSEED=0 uv run pytest benchmarks/ -c benchmarks/pytest.ini --benchmark-compare --benchmark-compare-fail=10%
 
 check: lint format-check typecheck test deptry ## Run all checks

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "project": "synapsekit",
+  "repo": ".",
+  "benchmark_dir": "benchmarks/asv",
+  "env_dir": ".asv/env",
+  "results_dir": ".asv/results",
+  "build_command": ["python", "-m", "pip", "install", "-e", "."],
+  "branches": ["main"]
+}

--- a/benchmarks/asv/bench_smoke.py
+++ b/benchmarks/asv/bench_smoke.py
@@ -1,0 +1,4 @@
+class TimeSmoke:
+    def time_sort(self):
+        data = list(range(1000, 0, -1))
+        sorted(data)

--- a/benchmarks/asv/machine.json
+++ b/benchmarks/asv/machine.json
@@ -1,0 +1,8 @@
+{
+  "machine": "DhruvGarg",
+  "os": "Linux 6.6.87.2-microsoft-standard-WSL2",
+  "arch": "x86_64",
+  "cpu": "11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz",
+  "num_cpu": "8",
+  "ram": "3868896"
+}

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+import platform
+import random
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - optional
+    np = None
+
+try:
+    import psutil
+except Exception:  # pragma: no cover - optional
+    psutil = None
+
+ROOT = Path(__file__).resolve().parents[1]
+COOLDOWN_SECONDS = 0.1
+
+
+def _git_sha() -> str | None:
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT, text=True).strip()
+    except Exception:
+        return None
+
+
+def pytest_sessionstart(session):
+    os.environ.setdefault("PYTHONHASHSEED", "0")
+    random.seed(0)
+    if np is not None:
+        np.random.seed(0)
+    root = Path(__file__).resolve().parents[1]
+    (root / ".benchmarks").mkdir(parents=True, exist_ok=True)
+
+
+@pytest.fixture(autouse=True)
+def _cooldown_between_benchmarks():
+    yield
+    time.sleep(COOLDOWN_SECONDS)
+
+
+def pytest_benchmark_update_machine_info(config, machine_info):
+    machine_info["git_sha"] = _git_sha()
+    machine_info["python"] = platform.python_version()
+    machine_info["os"] = platform.platform()
+    machine_info["cpu"] = platform.processor()
+    if psutil:
+        machine_info["ram_gb"] = round(psutil.virtual_memory().total / (1024**3), 2)

--- a/benchmarks/pytest.ini
+++ b/benchmarks/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+addopts =
+  --benchmark-autosave
+  --benchmark-histogram
+  --benchmark-sort=mean
+  --benchmark-json=benchmarks/benchmark.json
+  --benchmark-warmup=on
+  --benchmark-warmup-iterations=1
+  --benchmark-min-rounds=5

--- a/benchmarks/report.py
+++ b/benchmarks/report.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+from pathlib import Path
+
+
+def _percentiles(samples: list[float]) -> dict[str, float]:
+    if not samples:
+        return {"p50": 0.0, "p95": 0.0, "p99": 0.0}
+    qs = statistics.quantiles(samples, n=100, method="inclusive")
+    return {
+        "p50": qs[49],
+        "p95": qs[94],
+        "p99": qs[98],
+    }
+
+
+def _extract_samples(bench: dict) -> list[float]:
+    stats = bench.get("stats", {})
+    for key in ("data", "samples", "values", "raw"):
+        if isinstance(stats.get(key), list):
+            return stats[key]
+    return []
+
+
+def main(path: str) -> int:
+    json_path = Path(path)
+    if not json_path.exists():
+        fallback = Path(__file__).resolve().parents[1] / "benchmark.json"
+        if fallback.exists():
+            json_path = fallback
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    benches = payload.get("benchmarks", [])
+    for bench in benches:
+        name = bench.get("name", "unknown")
+        samples = _extract_samples(bench)
+        pcts = _percentiles(samples)
+        print(
+            f"{name}: p50={pcts['p50']:.6f}  p95={pcts['p95']:.6f}  p99={pcts['p99']:.6f}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1]))

--- a/benchmarks/test_smoke_benchmark.py
+++ b/benchmarks/test_smoke_benchmark.py
@@ -1,0 +1,3 @@
+def test_smoke_sort(benchmark):
+    data = list(range(1000, 0, -1))
+    benchmark(sorted, data)

--- a/examples/structured_output.py
+++ b/examples/structured_output.py
@@ -1,0 +1,66 @@
+"""Structured output validation with automatic correction retries.
+
+Run with an LLM provider that implements SynapseKit's async ``ask`` interface,
+for example ``OpenAILLM`` from ``synapsekit.llms``.
+"""
+
+import asyncio
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from synapsekit.structured_output import (
+    StructuredOutput,
+    StructuredOutputRetryStrategy,
+)
+
+
+class InvoiceExtraction(BaseModel):
+    invoice_id: str = Field(description="Invoice identifier from the document")
+    vendor: str
+    total_usd: float
+    due_date: str
+
+
+class APIResponseCheck(BaseModel):
+    status: Literal["ok", "error"]
+    request_id: str
+    retryable: bool
+    message: str
+
+
+async def main() -> None:
+    from synapsekit.llms import OpenAILLM
+
+    llm = OpenAILLM("gpt-4o-mini")
+    retry_strategy = StructuredOutputRetryStrategy(
+        max_attempts=3,
+        backoff_seconds=0.25,
+    )
+
+    invoice_extractor = StructuredOutput(
+        llm,
+        InvoiceExtraction,
+        retry_strategy=retry_strategy,
+    )
+    invoice = await invoice_extractor.generate(
+        "Extract invoice fields from this text as JSON only:\n"
+        "Invoice INV-1042 from Northwind Labs, total $1842.50, due 2026-06-15."
+    )
+    print(invoice.output.model_dump())
+    print(invoice.metadata["structured_output"]["attempt_count"])
+
+    api_validator = StructuredOutput(
+        llm,
+        APIResponseCheck,
+        retry_strategy=retry_strategy,
+    )
+    api_response = await api_validator.generate(
+        "Normalize this upstream API response as JSON only:\n"
+        '{"request_id":"req_123","state":"temporarily_unavailable","detail":"try later"}'
+    )
+    print(api_response.output.model_dump())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,6 +239,12 @@ dev = [
     "tzdata>=2024.1",
 ]
 
+bench = [
+    "pytest-benchmark[histogram]>=4.0",
+    "asv>=0.6",
+    "psutil>=5.9",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/synapsekit"]
 

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -268,6 +268,18 @@ from .retrieval.self_rag import SelfRAGRetriever
 from .retrieval.sentence_window import SentenceWindowRetriever
 from .retrieval.step_back import StepBackRetriever
 from .retrieval.vectorstore import InMemoryVectorStore
+from .structured_output import (
+    IncrementalJSONBuffer,
+    StructuredOutput,
+    StructuredOutputAttempt,
+    StructuredOutputError,
+    StructuredOutputResult,
+    StructuredOutputRetryStrategy,
+    StructuredOutputStreamEvent,
+    StructuredOutputValidationError,
+    build_corrective_prompt,
+    structured_output,
+)
 from .text_splitters import (
     BaseSplitter,
     CharacterTextSplitter,
@@ -576,6 +588,16 @@ __all__ = [
     "SQLiteCheckpointer",
     # Structured output
     "generate_structured",
+    "IncrementalJSONBuffer",
+    "StructuredOutput",
+    "StructuredOutputAttempt",
+    "StructuredOutputError",
+    "StructuredOutputResult",
+    "StructuredOutputRetryStrategy",
+    "StructuredOutputStreamEvent",
+    "StructuredOutputValidationError",
+    "build_corrective_prompt",
+    "structured_output",
     # Evaluation
     "EvalCaseMeta",
     "EvalRegression",

--- a/src/synapsekit/structured_output.py
+++ b/src/synapsekit/structured_output.py
@@ -1,0 +1,716 @@
+"""Provider-agnostic structured output validation for LLM responses."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import time
+from collections.abc import AsyncIterator, Callable, Iterable
+from dataclasses import asdict, dataclass, field
+from json import JSONDecodeError
+from typing import Any, Generic, TypeVar, cast
+
+try:  # Pydantic is optional until this module is used.
+    from pydantic import BaseModel, ValidationError
+except ImportError as exc:  # pragma: no cover - exercised only without pydantic.
+    BaseModel = object  # type: ignore[assignment,misc]
+    ValidationError = Exception  # type: ignore[assignment,misc]
+    _PYDANTIC_IMPORT_ERROR: ImportError | None = exc
+else:
+    _PYDANTIC_IMPORT_ERROR = None
+
+
+SchemaT = TypeVar("SchemaT", bound=Any)
+PromptBuilder = Callable[[str, type[SchemaT], str, str], str]
+
+
+@dataclass
+class StructuredOutputRetryStrategy:
+    """Retry policy for structured output generation.
+
+    ``max_attempts`` counts every provider call, including fallback calls.
+    When a fallback provider or model is configured, it is used starting at
+    ``fallback_after_attempt`` after the previous attempt failed.
+    """
+
+    max_attempts: int = 3
+    backoff_seconds: float = 0.0
+    backoff_multiplier: float = 2.0
+    fallback_provider: Any | None = None
+    fallback_model: str | None = None
+    fallback_after_attempt: int = 2
+
+    def __post_init__(self) -> None:
+        if self.max_attempts < 1:
+            raise ValueError("max_attempts must be at least 1")
+        if self.backoff_seconds < 0:
+            raise ValueError("backoff_seconds must be greater than or equal to 0")
+        if self.backoff_multiplier < 1:
+            raise ValueError("backoff_multiplier must be greater than or equal to 1")
+        if self.fallback_after_attempt < 1:
+            raise ValueError("fallback_after_attempt must be at least 1")
+
+
+@dataclass
+class StructuredOutputAttempt:
+    """Metadata for one LLM attempt."""
+
+    attempt: int
+    provider: str
+    model: str | None
+    prompt: str
+    raw_output: str
+    success: bool
+    streamed: bool = False
+    error_type: str | None = None
+    error_message: str | None = None
+    duration_ms: float = 0.0
+    prompt_tokens_estimate: int = 0
+    completion_tokens_estimate: int = 0
+    cost_metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_metadata(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["prompt"] = _truncate(data["prompt"])
+        data["raw_output"] = _truncate(data["raw_output"])
+        return data
+
+
+@dataclass
+class StructuredOutputResult(Generic[SchemaT]):
+    """Validated structured output plus the raw response and attempt metadata."""
+
+    output: SchemaT
+    raw_output: str
+    attempts: list[StructuredOutputAttempt]
+    metadata: dict[str, Any]
+
+
+@dataclass
+class StructuredOutputStreamEvent(Generic[SchemaT]):
+    """Event yielded by ``StructuredOutput.stream``."""
+
+    type: str
+    content: str = ""
+    output: SchemaT | None = None
+    metadata: dict[str, Any] | None = None
+    attempt: int = 1
+
+
+class StructuredOutputError(Exception):
+    """Base exception for structured output failures."""
+
+
+class StructuredOutputValidationError(StructuredOutputError):
+    """Raised when all attempts fail to produce valid structured output."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        attempts: list[StructuredOutputAttempt],
+        last_error: Exception,
+    ) -> None:
+        super().__init__(message)
+        self.attempts = attempts
+        self.last_error = last_error
+        self.metadata = _build_metadata(attempts)
+
+
+class IncrementalJSONBuffer:
+    """Small helper for buffering streamed JSON and detecting completion."""
+
+    def __init__(self) -> None:
+        self._parts: list[str] = []
+        self._decoder = json.JSONDecoder()
+        self.complete = False
+
+    @property
+    def text(self) -> str:
+        return "".join(self._parts)
+
+    def append(self, chunk: str) -> bool:
+        self._parts.append(chunk)
+        stripped = self.text.strip()
+        if not stripped:
+            self.complete = False
+            return False
+
+        try:
+            _, end = self._decoder.raw_decode(stripped)
+        except JSONDecodeError:
+            self.complete = False
+            return False
+
+        self.complete = not stripped[end:].strip()
+        return self.complete
+
+
+class StructuredOutput(Generic[SchemaT]):
+    """Wrap an LLM/provider and validate its JSON response with Pydantic v2.
+
+    The wrapped provider only needs one of the common async generation methods:
+    ``ask(prompt)``, ``generate(prompt)``, ``complete(prompt)``, or
+    ``__call__(prompt)``. Streaming uses ``stream(prompt)`` when available and
+    falls back to the non-streaming generation path otherwise.
+    """
+
+    def __init__(
+        self,
+        llm: Any,
+        schema: type[SchemaT],
+        *,
+        retry_strategy: StructuredOutputRetryStrategy | None = None,
+        cost_tracker: Any | None = None,
+        corrective_prompt_builder: PromptBuilder[SchemaT] | None = None,
+    ) -> None:
+        _ensure_pydantic_schema(schema)
+        self.llm = llm
+        self.schema = schema
+        self.retry_strategy = retry_strategy or StructuredOutputRetryStrategy()
+        self.cost_tracker = cost_tracker
+        self.corrective_prompt_builder = corrective_prompt_builder or build_corrective_prompt
+
+    async def generate(self, prompt: str) -> StructuredOutputResult[SchemaT]:
+        """Generate, validate, and return a Pydantic model instance."""
+
+        result, _ = await self._generate_with_retry(prompt, streamed=False)
+        return result
+
+    async def ask(self, prompt: str) -> StructuredOutputResult[SchemaT]:
+        """Alias for ``generate`` to match SynapseKit LLM naming."""
+
+        return await self.generate(prompt)
+
+    async def stream(self, prompt: str) -> AsyncIterator[StructuredOutputStreamEvent[SchemaT]]:
+        """Stream raw JSON chunks and yield a final validated result event.
+
+        Each attempt buffers provider chunks while forwarding them as ``chunk``
+        events. Validation happens once the provider stream finishes, or once a
+        complete JSON payload has been observed and no further non-whitespace
+        content arrives. Failed attempts yield a ``retry`` event before the
+        corrective prompt is sent.
+        """
+
+        attempts: list[StructuredOutputAttempt] = []
+        current_prompt = prompt
+        last_error: Exception | None = None
+
+        for attempt_number in range(1, self.retry_strategy.max_attempts + 1):
+            llm, model_override = self._select_llm(attempt_number)
+            started = time.perf_counter()
+            buffer = IncrementalJSONBuffer()
+
+            async for chunk in self._stream_text(llm, current_prompt, model_override):
+                buffer.append(chunk)
+                yield StructuredOutputStreamEvent(
+                    type="chunk",
+                    content=chunk,
+                    attempt=attempt_number,
+                )
+
+            raw_output = buffer.text
+            duration_ms = (time.perf_counter() - started) * 1000
+
+            try:
+                output = self._validate_raw(raw_output)
+            except (JSONDecodeError, ValidationError) as exc:
+                last_error = exc
+                attempt = await self._record_attempt(
+                    llm=llm,
+                    model_override=model_override,
+                    attempt_number=attempt_number,
+                    prompt=current_prompt,
+                    raw_output=raw_output,
+                    success=False,
+                    error=exc,
+                    duration_ms=duration_ms,
+                    streamed=True,
+                )
+                attempts.append(attempt)
+                if attempt_number >= self.retry_strategy.max_attempts:
+                    break
+
+                current_prompt = self.corrective_prompt_builder(
+                    prompt, self.schema, raw_output, _format_validation_error(exc)
+                )
+                yield StructuredOutputStreamEvent(
+                    type="retry",
+                    content=current_prompt,
+                    metadata=_build_metadata(attempts),
+                    attempt=attempt_number + 1,
+                )
+                await self._sleep_before_retry(attempt_number)
+                continue
+
+            attempt = await self._record_attempt(
+                llm=llm,
+                model_override=model_override,
+                attempt_number=attempt_number,
+                prompt=current_prompt,
+                raw_output=raw_output,
+                success=True,
+                error=None,
+                duration_ms=duration_ms,
+                streamed=True,
+            )
+            attempts.append(attempt)
+            metadata = _build_metadata(attempts)
+            yield StructuredOutputStreamEvent(
+                type="result",
+                output=output,
+                metadata=metadata,
+                attempt=attempt_number,
+            )
+            return
+
+        assert last_error is not None
+        raise StructuredOutputValidationError(
+            "LLM response did not match the requested structured output schema",
+            attempts=attempts,
+            last_error=last_error,
+        )
+
+    async def _generate_with_retry(
+        self, prompt: str, *, streamed: bool
+    ) -> tuple[StructuredOutputResult[SchemaT], list[StructuredOutputAttempt]]:
+        attempts: list[StructuredOutputAttempt] = []
+        current_prompt = prompt
+        last_error: Exception | None = None
+
+        for attempt_number in range(1, self.retry_strategy.max_attempts + 1):
+            llm, model_override = self._select_llm(attempt_number)
+            started = time.perf_counter()
+            raw_output = await self._call_text(llm, current_prompt, model_override)
+            duration_ms = (time.perf_counter() - started) * 1000
+
+            try:
+                output = self._validate_raw(raw_output)
+            except (JSONDecodeError, ValidationError) as exc:
+                last_error = exc
+                attempt = await self._record_attempt(
+                    llm=llm,
+                    model_override=model_override,
+                    attempt_number=attempt_number,
+                    prompt=current_prompt,
+                    raw_output=raw_output,
+                    success=False,
+                    error=exc,
+                    duration_ms=duration_ms,
+                    streamed=streamed,
+                )
+                attempts.append(attempt)
+                if attempt_number >= self.retry_strategy.max_attempts:
+                    break
+
+                current_prompt = self.corrective_prompt_builder(
+                    prompt, self.schema, raw_output, _format_validation_error(exc)
+                )
+                await self._sleep_before_retry(attempt_number)
+                continue
+
+            attempt = await self._record_attempt(
+                llm=llm,
+                model_override=model_override,
+                attempt_number=attempt_number,
+                prompt=current_prompt,
+                raw_output=raw_output,
+                success=True,
+                error=None,
+                duration_ms=duration_ms,
+                streamed=streamed,
+            )
+            attempts.append(attempt)
+            metadata = _build_metadata(attempts)
+            return (
+                StructuredOutputResult(
+                    output=output,
+                    raw_output=raw_output,
+                    attempts=attempts,
+                    metadata=metadata,
+                ),
+                attempts,
+            )
+
+        assert last_error is not None
+        raise StructuredOutputValidationError(
+            "LLM response did not match the requested structured output schema",
+            attempts=attempts,
+            last_error=last_error,
+        )
+
+    def _select_llm(self, attempt_number: int) -> tuple[Any, str | None]:
+        strategy = self.retry_strategy
+        use_fallback = attempt_number >= strategy.fallback_after_attempt
+        if use_fallback and strategy.fallback_provider is not None:
+            return strategy.fallback_provider, strategy.fallback_model
+        if use_fallback and strategy.fallback_model is not None:
+            return self.llm, strategy.fallback_model
+        return self.llm, None
+
+    async def _call_text(self, llm: Any, prompt: str, model_override: str | None) -> str:
+        method = _find_generation_method(llm)
+        response = await _invoke_provider(method, prompt, model_override)
+        return _coerce_text(response)
+
+    async def _stream_text(
+        self, llm: Any, prompt: str, model_override: str | None
+    ) -> AsyncIterator[str]:
+        stream_method = getattr(llm, "stream", None)
+        if callable(stream_method):
+            stream = _invoke_provider(stream_method, prompt, model_override)
+            stream = await stream if inspect.isawaitable(stream) else stream
+            async for chunk in _aiter(stream):
+                yield _coerce_text(chunk)
+            return
+
+        yield await self._call_text(llm, prompt, model_override)
+
+    def _validate_raw(self, raw_output: str) -> SchemaT:
+        data = json.loads(raw_output)
+        return self.schema.model_validate(data)  # type: ignore[attr-defined,no-any-return]
+
+    async def _record_attempt(
+        self,
+        *,
+        llm: Any,
+        model_override: str | None,
+        attempt_number: int,
+        prompt: str,
+        raw_output: str,
+        success: bool,
+        error: Exception | None,
+        duration_ms: float,
+        streamed: bool,
+    ) -> StructuredOutputAttempt:
+        prompt_tokens = _estimate_tokens(prompt)
+        completion_tokens = _estimate_tokens(raw_output)
+        attempt = StructuredOutputAttempt(
+            attempt=attempt_number,
+            provider=_provider_name(llm),
+            model=model_override or _model_name(llm),
+            prompt=prompt,
+            raw_output=raw_output,
+            success=success,
+            streamed=streamed,
+            error_type=type(error).__name__ if error else None,
+            error_message=_format_validation_error(error) if error else None,
+            duration_ms=duration_ms,
+            prompt_tokens_estimate=prompt_tokens,
+            completion_tokens_estimate=completion_tokens,
+        )
+        tracker = self.cost_tracker or getattr(llm, "cost_tracker", None)
+        if tracker is not None:
+            attempt.cost_metadata = await _record_cost_tracker_attempt(
+                tracker,
+                attempt,
+                operation="structured_output",
+                schema_name=self.schema.__name__,
+            )
+        return attempt
+
+    async def _sleep_before_retry(self, failed_attempt_number: int) -> None:
+        base = self.retry_strategy.backoff_seconds
+        if base == 0:
+            return
+        delay = base * (self.retry_strategy.backoff_multiplier ** (failed_attempt_number - 1))
+        await asyncio.sleep(delay)
+
+
+def structured_output(
+    llm: Any,
+    schema: type[SchemaT],
+    *,
+    retry_strategy: StructuredOutputRetryStrategy | None = None,
+    cost_tracker: Any | None = None,
+) -> StructuredOutput[SchemaT]:
+    """Convenience factory for ``StructuredOutput``."""
+
+    return StructuredOutput(
+        llm,
+        schema,
+        retry_strategy=retry_strategy,
+        cost_tracker=cost_tracker,
+    )
+
+
+def build_corrective_prompt(
+    original_prompt: str,
+    schema: type[SchemaT],
+    previous_output: str,
+    validation_error: str,
+) -> str:
+    """Build the default corrective prompt for a failed validation attempt."""
+
+    schema_json = json.dumps(schema.model_json_schema(), indent=2, sort_keys=True)  # type: ignore[attr-defined]
+    return (
+        "Your previous response could not be parsed as the requested structured "
+        "output.\n\n"
+        "Return only a complete JSON value that conforms to this JSON Schema. "
+        "Do not include markdown fences, prose, comments, or trailing text.\n\n"
+        f"Schema name: {schema.__name__}\n"
+        f"JSON Schema:\n{schema_json}\n\n"
+        f"Validation error:\n{validation_error}\n\n"
+        f"Previous response:\n{_truncate(previous_output, limit=4000)}\n\n"
+        f"Original prompt:\n{original_prompt}"
+    )
+
+
+async def _record_cost_tracker_attempt(
+    tracker: Any,
+    attempt: StructuredOutputAttempt,
+    *,
+    operation: str,
+    schema_name: str,
+) -> dict[str, Any]:
+    record = {
+        "operation": operation,
+        "schema_name": schema_name,
+        "attempt": attempt.attempt,
+        "provider": attempt.provider,
+        "model": attempt.model,
+        "prompt": attempt.prompt,
+        "completion": attempt.raw_output,
+        "prompt_tokens": attempt.prompt_tokens_estimate,
+        "completion_tokens": attempt.completion_tokens_estimate,
+        "input_tokens": attempt.prompt_tokens_estimate,
+        "output_tokens": attempt.completion_tokens_estimate,
+        "total_tokens": (attempt.prompt_tokens_estimate + attempt.completion_tokens_estimate),
+        "cost_usd": 0.0,
+        "success": attempt.success,
+        "metadata": {
+            "structured_output": True,
+            "streamed": attempt.streamed,
+            "error_type": attempt.error_type,
+            "error_message": attempt.error_message,
+        },
+    }
+
+    for method_name in (
+        "record_attempt",
+        "record_llm_call",
+        "record_call",
+        "track_call",
+        "track",
+        "add",
+    ):
+        method = getattr(tracker, method_name, None)
+        if not callable(method):
+            continue
+        try:
+            result = await _invoke_tracker_method(method, record)
+        except TypeError:
+            continue
+        return _serialize_tracker_result(result)
+
+    calls = getattr(tracker, "calls", None)
+    if isinstance(calls, list):
+        calls.append(record)
+        return {"recorded": True, "method": "calls.append"}
+
+    attempts = getattr(tracker, "attempts", None)
+    if isinstance(attempts, list):
+        attempts.append(record)
+        return {"recorded": True, "method": "attempts.append"}
+
+    return {"recorded": False, "reason": "no compatible CostTracker hook found"}
+
+
+async def _invoke_tracker_method(method: Callable[..., Any], record: dict[str, Any]) -> Any:
+    try:
+        signature = inspect.signature(method)
+    except (TypeError, ValueError):
+        result = method(record)
+        return await result if inspect.isawaitable(result) else result
+
+    params = signature.parameters
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()):
+        result = method(**record)
+        return await result if inspect.isawaitable(result) else result
+
+    kwargs: dict[str, Any] = {}
+    for name, param in params.items():
+        if name == "self":
+            continue
+        if name in record:
+            kwargs[name] = record[name]
+        elif param.default is inspect.Parameter.empty:
+            kwargs = {}
+            break
+
+    if kwargs:
+        result = method(**kwargs)
+    else:
+        positional = [
+            param
+            for param in params.values()
+            if param.kind
+            in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+            and param.default is inspect.Parameter.empty
+            and param.name != "self"
+        ]
+        if len(positional) <= 1:
+            result = method(record)
+        else:
+            raise TypeError("CostTracker method signature is not compatible")
+
+    return await result if inspect.isawaitable(result) else result
+
+
+def _serialize_tracker_result(result: Any) -> dict[str, Any]:
+    if result is None:
+        return {"recorded": True}
+    if isinstance(result, dict):
+        return cast(dict[str, Any], result)
+    if hasattr(result, "model_dump"):
+        return cast(dict[str, Any], result.model_dump())
+    if hasattr(result, "__dict__"):
+        return cast(dict[str, Any], dict(result.__dict__))
+    return {"recorded": True, "result": repr(result)}
+
+
+async def _invoke_provider(
+    method: Callable[..., Any], prompt: str, model_override: str | None
+) -> Any:
+    kwargs = _provider_kwargs(method, model_override)
+    result = method(prompt, **kwargs)
+    return await result if inspect.isawaitable(result) else result
+
+
+def _provider_kwargs(method: Callable[..., Any], model_override: str | None) -> dict[str, Any]:
+    if model_override is None:
+        return {}
+    try:
+        signature = inspect.signature(method)
+    except (TypeError, ValueError):
+        return {}
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()):
+        return {"model": model_override}
+    if "model" in signature.parameters:
+        return {"model": model_override}
+    if "model_name" in signature.parameters:
+        return {"model_name": model_override}
+    return {}
+
+
+def _find_generation_method(llm: Any) -> Callable[..., Any]:
+    for name in ("ask", "generate", "complete", "predict"):
+        method = getattr(llm, name, None)
+        if callable(method):
+            return cast(Callable[..., Any], method)
+    if callable(llm):
+        return cast(Callable[..., Any], llm)
+    raise TypeError(
+        "StructuredOutput requires an LLM/provider with ask(), generate(), "
+        "complete(), predict(), stream(), or __call__()."
+    )
+
+
+async def _aiter(value: Any) -> AsyncIterator[Any]:
+    if hasattr(value, "__aiter__"):
+        async for item in value:
+            yield item
+        return
+    if isinstance(value, Iterable):
+        for item in value:
+            yield item
+        return
+    raise TypeError("Provider stream() must return an async or sync iterable")
+
+
+def _coerce_text(response: Any) -> str:
+    if response is None:
+        return ""
+    if isinstance(response, str):
+        return response
+    for attr in ("content", "text", "message", "delta"):
+        value = getattr(response, attr, None)
+        if isinstance(value, str):
+            return value
+    if isinstance(response, dict):
+        for key in ("content", "text", "message", "delta"):
+            value = response.get(key)
+            if isinstance(value, str):
+                return value
+    return str(response)
+
+
+def _ensure_pydantic_schema(schema: type[Any]) -> None:
+    if _PYDANTIC_IMPORT_ERROR is not None:
+        raise ImportError(
+            "StructuredOutput requires pydantic>=2. Install SynapseKit with the "
+            "appropriate extra or add pydantic to your environment."
+        ) from _PYDANTIC_IMPORT_ERROR
+    if not inspect.isclass(schema) or not issubclass(schema, BaseModel):
+        raise TypeError("schema must be a Pydantic BaseModel subclass")
+    if not hasattr(schema, "model_validate") or not hasattr(schema, "model_json_schema"):
+        raise TypeError("schema must be a Pydantic v2 BaseModel subclass")
+
+
+def _format_validation_error(error: Exception | None) -> str:
+    if error is None:
+        return ""
+    if hasattr(error, "errors"):
+        try:
+            return json.dumps(error.errors(), indent=2, sort_keys=True)
+        except Exception:
+            pass
+    return str(error)
+
+
+def _build_metadata(attempts: list[StructuredOutputAttempt]) -> dict[str, Any]:
+    prompt_tokens = sum(attempt.prompt_tokens_estimate for attempt in attempts)
+    completion_tokens = sum(attempt.completion_tokens_estimate for attempt in attempts)
+    return {
+        "structured_output": {
+            "attempt_count": len(attempts),
+            "success": bool(attempts and attempts[-1].success),
+            "attempts": [attempt.to_metadata() for attempt in attempts],
+            "total_prompt_tokens_estimate": prompt_tokens,
+            "total_completion_tokens_estimate": completion_tokens,
+            "total_tokens_estimate": prompt_tokens + completion_tokens,
+        }
+    }
+
+
+def _provider_name(llm: Any) -> str:
+    provider = getattr(llm, "provider", None) or getattr(llm, "provider_name", None)
+    if provider:
+        return str(provider)
+    name = str(llm.__class__.__name__)
+    return name[:-3] if name.lower().endswith("llm") else name
+
+
+def _model_name(llm: Any) -> str | None:
+    for attr in ("model", "model_name", "model_id", "deployment", "engine"):
+        value = getattr(llm, attr, None)
+        if value is not None:
+            return str(value)
+    return None
+
+
+def _estimate_tokens(text: str) -> int:
+    if not text:
+        return 0
+    return max(1, len(text.split()))
+
+
+def _truncate(text: str, *, limit: int = 1000) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 15] + "...<truncated>"
+
+
+__all__ = [
+    "IncrementalJSONBuffer",
+    "StructuredOutput",
+    "StructuredOutputAttempt",
+    "StructuredOutputError",
+    "StructuredOutputResult",
+    "StructuredOutputRetryStrategy",
+    "StructuredOutputStreamEvent",
+    "StructuredOutputValidationError",
+    "build_corrective_prompt",
+    "structured_output",
+]

--- a/src/synapsekit/structured_output.py
+++ b/src/synapsekit/structured_output.py
@@ -8,7 +8,6 @@ import json
 import time
 from collections.abc import AsyncIterator, Callable, Iterable
 from dataclasses import asdict, dataclass, field
-from json import JSONDecodeError
 from typing import Any, Generic, TypeVar, cast
 
 try:  # Pydantic is optional until this module is used.
@@ -139,7 +138,7 @@ class IncrementalJSONBuffer:
 
         try:
             _, end = self._decoder.raw_decode(stripped)
-        except JSONDecodeError:
+        except json.JSONDecodeError:
             self.complete = False
             return False
 
@@ -215,7 +214,7 @@ class StructuredOutput(Generic[SchemaT]):
 
             try:
                 output = self._validate_raw(raw_output)
-            except (JSONDecodeError, ValidationError) as exc:
+            except (json.JSONDecodeError, ValidationError) as exc:
                 last_error = exc
                 attempt = await self._record_attempt(
                     llm=llm,
@@ -287,7 +286,7 @@ class StructuredOutput(Generic[SchemaT]):
 
             try:
                 output = self._validate_raw(raw_output)
-            except (JSONDecodeError, ValidationError) as exc:
+            except (json.JSONDecodeError, ValidationError) as exc:
                 last_error = exc
                 attempt = await self._record_attempt(
                     llm=llm,

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -1,0 +1,211 @@
+import asyncio
+
+import pytest
+from pydantic import BaseModel
+
+from synapsekit.structured_output import (
+    StructuredOutput,
+    StructuredOutputRetryStrategy,
+    StructuredOutputValidationError,
+    build_corrective_prompt,
+)
+
+
+class DocumentSummary(BaseModel):
+    title: str
+    page_count: int
+
+
+class FakeLLM:
+    provider = "fake"
+    model = "fake-primary"
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.prompts = []
+
+    async def ask(self, prompt):
+        self.prompts.append(prompt)
+        return self.responses.pop(0)
+
+
+class FakeStreamingLLM(FakeLLM):
+    async def stream(self, prompt):
+        self.prompts.append(prompt)
+        response = self.responses.pop(0)
+        for chunk in response:
+            yield chunk
+
+
+class FakeCostTracker:
+    def __init__(self):
+        self.records = []
+
+    def record_call(self, **kwargs):
+        self.records.append(kwargs)
+        return {"recorded": True, "record_index": len(self.records)}
+
+
+def test_retries_after_json_decode_error_and_records_cost():
+    llm = FakeLLM(
+        [
+            "not json",
+            '{"title": "Board report", "page_count": 12}',
+        ]
+    )
+    tracker = FakeCostTracker()
+    structured = StructuredOutput(
+        llm,
+        DocumentSummary,
+        retry_strategy=StructuredOutputRetryStrategy(max_attempts=2),
+        cost_tracker=tracker,
+    )
+
+    result = asyncio.run(structured.generate("Extract the document summary."))
+
+    assert result.output == DocumentSummary(title="Board report", page_count=12)
+    assert len(result.attempts) == 2
+    assert result.metadata["structured_output"]["attempt_count"] == 2
+    assert len(tracker.records) == 2
+    assert tracker.records[0]["operation"] == "structured_output"
+    assert "JSON Schema" in llm.prompts[1]
+    assert "Validation error" in llm.prompts[1]
+    assert "Expecting value" in llm.prompts[1]
+    assert "Previous response" in llm.prompts[1]
+    assert "not json" in llm.prompts[1]
+
+
+def test_retries_after_pydantic_validation_error_with_schema_context():
+    llm = FakeLLM(
+        [
+            '{"title": "Board report", "page_count": "many"}',
+            '{"title": "Board report", "page_count": 12}',
+        ]
+    )
+    structured = StructuredOutput(
+        llm,
+        DocumentSummary,
+        retry_strategy=StructuredOutputRetryStrategy(max_attempts=2),
+    )
+
+    result = asyncio.run(structured.generate("Extract the document summary."))
+
+    assert result.output.page_count == 12
+    corrective_prompt = llm.prompts[1]
+    assert "DocumentSummary" in corrective_prompt
+    assert "page_count" in corrective_prompt
+    assert "int_parsing" in corrective_prompt
+    assert '{"title": "Board report", "page_count": "many"}' in corrective_prompt
+
+
+def test_uses_fallback_provider_for_retry_attempts():
+    primary = FakeLLM(["not json"])
+    fallback = FakeLLM(['{"title": "Fallback report", "page_count": 3}'])
+    fallback.provider = "fallback"
+    fallback.model = "fallback-model"
+
+    structured = StructuredOutput(
+        primary,
+        DocumentSummary,
+        retry_strategy=StructuredOutputRetryStrategy(
+            max_attempts=2,
+            fallback_provider=fallback,
+            fallback_after_attempt=2,
+        ),
+    )
+
+    result = asyncio.run(structured.generate("Extract the document summary."))
+
+    assert result.output.title == "Fallback report"
+    assert len(primary.prompts) == 1
+    assert len(fallback.prompts) == 1
+    assert result.attempts[1].provider == "fallback"
+    assert result.attempts[1].model == "fallback-model"
+
+
+def test_stream_buffers_chunks_and_yields_validated_result():
+    llm = FakeStreamingLLM(
+        [
+            ['{"title": ', '"Streamed report"', ', "page_count": 8}'],
+        ]
+    )
+    structured = StructuredOutput(
+        llm,
+        DocumentSummary,
+        retry_strategy=StructuredOutputRetryStrategy(max_attempts=1),
+    )
+
+    async def collect():
+        return [event async for event in structured.stream("Extract summary.")]
+
+    events = asyncio.run(collect())
+
+    chunks = [event.content for event in events if event.type == "chunk"]
+    result_events = [event for event in events if event.type == "result"]
+    assert chunks == ['{"title": ', '"Streamed report"', ', "page_count": 8}']
+    assert len(result_events) == 1
+    assert result_events[0].output == DocumentSummary(
+        title="Streamed report",
+        page_count=8,
+    )
+    assert result_events[0].metadata["structured_output"]["attempt_count"] == 1
+
+
+def test_stream_retries_with_corrective_prompt():
+    llm = FakeStreamingLLM(
+        [
+            ["not ", "json"],
+            ['{"title": "Recovered", "page_count": 2}'],
+        ]
+    )
+    structured = StructuredOutput(
+        llm,
+        DocumentSummary,
+        retry_strategy=StructuredOutputRetryStrategy(max_attempts=2),
+    )
+
+    async def collect():
+        events = []
+        async for event in structured.stream("Extract summary."):
+            events.append(event)
+        return events
+
+    events = asyncio.run(collect())
+
+    retry_events = [event for event in events if event.type == "retry"]
+    result_events = [event for event in events if event.type == "result"]
+    assert len(retry_events) == 1
+    assert "JSON Schema" in retry_events[0].content
+    assert "not json" in retry_events[0].content
+    assert result_events[0].output.title == "Recovered"
+    assert len(llm.prompts) == 2
+
+
+def test_raises_with_attempt_metadata_after_exhaustion():
+    llm = FakeLLM(["not json"])
+    structured = StructuredOutput(
+        llm,
+        DocumentSummary,
+        retry_strategy=StructuredOutputRetryStrategy(max_attempts=1),
+    )
+
+    with pytest.raises(StructuredOutputValidationError) as exc_info:
+        asyncio.run(structured.generate("Extract summary."))
+
+    assert len(exc_info.value.attempts) == 1
+    assert exc_info.value.metadata["structured_output"]["success"] is False
+
+
+def test_build_corrective_prompt_mentions_schema_and_error():
+    prompt = build_corrective_prompt(
+        "Extract summary.",
+        DocumentSummary,
+        "bad",
+        "page_count is required",
+    )
+
+    assert "DocumentSummary" in prompt
+    assert "JSON Schema" in prompt
+    assert "page_count is required" in prompt
+    assert "bad" in prompt
+    assert "Extract summary." in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -359,6 +359,75 @@ wheels = [
 ]
 
 [[package]]
+name = "asv"
+version = "0.6.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asv-runner" },
+    { name = "build" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "importlib-metadata" },
+    { name = "json5" },
+    { name = "packaging" },
+    { name = "pympler", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "pyyaml", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "tabulate" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/50/f762be4ee8632d88aff4ba9e62e7c156a0684ef52db629c22bae24fda449/asv-0.6.5.tar.gz", hash = "sha256:a8eeb7c5037cd78c146bd727d27203132438d4d62f36e669eb0cd5d63da0cf39", size = 402650, upload-time = "2025-09-13T16:25:48.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/84/6db5430f169d42c72a92851a7491f868a593351bb41eafb3ed7d7c53140f/asv-0.6.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0174f8f1b8a0c8db4df44ae923f128f64951604489adca2282add143c4996d33", size = 180214, upload-time = "2025-09-13T16:23:58.384Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/af/defaf2f0ccc139deea6715fc252f39bd20d83c850dac77d4d27a429d43d7/asv-0.6.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5408856baf761e2520da08b40e854d33915a3d59c2b8187c9d510d570eee1df2", size = 180507, upload-time = "2025-09-13T16:24:00.561Z" },
+    { url = "https://files.pythonhosted.org/packages/20/cc/f2cf0f562e6cfc60f761c247510984321030a60e67a1578189f5793b5646/asv-0.6.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a998342b9f8f74f10324dddcb90554872cf3458a7ce6c8c3e96267c087a3459", size = 253792, upload-time = "2025-09-13T16:24:02.671Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/b4/1ce9b980728844fececcbcde487c24b5e130ec90c964e4fb0e19328f8817/asv-0.6.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4dad86244253438bffc8b1a8f941e48be1bf06e61fb51b3512102dd52dc6717b", size = 255498, upload-time = "2025-09-13T16:24:05.179Z" },
+    { url = "https://files.pythonhosted.org/packages/70/12/67e0aba3248b92c7c48225f30a56ae783aa6c593a7f198551376321dc93f/asv-0.6.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0a0068a12760e952741fd88050164658867258ccf5df5ee380e8b871cc6c6666", size = 806724, upload-time = "2025-09-13T16:24:08.008Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4c/8d07c5b94763a687046b349e4cffe7df7c2b2ce14421ec22d9e3eee6c113/asv-0.6.5-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:a1272609150c74144c86bc243a050eff63581fe906987b9b931abcaf26c65ca0", size = 1384071, upload-time = "2025-09-13T16:24:11.477Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/cc/3dda985fcf4e2bb940f7c574988f71f4b1fbb8d68d8a6c22a2b3c908f6be/asv-0.6.5-cp310-cp310-win_amd64.whl", hash = "sha256:ce0a6e834a4c30f2b567eb59c7189831bb0c2b345d5b92376b69b0def020f691", size = 182794, upload-time = "2025-09-13T16:24:13.771Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/95/27569d3f5077153911863207c2d1f96ea8b21ef7e9f8bc969dfac29d65f7/asv-0.6.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cfc6e195f51d83060458f443155adf8b968d73520c63d0c28c72f30be8d58858", size = 180216, upload-time = "2025-09-13T16:24:15.452Z" },
+    { url = "https://files.pythonhosted.org/packages/68/92/293280069e6cb7b670c72760edef05ef7e8fd2c77837d077c01b8d7b0448/asv-0.6.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:816a420666f39980e75b4dd58545a0702474811087b8c933dd14fb9f0cac5dd6", size = 180511, upload-time = "2025-09-13T16:24:17.144Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/aa/42e55241325cd03b489105206919dd56351f6b55113dd844ce0cba8b0d5c/asv-0.6.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5bba7568ca5c72e1d980746925c353ac9e76d46329fc324ed43778f91c5c00a1", size = 254428, upload-time = "2025-09-13T16:24:19.157Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/b6/271d74413393b886b073dc4aa5dbb698426cf8e4f6774555969a70921595/asv-0.6.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2d423f671f671f6ae5dd2a6912c64130ed374d01dfe2c3d05a6a5307cc47d5ed", size = 256087, upload-time = "2025-09-13T16:24:20.41Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3d/bddea222ad0141f4ae4b24ba406ebfd13ab1637a50c60407c13d5ec9e090/asv-0.6.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4d82cc4e95530ce386c0280d84586b6358a7e73b6bb6d814b35734c2d49cc43a", size = 808082, upload-time = "2025-09-13T16:24:22.048Z" },
+    { url = "https://files.pythonhosted.org/packages/08/11/8199376b9df37457c2a59a55e7f43f501f3c44cb54279dc5307f4966f666/asv-0.6.5-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7911132aab8263751946ff79d9b75d1178ec278d2731f09d6d14ef4f26842c70", size = 1384612, upload-time = "2025-09-13T16:24:24.38Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/47/3aceb8c4ca6d91e00b3fa6c6312580958791407034b0afd588f66dc6690e/asv-0.6.5-cp311-cp311-win_amd64.whl", hash = "sha256:48fba7264d348b932fd4d2f42b6128836347d46af3d61df0c9d641bc61678af8", size = 182792, upload-time = "2025-09-13T16:24:26.124Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/58/3c94d6043f2d815480b873f302ecda3b9debb0f202556fd822b118e87415/asv-0.6.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:375da7109fa160d41e4b86a5de7783e8c9bc9f1c930a1c02c29b652b15d46835", size = 180231, upload-time = "2025-09-13T16:24:27.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/75/2a23346aabb19698e97b7ee8f57eb905dabf7460b226a2070c6cdd3e8c17/asv-0.6.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:980cb8e9c3be5350621c85201bfb25f70c26695f69bd4e91b19f1b3c97f00ff3", size = 180531, upload-time = "2025-09-13T16:24:28.693Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d3/22bc22619266bced0a53ff07ee94a41bb09fed2bbe505e07a146fc4c1a58/asv-0.6.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13f503d45077ba275d357a9712fe1506b98e507eb276ca01e981c9e5baf30b43", size = 254851, upload-time = "2025-09-13T16:24:30.035Z" },
+    { url = "https://files.pythonhosted.org/packages/de/70/9991371db795a84b4fb0774ff050ed48730c14568953f9f59ca35170541b/asv-0.6.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:440aca773d254f6590f7a459bdc388441027bc2745eae644675665acc3809c2e", size = 256342, upload-time = "2025-09-13T16:24:31.309Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1d/7cb7f02091908201c45c609d29ced5bbc1101a057edc0e1fb153f7592b4e/asv-0.6.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bf63f7ee3d35ec8191543d82ca3a3be3a3c0cde8eb2d45a672f09f32ba5fbb37", size = 807867, upload-time = "2025-09-13T16:24:33.298Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/02/946c53292fe551b3bb977260f29b5bfa9f284bf17088ccef5c8ddf28f06c/asv-0.6.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:58a0d2de09ebc67642b661d904d2e686e0f32bb5e8b4867523a15ff7561f061a", size = 1384841, upload-time = "2025-09-13T16:24:34.857Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f7/b43efa62f20af7e9035f6fd6dadb7109feddfb4e0b1e2ff791656ae55606/asv-0.6.5-cp312-cp312-win_amd64.whl", hash = "sha256:8df71cd3c656680051e0d0b2834521f7ab6da3d4804c48354c0e5ca341a0a39e", size = 182804, upload-time = "2025-09-13T16:24:36.135Z" },
+    { url = "https://files.pythonhosted.org/packages/25/70/a00673c98d30de3377b036cd85247274330ade931c0e4909c3e2d269c0c6/asv-0.6.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bedfc7f0138ab136ccd67f42575dd4b2471c811239ad8c7b7aabc83f5eba79c3", size = 180236, upload-time = "2025-09-13T16:24:37.775Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/fd/d2f5c43dcb614cfedd1f339feb2f711b0a69e7c2ad96d68b547d44227c80/asv-0.6.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2f062e0658e568b98154afe11d91b5fb631f884678b7ad4a00ebcc0d6aa6b41f", size = 180537, upload-time = "2025-09-13T16:24:39.396Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/00/a8dba759f554e6aedc5a7caf2a8efd00e5c69536560c670b1f41e7b53d83/asv-0.6.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6caedcca3ec60602b907caeab54d1706abb12e088ce96650862c6fc117831cc0", size = 254761, upload-time = "2025-09-13T16:24:41.262Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/bd/89c4483e1e781e39957547d7bda0a7a7af338911ea159cd66a9415cc811d/asv-0.6.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:861ae69bfdd8659f95a058891c98757d3a5f857bf0ddc5d810e0dabf3405042e", size = 256267, upload-time = "2025-09-13T16:24:43.033Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f1/752a51a07be0c153281f04795433524c76e6926063da005b78e2053117c5/asv-0.6.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:7344c0020c1ab1cb33af9626cf24e05c346b4fd521d4f866f35a7a9a276f8e16", size = 806346, upload-time = "2025-09-13T16:24:45.123Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ce/c6d9f2dc42462db7897178e21e38c925d8efb75813dde8e7a0a2e5126387/asv-0.6.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1279a92cd8a601d2be5430afe3dd9f942ab0e6003f33ff1914dd9f638b595a3d", size = 1384779, upload-time = "2025-09-13T16:24:46.758Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/4f/48af74f756f1c67b71074c99f265d382927de742288cf416e212c1808c7d/asv-0.6.5-cp313-cp313-win_amd64.whl", hash = "sha256:dbc3269464ec27d025d3b25e0e1f3d616035e05e01bcfceb2f4e965278d72197", size = 182807, upload-time = "2025-09-13T16:24:47.978Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a1/722271d6b4d7756a71a425deaa4c57e1341f84c153765cd432e001885388/asv-0.6.5-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:bacb55e91562d5c8aa1ec63393db8cd5faac15be20133f9b5b538453341604a7", size = 179850, upload-time = "2025-09-13T16:25:19.183Z" },
+    { url = "https://files.pythonhosted.org/packages/44/8d/14b0691728311e295ef7d22dc08782eb02ef79e080a748a37c22e26bda45/asv-0.6.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bd9d0476ed9712252b933a27b29e0208b68c0909f0ff512f9c95cc1112def49", size = 179470, upload-time = "2025-09-13T16:25:20.407Z" },
+    { url = "https://files.pythonhosted.org/packages/63/19/ecd112b688913b406772c919c64da9d3345747cf127cb967cff8d83bc591/asv-0.6.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dca4988cee5bdb2aa7552a123fe1e405574d1e67fa084bde25c32d93f329462a", size = 180233, upload-time = "2025-09-13T16:25:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6d/b89b6b240e43375025363e6f68ea1ea2e59db832fe5a22e5a22b4718b0ac/asv-0.6.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:43b25126ca1a8620887be80caa1e826e79224277fc637e31ad6cacd38b6a81a9", size = 182887, upload-time = "2025-09-13T16:25:23.052Z" },
+    { url = "https://files.pythonhosted.org/packages/35/78/ee6ad8ca4de3ad89e382f7fd45eabcfecfcd6dca844462706a8aa1f8d895/asv-0.6.5-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:5204d6e4c9d574a9f8dd9b3834c3385b8b118d48ce4fcb3bc10b61f60de287fd", size = 179852, upload-time = "2025-09-13T16:25:24.263Z" },
+    { url = "https://files.pythonhosted.org/packages/de/24/22a85656df00f64ceb1bc7c4a5a358a3990410cd9a96c48486fc2c13bdaf/asv-0.6.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c419db85e40ca1cebefbe8bd5f338a16cbc5f7a2cbf2de0793f95d6bda9ede6c", size = 179470, upload-time = "2025-09-13T16:25:25.76Z" },
+    { url = "https://files.pythonhosted.org/packages/33/28/30a5571658ab4cd0f8ba616afad7782ed7ad82e04a7b6eda77e480abf174/asv-0.6.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:80a76dc32330c97bfba861c547dd17bcc04811946f386e00c8c7dfbb12354280", size = 180233, upload-time = "2025-09-13T16:25:27.158Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/d6/04875bb5abf2c6b8390d63e0ff45dc0a5c6413377be975b9e825150c7d75/asv-0.6.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:0f26006545918b9a2fb78323823bc4f9fa8bad628fc2aae5bd77d41f58fa61ac", size = 182887, upload-time = "2025-09-13T16:25:28.58Z" },
+]
+
+[[package]]
+name = "asv-runner"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/4b/da5ae9c35e0b9f793d07d4939ad99e1d2ba7c9c502fd6074af5ff4554b03/asv_runner-0.2.1.tar.gz", hash = "sha256:945dd301a06fa9102f221b1e9ddd048f5ecd863796d4c8cd487f5577fe0db66d", size = 39518, upload-time = "2024-02-17T14:11:48.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/9a/6872af94fc8e8072723946651e65f66e16a0ca0efec7806bce8c2e2483d1/asv_runner-0.2.1-py3-none-any.whl", hash = "sha256:655d466208ce311768071f5003a61611481b24b3ad5ac41fb8a6374197e647e9", size = 47660, upload-time = "2024-02-11T21:50:07.026Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3408,6 +3477,15 @@ wheels = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/4b/6f8906aaf67d501e259b0adab4d312945bb7211e8b8d4dcc77c92320edaa/json5-0.14.0.tar.gz", hash = "sha256:b3f492fad9f6cdbced8b7d40b28b9b1c9701c5f561bef0d33b81c2ff433fefcb", size = 52656, upload-time = "2026-03-27T22:50:48.108Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/42/cf027b4ac873b076189d935b135397675dac80cb29acb13e1ab86ad6c631/json5-0.14.0-py3-none-any.whl", hash = "sha256:56cf861bab076b1178eb8c92e1311d273a9b9acea2ccc82c276abf839ebaef3a", size = 36271, upload-time = "2026-03-27T22:50:47.073Z" },
+]
+
+[[package]]
 name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
@@ -6170,6 +6248,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "pyairtable"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6723,6 +6810,27 @@ wheels = [
 ]
 
 [[package]]
+name = "pygal"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/b6/04176faeb312c84d7f9bc1a810f96ee38d15597e226bb9bda59f3a5cb122/pygal-3.1.0.tar.gz", hash = "sha256:fbdee7351a7423e7907fb8a9c3b77305f6b5678cb2e6fd0db36a8825e42955ec", size = 81006, upload-time = "2025-12-09T10:29:19.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/4c/2862dd25352fe4b22ec7760d4fa12cb692587cd7ec3e378cbf644fc0d2a8/pygal-3.1.0-py3-none-any.whl", hash = "sha256:4e923490f3490c90c481f4535fa3adcda20ff374257ab9d8ae897f91b632c0bb", size = 130171, upload-time = "2025-12-09T10:29:16.721Z" },
+]
+
+[[package]]
+name = "pygaljs"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/19/3a53f34232a9e6ddad665e71c83693c5db9a31f71785105905c5bc9fbbba/pygaljs-1.0.2.tar.gz", hash = "sha256:0b71ee32495dcba5fbb4a0476ddbba07658ad65f5675e4ad409baf154dec5111", size = 89711, upload-time = "2020-04-03T07:51:44.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/6f/07dab31ca496feda35cf3455b9e9380c43b5c685bb54ad890831c790da38/pygaljs-1.0.2-py2.py3-none-any.whl", hash = "sha256:d75e18cb21cc2cda40c45c3ee690771e5e3d4652bf57206f20137cf475c0dbe8", size = 91111, upload-time = "2020-04-03T07:51:42.658Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -6887,6 +6995,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/15/c7/b5337093bb01da852f945802328665f85f8109dbe91d81ea2afe5ff059b9/pymongo-4.16.0-cp314-cp314t-win32.whl", hash = "sha256:948152b30eddeae8355495f9943a3bf66b708295c0b9b6f467de1c620f215487", size = 1040560, upload-time = "2026-01-07T18:05:23.888Z" },
     { url = "https://files.pythonhosted.org/packages/96/8c/5b448cd1b103f3889d5713dda37304c81020ff88e38a826e8a75ddff4610/pymongo-4.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f6e42c1bc985d9beee884780ae6048790eb4cd565c46251932906bdb1630034a", size = 1075081, upload-time = "2026-01-07T18:05:26.874Z" },
     { url = "https://files.pythonhosted.org/packages/32/cd/ddc794cdc8500f6f28c119c624252fb6dfb19481c6d7ed150f13cf468a6d/pymongo-4.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:6b2a20edb5452ac8daa395890eeb076c570790dfce6b7a44d788af74c2f8cf96", size = 1047725, upload-time = "2026-01-07T18:05:28.47Z" },
+]
+
+[[package]]
+name = "pympler"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/37/c384631908029676d8e7213dd956bb686af303a80db7afbc9be36bc49495/pympler-1.1.tar.gz", hash = "sha256:1eaa867cb8992c218430f1708fdaccda53df064144d1c5656b1e6f1ee6000424", size = 179954, upload-time = "2024-06-28T19:56:06.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/4f/a6a2e2b202d7fd97eadfe90979845b8706676b41cbd3b42ba75adf329d1f/Pympler-1.1-py3-none-any.whl", hash = "sha256:5b223d6027d0619584116a0cbc28e8d2e378f7a79c1e5e024f9ff3b673c58506", size = 165766, upload-time = "2024-06-28T19:56:05.087Z" },
 ]
 
 [[package]]
@@ -9951,6 +10071,26 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
+]
+
+[package.optional-dependencies]
+histogram = [
+    { name = "pygal" },
+    { name = "pygaljs" },
+    { name = "setuptools" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -11839,6 +11979,11 @@ youtube-transcript = [
 ]
 
 [package.dev-dependencies]
+bench = [
+    { name = "asv" },
+    { name = "psutil" },
+    { name = "pytest-benchmark", extra = ["histogram"] },
+]
 dev = [
     { name = "beautifulsoup4" },
     { name = "deptry" },
@@ -12054,6 +12199,11 @@ requires-dist = [
 provides-extras = ["openai", "anthropic", "semantic", "colbert", "pdf", "wikipedia", "arxiv", "html", "web", "chroma", "faiss", "qdrant", "pinecone", "weaviate", "milvus", "lancedb", "sqlite-vec", "cassandra", "clickhouse", "duckdb-vector", "marqo", "opensearch", "vespa", "replicate", "ollama", "lmstudio", "vllm", "ai21", "cohere", "mistral", "gemini", "bedrock", "gcal-tool", "aws-lambda", "rss", "groq", "audio", "video", "voice", "voice-local", "voice-stream", "cron", "excel", "pptx", "docx", "yaml", "teams", "http", "search", "huggingface", "transformers", "tiktoken", "google-search", "tavily", "youtube", "mcp", "redis", "memcached", "vertex", "cloudflare", "aleph-alpha", "llamacpp", "gpt4all", "ernie", "minimax", "serve", "graph-ui", "observe", "postgres", "pgvector", "wolfram", "dynamodb", "discord", "gcs", "bigquery", "gdrive", "git", "gsheets", "jira", "hubspot", "sql", "snowflake", "mongodb", "mongodb-vector", "salesforce", "azure", "s3", "onedrive", "slack", "supabase", "notion", "confluence", "dropbox", "rtf", "epub", "parquet", "elasticsearch", "browser", "youtube-transcript", "airtable", "performance", "all"]
 
 [package.metadata.requires-dev]
+bench = [
+    { name = "asv", specifier = ">=0.6" },
+    { name = "psutil", specifier = ">=5.9" },
+    { name = "pytest-benchmark", extras = ["histogram"], specifier = ">=4.0" },
+]
 dev = [
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "deptry", specifier = ">=0.16" },
@@ -12070,6 +12220,15 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "ruff", specifier = ">=0.9" },
     { name = "tzdata", specifier = ">=2024.1" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add benchmark harness with pytest-benchmark config + smoke benchmark + percentile report
- add ASV config + machine profile for regression tracking
- add CI workflow + Makefile targets for bench/compare

## Testing
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run mypy
- uv run pytest tests/ -v
