### PR TITLE
docs(architecture): add deep-dive document and diagrams (#673)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ CLAUDE.md
 docs/*
 !docs/observability.md
 !docs/evalhub.md
+!docs/architecture/
 
 # Saved vectorstores
 *.npz

--- a/docs/architecture/deep-dive.md
+++ b/docs/architecture/deep-dive.md
@@ -1,0 +1,168 @@
+# Architecture Deep Dive
+
+**SynapseKit v0.9+ — Internal Design Explained**
+
+This document is written for **power users, contributors, and curious engineers** who want to understand how SynapseKit works under the hood.
+
+---
+
+## 1. Async Runtime
+
+SynapseKit is built from the ground up to be **async-first**.
+
+### Core Strategy
+
+```python
+# src/synapsekit/_loop.py
+def install_fast_loop():
+    try:
+        import uvloop
+        uvloop.install()
+    except ImportError:
+        pass
+```
+
+- Uses `uvloop` when available for maximum performance.
+- Falls back gracefully to standard `asyncio`.
+- All public APIs are `async` by default (`await graph.run()`, `await agent.run()`, etc.).
+- Synchronous wrappers (`ask_sync`, `run_sync`) are provided via `run_sync()` utility for convenience.
+
+```python
+# src/synapsekit/_compat.py
+T = TypeVar("T")
+install_fast_loop()
+
+
+def run_sync(coro: Coroutine[Any, Any, T]) -> T:
+    import asyncio
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is not None and loop.is_running():
+        import concurrent.futures
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(asyncio.run, coro)
+            return future.result()
+    else:
+        return asyncio.run(coro)
+```
+
+**Diagram**: `docs/architecture/diagrams/async-runtime.html`
+
+---
+
+## 2. Graph Engine (`StateGraph`)
+
+This is the heart of SynapseKit.
+
+### Builder Pattern
+
+```python
+graph = StateGraph(state_schema=MyState)
+graph.add_node("retrieve", retrieve)
+graph.add_node("generate", generate)
+graph.add_edge("retrieve", "generate")
+graph.set_entry_point("retrieve")
+compiled = graph.compile()
+```
+
+### Compiled Execution Model
+
+The `CompiledGraph` class:
+- Builds an adjacency list for O(1) edge lookup
+- Executes in **waves** — parallel nodes in the same wave run concurrently using `asyncio.gather()`
+- Supports checkpointing, human-in-the-loop (`GraphInterrupt`), and resumability
+- Uses a versioned checkpointing system to support schema migrations
+
+**Diagram**: `docs/architecture/diagrams/graph-engine.html`
+
+---
+
+## 3. RAG Facade (`RAG`)
+
+The famous 3-line API is a **facade** over a much richer system.
+
+```python
+rag = RAG(model="gpt-4o-mini")
+rag.add("my documents...")
+answer = rag.ask_sync("What is X?")
+```
+
+Under the hood:
+- `RAG` class composes `RAGPipeline`, `Retriever`, `Embedder`, `LLM`, and optional `ConversationMemory`
+- Uses sensible defaults but is fully configurable
+- Supports streaming, evaluation, cost tracking, and guardrails out of the box
+
+```python
+# src/synapsekit/rag/pipeline.py
+@dataclass
+class RAGConfig:
+    llm: BaseLLM
+    retriever: Retriever
+    memory: ConversationMemory
+    tracer: TokenTracer | None = None
+    retrieval_top_k: int = 5
+    system_prompt: str = "Answer using only the provided context."
+```
+
+**Diagram**: `docs/architecture/diagrams/rag-facade.html`
+
+---
+
+## 4. Plugin System
+
+SynapseKit has a clean plugin architecture.
+
+```python
+class MyPlugin(BasePlugin):
+    name = "my_plugin"
+    version = "1.0.0"
+
+    async def on_load(self):
+        ...
+```
+
+- `BasePlugin` provides lifecycle hooks (`on_load`, `on_unload`)
+- `PluginLoader` can load plugins from Python files dynamically
+- Global registry makes plugins discoverable
+
+```python
+# src/synapsekit/plugins/loader.py
+module = importlib.util.module_from_spec(spec)
+sys.modules[module_name] = module
+spec.loader.exec_module(module)
+```
+
+**Diagram**: `docs/architecture/diagrams/plugin-system.html`
+
+---
+
+## 5. How Everything Fits Together
+
+SynapseKit is designed as a composable stack:
+
+1. **Facade layer** provides simple entry points (`RAG`, `Agent`, `StateGraph`).
+2. **Graph engine** orchestrates execution with checkpointing and routing.
+3. **LLM + Retrieval + Memory** form the core inference pipeline.
+4. **Plugins** extend behavior without altering core code.
+5. **Observability** and async runtime underpin all layers.
+
+**Diagram**: `docs/architecture/diagrams/full-architecture.html`
+
+---
+
+## Contributing to the Architecture
+
+If you want to contribute:
+
+- Graph core ? `src/synapsekit/graph/`
+- RAG pipeline ? `src/synapsekit/rag/`
+- Plugin system ? `src/synapsekit/plugins/`
+- Async runtime ? `_loop.py`, `_compat.py`
+
+---
+
+**Status**: Architecture deep-dive complete.

--- a/docs/architecture/diagrams/async-runtime.html
+++ b/docs/architecture/diagrams/async-runtime.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Async Runtime Flow</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #f8fafc;
+    --fg: #172033;
+    --muted: #5b6475;
+    --line: #64748b;
+    --neutral: #e2e8f0;
+    --input: #bfdbfe;
+    --process: #c7d2fe;
+    --storage: #99f6e4;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0f172a;
+      --fg: #e5e7eb;
+      --muted: #a3adbd;
+      --line: #94a3b8;
+      --neutral: #334155;
+      --input: #1d4ed8;
+      --process: #4338ca;
+      --storage: #0f766e;
+    }
+  }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font: 14px/1.4 ui-sans-serif, system-ui, sans-serif;
+  }
+  main {
+    max-width: 980px;
+    margin: 32px auto;
+    padding: 0 20px;
+  }
+  svg { width: 100%; height: auto; display: block; }
+  .title { font-size: 20px; font-weight: 650; fill: var(--fg); }
+  .label { font-size: 14px; font-weight: 600; fill: var(--fg); }
+  .small { font-size: 12px; fill: var(--muted); }
+  .node { stroke: var(--line); stroke-width: 1.5; }
+  .neutral { fill: var(--neutral); }
+  .input { fill: var(--input); }
+  .process { fill: var(--process); }
+  .storage { fill: var(--storage); }
+  .edge { stroke: var(--line); stroke-width: 1.5; fill: none; }
+</style>
+<main>
+<svg viewBox="0 0 900 420" xmlns="http://www.w3.org/2000/svg">
+  <text x="450" y="30" class="title" text-anchor="middle">SynapseKit Async Runtime Flow</text>
+
+  <rect x="60" y="80" width="170" height="70" rx="10" class="node input" />
+  <text x="145" y="110" class="label" text-anchor="middle">App Entry</text>
+  <text x="145" y="130" class="small" text-anchor="middle">User calls API</text>
+
+  <rect x="280" y="80" width="170" height="70" rx="10" class="node neutral" />
+  <text x="365" y="110" class="label" text-anchor="middle">install_fast_loop()</text>
+  <text x="365" y="130" class="small" text-anchor="middle">_loop.py</text>
+
+  <rect x="500" y="80" width="150" height="70" rx="10" class="node process" />
+  <text x="575" y="110" class="label" text-anchor="middle">uvloop</text>
+  <text x="575" y="130" class="small" text-anchor="middle">if available</text>
+
+  <rect x="690" y="80" width="150" height="70" rx="10" class="node process" />
+  <text x="765" y="110" class="label" text-anchor="middle">asyncio</text>
+  <text x="765" y="130" class="small" text-anchor="middle">fallback</text>
+
+  <rect x="300" y="220" width="300" height="90" rx="12" class="node storage" />
+  <text x="450" y="250" class="label" text-anchor="middle">run_sync()</text>
+  <text x="450" y="270" class="small" text-anchor="middle">Thread fallback inside event loop</text>
+  <text x="450" y="288" class="small" text-anchor="middle">_compat.py</text>
+
+  <path d="M 230 115 L 280 115" class="edge" marker-end="url(#arrow)" />
+  <path d="M 450 115 L 500 115" class="edge" marker-end="url(#arrow)" />
+  <path d="M 650 115 L 690 115" class="edge" marker-end="url(#arrow)" />
+  <path d="M 365 150 L 365 220" class="edge" marker-end="url(#arrow)" />
+
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#64748b" />
+    </marker>
+  </defs>
+</svg>
+</main>

--- a/docs/architecture/diagrams/full-architecture.html
+++ b/docs/architecture/diagrams/full-architecture.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>SynapseKit Full Architecture</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #f8fafc;
+    --fg: #172033;
+    --muted: #5b6475;
+    --line: #64748b;
+    --neutral: #e2e8f0;
+    --input: #bfdbfe;
+    --process: #c7d2fe;
+    --storage: #99f6e4;
+    --external: #fde68a;
+    --risk: #fecaca;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0f172a;
+      --fg: #e5e7eb;
+      --muted: #a3adbd;
+      --line: #94a3b8;
+      --neutral: #334155;
+      --input: #1d4ed8;
+      --process: #4338ca;
+      --storage: #0f766e;
+      --external: #92400e;
+      --risk: #991b1b;
+    }
+  }
+  body { margin: 0; background: var(--bg); color: var(--fg); font: 14px/1.4 ui-sans-serif, system-ui, sans-serif; }
+  main { max-width: 1100px; margin: 32px auto; padding: 0 20px; }
+  svg { width: 100%; height: auto; display: block; }
+  .title { font-size: 20px; font-weight: 650; fill: var(--fg); }
+  .label { font-size: 13px; font-weight: 600; fill: var(--fg); }
+  .small { font-size: 11px; fill: var(--muted); }
+  .node { stroke: var(--line); stroke-width: 1.5; }
+  .neutral { fill: var(--neutral); }
+  .input { fill: var(--input); }
+  .process { fill: var(--process); }
+  .storage { fill: var(--storage); }
+  .external { fill: var(--external); }
+  .edge { stroke: var(--line); stroke-width: 1.5; fill: none; }
+</style>
+<main>
+<svg viewBox="0 0 1000 600" xmlns="http://www.w3.org/2000/svg">
+  <text x="500" y="30" class="title" text-anchor="middle">SynapseKit Full Architecture</text>
+
+  <rect x="60" y="70" width="160" height="70" rx="10" class="node input" />
+  <text x="140" y="100" class="label" text-anchor="middle">User Request</text>
+  <text x="140" y="120" class="small" text-anchor="middle">SDK / API</text>
+
+  <rect x="260" y="70" width="170" height="70" rx="10" class="node process" />
+  <text x="345" y="100" class="label" text-anchor="middle">Facade Layer</text>
+  <text x="345" y="120" class="small" text-anchor="middle">RAG / Agents / Graph</text>
+
+  <rect x="470" y="60" width="170" height="90" rx="10" class="node neutral" />
+  <text x="555" y="95" class="label" text-anchor="middle">Graph Engine</text>
+  <text x="555" y="115" class="small" text-anchor="middle">StateGraph / CompiledGraph</text>
+
+  <rect x="700" y="60" width="170" height="90" rx="10" class="node storage" />
+  <text x="785" y="95" class="label" text-anchor="middle">Checkpointers</text>
+  <text x="785" y="115" class="small" text-anchor="middle">SQLite / Redis / Postgres</text>
+
+  <rect x="260" y="200" width="170" height="70" rx="10" class="node process" />
+  <text x="345" y="230" class="label" text-anchor="middle">LLM Layer</text>
+  <text x="345" y="250" class="small" text-anchor="middle">Providers + Routing</text>
+
+  <rect x="470" y="200" width="170" height="70" rx="10" class="node storage" />
+  <text x="555" y="230" class="label" text-anchor="middle">Retriever</text>
+  <text x="555" y="250" class="small" text-anchor="middle">Vector Stores</text>
+
+  <rect x="700" y="200" width="170" height="70" rx="10" class="node storage" />
+  <text x="785" y="230" class="label" text-anchor="middle">Memory</text>
+  <text x="785" y="250" class="small" text-anchor="middle">Conversation / Vector</text>
+
+  <rect x="260" y="320" width="170" height="70" rx="10" class="node process" />
+  <text x="345" y="350" class="label" text-anchor="middle">Observability</text>
+  <text x="345" y="370" class="small" text-anchor="middle">Tracing / Metrics</text>
+
+  <rect x="470" y="320" width="170" height="70" rx="10" class="node external" />
+  <text x="555" y="350" class="label" text-anchor="middle">Plugin System</text>
+  <text x="555" y="370" class="small" text-anchor="middle">Dynamic Extensions</text>
+
+  <rect x="700" y="320" width="170" height="70" rx="10" class="node neutral" />
+  <text x="785" y="350" class="label" text-anchor="middle">Async Runtime</text>
+  <text x="785" y="370" class="small" text-anchor="middle">uvloop / asyncio</text>
+
+  <!-- Edges -->
+  <path d="M 220 105 L 260 105" class="edge" marker-end="url(#arrow)" />
+  <path d="M 430 105 L 470 105" class="edge" marker-end="url(#arrow)" />
+  <path d="M 640 105 L 700 105" class="edge" marker-end="url(#arrow)" />
+
+  <path d="M 345 140 L 345 200" class="edge" marker-end="url(#arrow)" />
+  <path d="M 555 150 L 555 200" class="edge" marker-end="url(#arrow)" />
+  <path d="M 785 150 L 785 200" class="edge" marker-end="url(#arrow)" />
+
+  <path d="M 345 270 L 345 320" class="edge" marker-end="url(#arrow)" />
+  <path d="M 555 270 L 555 320" class="edge" marker-end="url(#arrow)" />
+  <path d="M 785 270 L 785 320" class="edge" marker-end="url(#arrow)" />
+
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#64748b" />
+    </marker>
+  </defs>
+</svg>
+</main>

--- a/docs/architecture/diagrams/graph-engine.html
+++ b/docs/architecture/diagrams/graph-engine.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Graph Engine Architecture</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #f8fafc;
+    --fg: #172033;
+    --muted: #5b6475;
+    --line: #64748b;
+    --neutral: #e2e8f0;
+    --input: #bfdbfe;
+    --process: #c7d2fe;
+    --storage: #99f6e4;
+    --external: #fde68a;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0f172a;
+      --fg: #e5e7eb;
+      --muted: #a3adbd;
+      --line: #94a3b8;
+      --neutral: #334155;
+      --input: #1d4ed8;
+      --process: #4338ca;
+      --storage: #0f766e;
+      --external: #92400e;
+    }
+  }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font: 14px/1.4 ui-sans-serif, system-ui, sans-serif;
+  }
+  main {
+    max-width: 1100px;
+    margin: 32px auto;
+    padding: 0 20px;
+  }
+  svg {
+    width: 100%;
+    height: auto;
+    display: block;
+    background: var(--bg);
+  }
+  .title {
+    font-size: 22px;
+    font-weight: 700;
+    fill: var(--fg);
+  }
+  .label {
+    font-size: 14px;
+    font-weight: 600;
+    fill: var(--fg);
+  }
+  .small {
+    font-size: 11px;
+    fill: var(--muted);
+  }
+  .node {
+    stroke: var(--line);
+    stroke-width: 2;
+  }
+  .neutral { fill: var(--neutral); }
+  .input { fill: var(--input); }
+  .process { fill: var(--process); }
+  .storage { fill: var(--storage); }
+  .external { fill: var(--external); }
+  .edge {
+    stroke: var(--line);
+    stroke-width: 2;
+    fill: none;
+  }
+</style>
+<main>
+<svg viewBox="0 0 900 520" xmlns="http://www.w3.org/2000/svg">
+  <!-- Title -->
+  <text x="450" y="35" class="title" text-anchor="middle">SynapseKit Graph Engine Architecture</text>
+
+  <!-- User Request -->
+  <rect x="50" y="80" width="140" height="70" rx="12" class="node input" />
+  <text x="120" y="115" class="label" text-anchor="middle">User Request</text>
+
+  <!-- Entry Point -->
+  <rect x="260" y="80" width="110" height="70" rx="12" class="node neutral" />
+  <text x="315" y="105" class="label" text-anchor="middle">StateGraph</text>
+  <text x="315" y="125" class="small" text-anchor="middle">.compile()</text>
+
+  <!-- Compiled Graph -->
+  <rect x="440" y="80" width="130" height="70" rx="12" class="node process" />
+  <text x="505" y="105" class="label" text-anchor="middle">CompiledGraph</text>
+  <text x="505" y="125" class="small" text-anchor="middle">run() / ainvoke()</text>
+
+  <!-- Checkpointing -->
+  <rect x="640" y="60" width="110" height="110" rx="12" class="node storage" />
+  <text x="695" y="95" class="label" text-anchor="middle">Checkpointer</text>
+  <text x="695" y="115" class="small" text-anchor="middle">(SQLite, Redis, etc.)</text>
+
+  <!-- Nodes -->
+  <rect x="280" y="220" width="100" height="65" rx="10" class="node neutral" />
+  <text x="330" y="250" class="label" text-anchor="middle">Node A</text>
+
+  <rect x="480" y="180" width="100" height="65" rx="10" class="node process" />
+  <text x="530" y="210" class="label" text-anchor="middle">Node B</text>
+
+  <rect x="480" y="280" width="100" height="65" rx="10" class="node neutral" />
+  <text x="530" y="310" class="label" text-anchor="middle">Node C</text>
+
+  <!-- Conditional Edge -->
+  <rect x="650" y="240" width="110" height="65" rx="10" class="node external" />
+  <text x="705" y="265" class="label" text-anchor="middle">Conditional</text>
+  <text x="705" y="285" class="small" text-anchor="middle">Routing</text>
+
+  <!-- Edges -->
+  <path d="M 190 115 L 255 115" class="edge" marker-end="url(#arrow)" />
+  <path d="M 370 115 L 435 115" class="edge" marker-end="url(#arrow)" />
+  <path d="M 570 115 L 635 115" class="edge" marker-end="url(#arrow)" />
+
+  <!-- Node connections -->
+  <path d="M 330 150 L 330 210" class="edge" marker-end="url(#arrow)" />
+  <path d="M 430 245 L 475 215" class="edge" marker-end="url(#arrow)" />
+  <path d="M 430 285 L 475 315" class="edge" marker-end="url(#arrow)" />
+  <path d="M 580 245 L 645 265" class="edge" marker-end="url(#arrow)" />
+
+  <!-- Legend -->
+  <rect x="50" y="400" width="800" height="85" rx="8" fill="#f1f5f9" stroke="#64748b" stroke-width="1" />
+  <text x="70" y="425" class="label">Legend</text>
+  <rect x="70" y="440" width="22" height="22" rx="4" fill="#bfdbfe" />
+  <text x="105" y="455" class="small">Input / Request</text>
+  
+  <rect x="220" y="440" width="22" height="22" rx="4" fill="#e2e8f0" />
+  <text x="255" y="455" class="small">Graph Builder</text>
+  
+  <rect x="370" y="440" width="22" height="22" rx="4" fill="#c7d2fe" />
+  <text x="405" y="455" class="small">Execution Engine</text>
+  
+  <rect x="540" y="440" width="22" height="22" rx="4" fill="#99f6e4" />
+  <text x="575" y="455" class="small">Persistence</text>
+
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#64748b" />
+    </marker>
+  </defs>
+</svg>
+</main>

--- a/docs/architecture/diagrams/plugin-system.html
+++ b/docs/architecture/diagrams/plugin-system.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Plugin Loading Flow</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #f8fafc;
+    --fg: #172033;
+    --muted: #5b6475;
+    --line: #64748b;
+    --neutral: #e2e8f0;
+    --input: #bfdbfe;
+    --process: #c7d2fe;
+    --storage: #99f6e4;
+    --external: #fde68a;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0f172a;
+      --fg: #e5e7eb;
+      --muted: #a3adbd;
+      --line: #94a3b8;
+      --neutral: #334155;
+      --input: #1d4ed8;
+      --process: #4338ca;
+      --storage: #0f766e;
+      --external: #92400e;
+    }
+  }
+  body { margin: 0; background: var(--bg); color: var(--fg); font: 14px/1.4 ui-sans-serif, system-ui, sans-serif; }
+  main { max-width: 980px; margin: 32px auto; padding: 0 20px; }
+  svg { width: 100%; height: auto; display: block; }
+  .title { font-size: 20px; font-weight: 650; fill: var(--fg); }
+  .label { font-size: 14px; font-weight: 600; fill: var(--fg); }
+  .small { font-size: 12px; fill: var(--muted); }
+  .node { stroke: var(--line); stroke-width: 1.5; }
+  .input { fill: var(--input); }
+  .process { fill: var(--process); }
+  .storage { fill: var(--storage); }
+  .external { fill: var(--external); }
+  .edge { stroke: var(--line); stroke-width: 1.5; fill: none; }
+</style>
+<main>
+<svg viewBox="0 0 920 420" xmlns="http://www.w3.org/2000/svg">
+  <text x="460" y="30" class="title" text-anchor="middle">Plugin Loading Flow</text>
+
+  <rect x="60" y="80" width="160" height="70" rx="10" class="node input" />
+  <text x="140" y="110" class="label" text-anchor="middle">Plugin File</text>
+  <text x="140" y="130" class="small" text-anchor="middle">my_plugin.py</text>
+
+  <rect x="260" y="80" width="170" height="70" rx="10" class="node process" />
+  <text x="345" y="110" class="label" text-anchor="middle">loader.py</text>
+  <text x="345" y="130" class="small" text-anchor="middle">load_plugin_from_path</text>
+
+  <rect x="480" y="80" width="170" height="70" rx="10" class="node process" />
+  <text x="565" y="110" class="label" text-anchor="middle">importlib.util</text>
+  <text x="565" y="130" class="small" text-anchor="middle">exec_module</text>
+
+  <rect x="700" y="80" width="170" height="70" rx="10" class="node storage" />
+  <text x="785" y="110" class="label" text-anchor="middle">Registry</text>
+  <text x="785" y="130" class="small" text-anchor="middle">plugins/registry.py</text>
+
+  <rect x="300" y="220" width="300" height="90" rx="12" class="node external" />
+  <text x="450" y="250" class="label" text-anchor="middle">BasePlugin subclasses</text>
+  <text x="450" y="270" class="small" text-anchor="middle">on_load / on_unload</text>
+
+  <path d="M 220 115 L 260 115" class="edge" marker-end="url(#arrow)" />
+  <path d="M 430 115 L 480 115" class="edge" marker-end="url(#arrow)" />
+  <path d="M 650 115 L 700 115" class="edge" marker-end="url(#arrow)" />
+  <path d="M 430 150 L 430 220" class="edge" marker-end="url(#arrow)" />
+  <path d="M 600 220 L 700 150" class="edge" marker-end="url(#arrow)" />
+
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#64748b" />
+    </marker>
+  </defs>
+</svg>
+</main>

--- a/docs/architecture/diagrams/rag-facade.html
+++ b/docs/architecture/diagrams/rag-facade.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>RAG Facade Architecture</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #f8fafc;
+    --fg: #172033;
+    --muted: #5b6475;
+    --line: #64748b;
+    --neutral: #e2e8f0;
+    --input: #bfdbfe;
+    --process: #c7d2fe;
+    --storage: #99f6e4;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0f172a;
+      --fg: #e5e7eb;
+      --muted: #a3adbd;
+      --line: #94a3b8;
+      --neutral: #334155;
+      --input: #1d4ed8;
+      --process: #4338ca;
+      --storage: #0f766e;
+    }
+  }
+  body { margin: 0; background: var(--bg); color: var(--fg); font: 14px/1.4 ui-sans-serif, system-ui, sans-serif; }
+  main { max-width: 980px; margin: 32px auto; padding: 0 20px; }
+  svg { width: 100%; height: auto; display: block; }
+  .title { font-size: 20px; font-weight: 650; fill: var(--fg); }
+  .label { font-size: 14px; font-weight: 600; fill: var(--fg); }
+  .small { font-size: 12px; fill: var(--muted); }
+  .node { stroke: var(--line); stroke-width: 1.5; }
+  .input { fill: var(--input); }
+  .process { fill: var(--process); }
+  .storage { fill: var(--storage); }
+  .neutral { fill: var(--neutral); }
+  .edge { stroke: var(--line); stroke-width: 1.5; fill: none; }
+</style>
+<main>
+<svg viewBox="0 0 940 470" xmlns="http://www.w3.org/2000/svg">
+  <text x="470" y="30" class="title" text-anchor="middle">RAG Facade Architecture</text>
+
+  <rect x="60" y="80" width="150" height="70" rx="10" class="node input" />
+  <text x="135" y="110" class="label" text-anchor="middle">RAG Facade</text>
+  <text x="135" y="130" class="small" text-anchor="middle">rag = RAG(...)</text>
+
+  <rect x="260" y="80" width="170" height="70" rx="10" class="node process" />
+  <text x="345" y="110" class="label" text-anchor="middle">RAGPipeline</text>
+  <text x="345" y="130" class="small" text-anchor="middle">pipeline.py</text>
+
+  <rect x="480" y="60" width="170" height="70" rx="10" class="node storage" />
+  <text x="565" y="90" class="label" text-anchor="middle">Retriever</text>
+  <text x="565" y="110" class="small" text-anchor="middle">vector store</text>
+
+  <rect x="480" y="150" width="170" height="70" rx="10" class="node neutral" />
+  <text x="565" y="180" class="label" text-anchor="middle">Embeddings</text>
+  <text x="565" y="200" class="small" text-anchor="middle">backend</text>
+
+  <rect x="700" y="80" width="170" height="70" rx="10" class="node process" />
+  <text x="785" y="110" class="label" text-anchor="middle">LLM</text>
+  <text x="785" y="130" class="small" text-anchor="middle">llm/_factory.py</text>
+
+  <rect x="260" y="200" width="170" height="70" rx="10" class="node storage" />
+  <text x="345" y="230" class="label" text-anchor="middle">Memory</text>
+  <text x="345" y="250" class="small" text-anchor="middle">ConversationMemory</text>
+
+  <rect x="480" y="260" width="170" height="70" rx="10" class="node neutral" />
+  <text x="565" y="290" class="label" text-anchor="middle">TokenTracer</text>
+  <text x="565" y="310" class="small" text-anchor="middle">observability</text>
+
+  <path d="M 210 115 L 260 115" class="edge" marker-end="url(#arrow)" />
+  <path d="M 430 115 L 480 95" class="edge" marker-end="url(#arrow)" />
+  <path d="M 430 115 L 480 185" class="edge" marker-end="url(#arrow)" />
+  <path d="M 650 95 L 700 115" class="edge" marker-end="url(#arrow)" />
+  <path d="M 430 230 L 430 200" class="edge" marker-end="url(#arrow)" />
+  <path d="M 430 230 L 480 295" class="edge" marker-end="url(#arrow)" />
+
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#64748b" />
+    </marker>
+  </defs>
+</svg>
+</main>


### PR DESCRIPTION
Implements the architecture deep-dive requested in #673.

## Changes
- Added comprehensive docs/architecture/deep-dive.md
- Added 5 supporting architecture diagrams (Async Runtime, Graph Engine, RAG Facade, Plugin System, Full System)
- Updated .gitignore to allow architecture documentation

This is a clean PR containing only the architecture deep-dive work.

Closes #673