### PR TITLE
feat: add edge runtime with local inference fallback

### DIFF
--- a/docs/edge.md
+++ b/docs/edge.md
@@ -1,0 +1,138 @@
+# Edge SynapseKit
+
+Edge SynapseKit runs local models first and falls back to a cloud model only
+when an explicit policy allows it. This is intended for privacy-sensitive
+agents that need to work on laptops, edge servers, and offline environments.
+
+## Install
+
+Install only the backends you need:
+
+```bash
+pip install "synapsekit[llamacpp,sqlite-vec]"
+pip install "synapsekit[onnx]"
+pip install "synapsekit[edge]"
+```
+
+The core package does not import llama.cpp, ONNX Runtime, or MLX unless you
+instantiate those providers.
+
+## Local-first runtime
+
+```python
+from synapsekit import EdgeRuntime, FallbackPolicy, LLMConfig
+from synapsekit.llm.llamacpp import LlamaCppLLM
+
+local = LlamaCppLLM(
+    LLMConfig(model="llama-3.2-3b", api_key="", provider="llamacpp"),
+    model_path="/models/Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+    n_ctx=8192,
+)
+
+runtime = EdgeRuntime(
+    local_llm=local,
+    fallback=FallbackPolicy(),
+)
+```
+
+With no cloud model and no fallback gates, all calls stay local. If the local
+model cannot handle a request, SynapseKit raises a clear edge fallback error
+instead of silently sending data to a remote provider.
+
+## Cloud fallback
+
+Fallback is default-deny. Configure only the routes your application accepts:
+
+```python
+from synapsekit import EdgeRuntime, FallbackPolicy
+from synapsekit.llm.anthropic import AnthropicLLM
+
+runtime = EdgeRuntime(
+    local_llm=local,
+    cloud_llm=AnthropicLLM(...),
+    fallback=FallbackPolicy(
+        if_context_exceeds=8192,
+        if_tool_unsupported_locally=True,
+        if_user_opts_in=True,
+        require_pii_redaction_before_fallback=True,
+    ),
+)
+```
+
+Supported fallback reasons:
+
+- context exceeds the configured local limit
+- tool calling is not supported by the local provider
+- the caller explicitly passes `allow_cloud_fallback=True`
+- local model errors, only when `fallback_on_local_error=True`
+
+The last route is observable:
+
+```python
+answer = await runtime.generate(prompt)
+print(runtime.last_route, runtime.last_fallback_reason)
+```
+
+## PII redaction
+
+When `require_pii_redaction_before_fallback=True`, prompts and chat messages
+are passed through `PIIRedactor` before the cloud model receives them. Email
+addresses, phone numbers, SSNs, and other configured PII patterns are replaced
+with stable placeholders.
+
+```python
+answer = await runtime.generate("Email alice@example.com", allow_cloud_fallback=True)
+print(runtime.last_redaction.pii_types_found)
+```
+
+Use `mode="redact"` on `PIIRedactor` for irreversible redaction, or the default
+masking mode when your application needs a reversible mapping.
+
+## Local embeddings and SQLite-vec
+
+For edge RAG, pair `ONNXEmbeddings` with `SQLiteVecStore`:
+
+```python
+from synapsekit import ONNXEmbeddings, SQLiteVecStore
+
+embeddings = ONNXEmbeddings("/models/all-MiniLM-L6-v2.onnx")
+store = SQLiteVecStore(embeddings, db_path="edge_vectors.db")
+await store.add(["PHI policy document"], metadata=[{"source": "policy"}])
+```
+
+This keeps vectors and source text in a local SQLite database and avoids a
+network vector store in regulated deployments.
+
+## CLI
+
+List known edge models:
+
+```bash
+synapsekit edge list
+```
+
+Pull a known model into the local cache:
+
+```bash
+synapsekit edge pull llama-3.2-3b
+```
+
+Quantize a local model with llama.cpp:
+
+```bash
+synapsekit edge quantize model-f16.gguf model-q4.gguf --quantization Q4_K_M
+```
+
+## HIPAA-safe agent pattern
+
+1. Run the primary LLM through `LlamaCppLLM`, `GPT4AllLLM`, `OllamaLLM`, or
+   `MLXLLM`.
+2. Use `SQLiteVecStore` for retrieval memory.
+3. Set fallback gates narrowly, preferably only for context overflow or
+   explicit user opt-in.
+4. Keep `require_pii_redaction_before_fallback=True`.
+5. Log `runtime.last_route` and `runtime.last_fallback_reason` for audits.
+
+Mobile Swift/Kotlin wrappers are intentionally left for a future PR. The
+runtime added here is the Python policy and provider foundation those bindings
+can call into later.

--- a/examples/edge_runtime.py
+++ b/examples/edge_runtime.py
@@ -1,0 +1,54 @@
+"""EdgeRuntime example with local-first routing and guarded fallback."""
+
+from __future__ import annotations
+
+import asyncio
+
+from synapsekit import BaseLLM, EdgeRuntime, FallbackPolicy, LLMConfig
+
+
+class DemoLocalLLM(BaseLLM):
+    def __init__(self) -> None:
+        super().__init__(LLMConfig(model="demo-local", api_key="", provider="local"))
+
+    async def stream(self, prompt: str, **kw):
+        yield f"local: {prompt}"
+
+
+class DemoCloudLLM(BaseLLM):
+    def __init__(self) -> None:
+        super().__init__(LLMConfig(model="demo-cloud", api_key="", provider="cloud"))
+        self.last_prompt = ""
+
+    async def stream(self, prompt: str, **kw):
+        self.last_prompt = prompt
+        yield f"cloud: {prompt}"
+
+
+async def main() -> None:
+    cloud = DemoCloudLLM()
+    runtime = EdgeRuntime(
+        local_llm=DemoLocalLLM(),
+        cloud_llm=cloud,
+        fallback=FallbackPolicy(
+            if_context_exceeds=8,
+            if_user_opts_in=True,
+            require_pii_redaction_before_fallback=True,
+        ),
+    )
+
+    local_answer = await runtime.generate("short task")
+    print(local_answer)
+    print("route:", runtime.last_route)
+
+    cloud_answer = await runtime.generate(
+        "Please summarize this long private note for alice@example.com",
+        allow_cloud_fallback=True,
+    )
+    print(cloud_answer)
+    print("route:", runtime.last_route)
+    print("cloud saw:", cloud.last_prompt)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,13 @@ cloudflare = ["httpx>=0.27"]
 aleph-alpha = ["aleph-alpha-client>=7.0"]
 llamacpp = ["llama-cpp-python>=0.2"]
 gpt4all = ["gpt4all>=2.0"]
+onnx = ["onnxruntime>=1.17"]
+mlx = ["mlx-lm>=0.20; platform_system == 'Darwin' and platform_machine == 'arm64'"]
+edge = [
+    "llama-cpp-python>=0.2",
+    "onnxruntime>=1.17",
+    "sqlite-vec>=0.1",
+]
 ernie = ["erniebot>=0.5"]
 minimax = ["httpx>=0.27"]
 serve = ["fastapi>=0.110", "uvicorn[standard]>=0.29"]

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -183,6 +183,7 @@ from .graph import (
 from .llm.base import BaseLLM, LLMConfig
 from .llm.cost_quality_router import CostQualityRouter
 from .llm.cost_router import QUALITY_TABLE, CostRouter, CostRouterConfig, RouterModelSpec
+from .llm.edge import EdgeFallbackBlockedError, EdgeRuntime, EdgeRouteMetadata, FallbackPolicy
 from .llm.fallback_chain import FallbackChain, FallbackChainConfig
 from .llm.multimodal import AudioContent, ImageContent, MultimodalMessage
 from .llm.reasoning import (
@@ -362,6 +363,10 @@ __all__ = [
     "CostRouterConfig",
     "RouterModelSpec",
     "QUALITY_TABLE",
+    "EdgeFallbackBlockedError",
+    "EdgeRouteMetadata",
+    "EdgeRuntime",
+    "FallbackPolicy",
     "FallbackChain",
     "FallbackChainConfig",
     "BaseReasoningProvider",
@@ -389,9 +394,11 @@ __all__ = [
     "WriterLLM",
     "ZhipuLLM",
     "LMStudioLLM",
+    "MLXLLM",
     "VLLMLLM",
     # Embeddings
     "SynapsekitEmbeddings",
+    "ONNXEmbeddings",
     # Vector stores
     "VectorStore",
     "InMemoryVectorStore",
@@ -798,6 +805,7 @@ _LAZY_IMPORTS = {
     "PineconeVectorStore": "retrieval.pinecone",
     "WeaviateVectorStore": "retrieval.weaviate",
     "SQLiteVecStore": "retrieval.sqlite_vec",
+    "ONNXEmbeddings": "embeddings.onnx",
     # LLM providers
     "AsyncLRUCache": "llm._cache",
     "DynamoDBCacheBackend": "llm._cache_dynamodb",
@@ -822,6 +830,7 @@ _LAZY_IMPORTS = {
     "WriterLLM": "llm.writer",
     "ZhipuLLM": "llm.zhipu",
     "LMStudioLLM": "llm.lmstudio",
+    "MLXLLM": "llm.mlx",
     "VLLMLLM": "llm.vllm",
     "CloudflareLLM": "llm.cloudflare",
     "BaseReasoningProvider": "llm.reasoning",

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -183,7 +183,7 @@ from .graph import (
 from .llm.base import BaseLLM, LLMConfig
 from .llm.cost_quality_router import CostQualityRouter
 from .llm.cost_router import QUALITY_TABLE, CostRouter, CostRouterConfig, RouterModelSpec
-from .llm.edge import EdgeFallbackBlockedError, EdgeRuntime, EdgeRouteMetadata, FallbackPolicy
+from .llm.edge import EdgeFallbackBlockedError, EdgeRouteMetadata, EdgeRuntime, FallbackPolicy
 from .llm.fallback_chain import FallbackChain, FallbackChainConfig
 from .llm.multimodal import AudioContent, ImageContent, MultimodalMessage
 from .llm.reasoning import (

--- a/src/synapsekit/cli/edge.py
+++ b/src/synapsekit/cli/edge.py
@@ -9,7 +9,6 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
-
 DEFAULT_EDGE_CACHE = Path.home() / ".cache" / "synapsekit" / "edge"
 
 

--- a/src/synapsekit/cli/edge.py
+++ b/src/synapsekit/cli/edge.py
@@ -1,0 +1,210 @@
+"""``synapsekit edge`` commands for local model management."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_EDGE_CACHE = Path.home() / ".cache" / "synapsekit" / "edge"
+
+
+@dataclass(frozen=True)
+class EdgeModel:
+    """Registry entry for a known edge model artifact."""
+
+    name: str
+    repo_id: str
+    filename: str
+    backend: str
+    size: str
+    description: str
+
+    @property
+    def local_filename(self) -> str:
+        return self.filename.rsplit("/", 1)[-1]
+
+
+MODEL_REGISTRY: dict[str, EdgeModel] = {
+    "llama-3.2-3b": EdgeModel(
+        name="llama-3.2-3b",
+        repo_id="bartowski/Llama-3.2-3B-Instruct-GGUF",
+        filename="Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+        backend="llamacpp",
+        size="~2.0GB",
+        description="Meta Llama 3.2 3B Instruct quantized for llama.cpp",
+    ),
+    "phi-3.5-mini": EdgeModel(
+        name="phi-3.5-mini",
+        repo_id="bartowski/Phi-3.5-mini-instruct-GGUF",
+        filename="Phi-3.5-mini-instruct-Q4_K_M.gguf",
+        backend="llamacpp",
+        size="~2.4GB",
+        description="Microsoft Phi 3.5 Mini Instruct quantized for llama.cpp",
+    ),
+    "minilm-l6-onnx": EdgeModel(
+        name="minilm-l6-onnx",
+        repo_id="Xenova/all-MiniLM-L6-v2",
+        filename="onnx/model.onnx",
+        backend="onnx",
+        size="~90MB",
+        description="All-MiniLM-L6-v2 sentence embeddings exported to ONNX",
+    ),
+}
+
+
+def _cache_root(args: Any) -> Path:
+    return Path(getattr(args, "cache_dir", None) or DEFAULT_EDGE_CACHE).expanduser()
+
+
+def _model_path(model: EdgeModel, cache_root: Path) -> Path:
+    return cache_root / model.name / model.local_filename
+
+
+def _metadata_path(model: EdgeModel, cache_root: Path) -> Path:
+    return cache_root / model.name / "model.json"
+
+
+def _print_registry(args: Any) -> None:
+    cache_root = _cache_root(args)
+    payload = []
+
+    for model in MODEL_REGISTRY.values():
+        path = _model_path(model, cache_root)
+        record = asdict(model)
+        record["downloaded"] = path.exists()
+        record["path"] = str(path)
+        payload.append(record)
+
+    if getattr(args, "output_format", "table") == "json":
+        print(json.dumps({"models": payload}, indent=2))
+        return
+
+    print("Known edge models:")
+    for record in payload:
+        status = "downloaded" if record["downloaded"] else "missing"
+        print(
+            f"  - {record['name']:<16} {record['backend']:<8} {record['size']:<8} "
+            f"{status:<10} {record['description']}"
+        )
+
+
+def _resolve_model(name: str) -> EdgeModel:
+    try:
+        return MODEL_REGISTRY[name]
+    except KeyError as exc:
+        known = ", ".join(sorted(MODEL_REGISTRY))
+        raise SystemExit(f"Unknown edge model '{name}'. Known models: {known}") from exc
+
+
+def _download_model(model: EdgeModel, cache_root: Path, force: bool) -> Path:
+    destination_dir = cache_root / model.name
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    target_path = _model_path(model, cache_root)
+
+    if target_path.exists() and not force:
+        return target_path
+
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError:
+        raise SystemExit(
+            "huggingface-hub required for 'synapsekit edge pull'. "
+            "Install it with: pip install synapsekit[huggingface]"
+        ) from None
+
+    downloaded = hf_hub_download(
+        repo_id=model.repo_id,
+        filename=model.filename,
+        local_dir=str(destination_dir),
+        local_dir_use_symlinks=False,
+        force_download=force,
+    )
+    downloaded_path = Path(downloaded)
+
+    metadata = asdict(model)
+    metadata["path"] = str(downloaded_path)
+    _metadata_path(model, cache_root).write_text(json.dumps(metadata, indent=2) + "\n")
+    return downloaded_path
+
+
+def _pull_model(args: Any) -> None:
+    model = _resolve_model(args.model)
+    path = _download_model(model, _cache_root(args), bool(getattr(args, "force", False)))
+    print(json.dumps({"model": model.name, "backend": model.backend, "path": str(path)}, indent=2))
+
+
+def _quantize(args: Any) -> None:
+    llama_quantize = getattr(args, "llama_quantize", None) or shutil.which("llama-quantize")
+    if not llama_quantize:
+        raise SystemExit(
+            "llama-quantize was not found. Build llama.cpp and pass "
+            "--llama-quantize /path/to/llama-quantize."
+        )
+
+    input_path = Path(args.input_model).expanduser()
+    if not input_path.exists():
+        raise SystemExit(f"Input model not found: {input_path}")
+
+    output_path = Path(args.output).expanduser()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    quantization = getattr(args, "quantization", "Q4_K_M")
+
+    cmd = [str(llama_quantize), str(input_path), str(output_path), quantization]
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(f"Quantization failed with exit code {exc.returncode}") from exc
+
+    print(json.dumps({"input": str(input_path), "output": str(output_path), "quantization": quantization}, indent=2))
+
+
+def run_edge(args: Any) -> None:
+    """Dispatch ``synapsekit edge`` subcommands."""
+
+    command = getattr(args, "edge_command", None)
+    if command == "list":
+        _print_registry(args)
+        return
+    if command == "pull":
+        _pull_model(args)
+        return
+    if command == "quantize":
+        _quantize(args)
+        return
+    raise SystemExit("Missing edge action. Use 'list', 'pull', or 'quantize'.")
+
+
+def build_edge_parser(subparsers: Any) -> None:
+    """Register the ``edge`` parser with the top-level CLI."""
+
+    parser = subparsers.add_parser("edge", help="Manage local edge models")
+    parser.add_argument("--cache-dir", default=None, help="Edge model cache directory")
+    edge_sub = parser.add_subparsers(dest="edge_command")
+
+    list_cmd = edge_sub.add_parser("list", help="List known edge models")
+    list_cmd.add_argument(
+        "--format",
+        dest="output_format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format",
+    )
+
+    pull_cmd = edge_sub.add_parser("pull", help="Download a known edge model")
+    pull_cmd.add_argument("model", help="Registry name, e.g. llama-3.2-3b")
+    pull_cmd.add_argument("--force", action="store_true", help="Redownload existing files")
+
+    quantize_cmd = edge_sub.add_parser("quantize", help="Quantize a GGUF model with llama.cpp")
+    quantize_cmd.add_argument("input_model", help="Input GGUF/F16 model path")
+    quantize_cmd.add_argument("output", help="Output GGUF model path")
+    quantize_cmd.add_argument("--quantization", default="Q4_K_M", help="llama.cpp quantization type")
+    quantize_cmd.add_argument(
+        "--llama-quantize",
+        default=None,
+        help="Path to llama.cpp llama-quantize binary",
+    )

--- a/src/synapsekit/cli/edge.py
+++ b/src/synapsekit/cli/edge.py
@@ -159,7 +159,12 @@ def _quantize(args: Any) -> None:
     except subprocess.CalledProcessError as exc:
         raise SystemExit(f"Quantization failed with exit code {exc.returncode}") from exc
 
-    print(json.dumps({"input": str(input_path), "output": str(output_path), "quantization": quantization}, indent=2))
+    print(
+        json.dumps(
+            {"input": str(input_path), "output": str(output_path), "quantization": quantization},
+            indent=2,
+        )
+    )
 
 
 def run_edge(args: Any) -> None:
@@ -201,7 +206,9 @@ def build_edge_parser(subparsers: Any) -> None:
     quantize_cmd = edge_sub.add_parser("quantize", help="Quantize a GGUF model with llama.cpp")
     quantize_cmd.add_argument("input_model", help="Input GGUF/F16 model path")
     quantize_cmd.add_argument("output", help="Output GGUF model path")
-    quantize_cmd.add_argument("--quantization", default="Q4_K_M", help="llama.cpp quantization type")
+    quantize_cmd.add_argument(
+        "--quantization", default="Q4_K_M", help="llama.cpp quantization type"
+    )
     quantize_cmd.add_argument(
         "--llama-quantize",
         default=None,

--- a/src/synapsekit/cli/main.py
+++ b/src/synapsekit/cli/main.py
@@ -149,6 +149,12 @@ def _add_bench_parser(subparsers: argparse._SubParsersAction) -> None:  # type: 
     build_bench_parser(subparsers)
 
 
+def _add_edge_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    from .edge import build_edge_parser
+
+    build_edge_parser(subparsers)
+
+
 def main(argv: list[str] | None = None) -> None:
     """CLI entry point."""
     from .._loop import install_fast_loop
@@ -169,6 +175,7 @@ def main(argv: list[str] | None = None) -> None:
     _add_graph_builder_parser(subparsers)
     _add_benchmark_parser(subparsers)
     _add_bench_parser(subparsers)
+    _add_edge_parser(subparsers)
     _add_ui_parser(subparsers)
     _add_plugin_parser(subparsers)
 
@@ -208,6 +215,10 @@ def main(argv: list[str] | None = None) -> None:
         from .bench import run_bench
 
         run_bench(args)
+    elif args.command == "edge":
+        from .edge import run_edge
+
+        run_edge(args)
     elif args.command == "ui":
         from .ui import run_ui
 

--- a/src/synapsekit/embeddings/__init__.py
+++ b/src/synapsekit/embeddings/__init__.py
@@ -1,3 +1,18 @@
 from .backend import SynapsekitEmbeddings
 
-__all__ = ["SynapsekitEmbeddings"]
+__all__ = ["ONNXEmbeddings", "SynapsekitEmbeddings"]
+
+_BACKENDS = {
+    "ONNXEmbeddings": ".onnx",
+}
+
+
+def __getattr__(name: str):
+    if name in _BACKENDS:
+        import importlib
+
+        mod = importlib.import_module(_BACKENDS[name], __name__)
+        cls = getattr(mod, name)
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/synapsekit/embeddings/onnx.py
+++ b/src/synapsekit/embeddings/onnx.py
@@ -1,0 +1,122 @@
+"""ONNX Runtime embeddings backend for edge deployments."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+class ONNXEmbeddings:
+    """Async embeddings backed by an ONNX Runtime session.
+
+    The class accepts an optional tokenizer callable so deployments can reuse
+    an application-specific tokenizer. If omitted, it uses a deterministic
+    lightweight byte tokenizer that is sufficient for smoke tests and small
+    edge demos, while production users can pass a Hugging Face tokenizer or
+    another callable returning ONNX input tensors.
+    """
+
+    def __init__(
+        self,
+        model_path: str | Path,
+        *,
+        tokenizer: Callable[[list[str]], dict[str, Any]] | None = None,
+        providers: list[str] | None = None,
+        normalize: bool = True,
+        max_length: int = 256,
+    ) -> None:
+        self.model_path = str(model_path)
+        self._tokenizer = tokenizer
+        self._providers = providers
+        self._normalize = normalize
+        self._max_length = max_length
+        self._session: Any = None
+
+    def _get_session(self) -> Any:
+        if self._session is None:
+            try:
+                import onnxruntime as ort
+            except ImportError:
+                raise ImportError("onnxruntime required: pip install synapsekit[onnx]") from None
+
+            kwargs: dict[str, Any] = {}
+            if self._providers is not None:
+                kwargs["providers"] = self._providers
+            self._session = ort.InferenceSession(self.model_path, **kwargs)
+        return self._session
+
+    def _default_tokenize(self, texts: list[str]) -> dict[str, np.ndarray]:
+        input_ids = np.zeros((len(texts), self._max_length), dtype=np.int64)
+        attention_mask = np.zeros((len(texts), self._max_length), dtype=np.int64)
+
+        for row, text in enumerate(texts):
+            encoded = text.encode("utf-8")[: self._max_length]
+            if not encoded:
+                continue
+            values = np.frombuffer(encoded, dtype=np.uint8).astype(np.int64)
+            input_ids[row, : len(values)] = values
+            attention_mask[row, : len(values)] = 1
+
+        return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+    def _build_inputs(self, texts: list[str]) -> dict[str, Any]:
+        if self._tokenizer is not None:
+            return self._tokenizer(texts)
+        return self._default_tokenize(texts)
+
+    @staticmethod
+    def _first_array(outputs: list[Any] | tuple[Any, ...] | Any) -> np.ndarray:
+        if isinstance(outputs, np.ndarray):
+            return outputs
+        for item in outputs:
+            if isinstance(item, np.ndarray):
+                return item
+        raise ValueError("ONNX model did not return a numpy array")
+
+    @staticmethod
+    def _pool(arr: np.ndarray, attention_mask: np.ndarray | None) -> np.ndarray:
+        if arr.ndim == 2:
+            return arr.astype(np.float32)
+        if arr.ndim != 3:
+            raise ValueError(f"Expected ONNX output with 2 or 3 dims, got shape {arr.shape}")
+
+        values = arr.astype(np.float32)
+        if attention_mask is None:
+            return values.mean(axis=1)
+
+        mask = attention_mask.astype(np.float32)[..., None]
+        denom = np.maximum(mask.sum(axis=1), 1.0)
+        return (values * mask).sum(axis=1) / denom
+
+    def _normalize_vectors(self, arr: np.ndarray) -> np.ndarray:
+        arr = np.asarray(arr, dtype=np.float32)
+        if not self._normalize:
+            return arr
+        norms = np.linalg.norm(arr, axis=1, keepdims=True)
+        norms = np.where(norms == 0, 1.0, norms)
+        return arr / norms
+
+    async def embed(self, texts: list[str]) -> np.ndarray:
+        """Embed a batch of texts, returning an ``(N, D)`` float32 array."""
+
+        import asyncio
+
+        if not texts:
+            return np.empty((0, 0), dtype=np.float32)
+
+        session = self._get_session()
+        inputs = self._build_inputs(texts)
+        loop = asyncio.get_running_loop()
+        outputs = await loop.run_in_executor(None, session.run, None, inputs)
+        arr = self._first_array(outputs)
+        pooled = self._pool(arr, inputs.get("attention_mask"))
+        return self._normalize_vectors(pooled)
+
+    async def embed_one(self, text: str) -> np.ndarray:
+        """Embed a single string, returning a one-dimensional vector."""
+
+        vectors = await self.embed([text])
+        return vectors[0]

--- a/src/synapsekit/embeddings/onnx.py
+++ b/src/synapsekit/embeddings/onnx.py
@@ -85,11 +85,11 @@ class ONNXEmbeddings:
 
         values = arr.astype(np.float32)
         if attention_mask is None:
-            return values.mean(axis=1)
+            return np.asarray(values.mean(axis=1), dtype=np.float32)
 
         mask = attention_mask.astype(np.float32)[..., None]
         denom = np.maximum(mask.sum(axis=1), 1.0)
-        return (values * mask).sum(axis=1) / denom
+        return np.asarray((values * mask).sum(axis=1) / denom, dtype=np.float32)
 
     def _normalize_vectors(self, arr: np.ndarray) -> np.ndarray:
         arr = np.asarray(arr, dtype=np.float32)
@@ -119,4 +119,4 @@ class ONNXEmbeddings:
         """Embed a single string, returning a one-dimensional vector."""
 
         vectors = await self.embed([text])
-        return vectors[0]
+        return np.asarray(vectors[0], dtype=np.float32)

--- a/src/synapsekit/llm/__init__.py
+++ b/src/synapsekit/llm/__init__.py
@@ -2,7 +2,7 @@ from ._cache import AsyncLRUCache
 from .base import BaseLLM, LLMConfig
 from .cost_quality_router import CostQualityRouter
 from .cost_router import QUALITY_TABLE, CostRouter, CostRouterConfig, RouterModelSpec
-from .edge import EdgeFallbackBlockedError, EdgeRuntime, EdgeRouteMetadata, FallbackPolicy
+from .edge import EdgeFallbackBlockedError, EdgeRouteMetadata, EdgeRuntime, FallbackPolicy
 from .fallback_chain import FallbackChain, FallbackChainConfig
 from .structured import generate_structured
 

--- a/src/synapsekit/llm/__init__.py
+++ b/src/synapsekit/llm/__init__.py
@@ -2,6 +2,7 @@ from ._cache import AsyncLRUCache
 from .base import BaseLLM, LLMConfig
 from .cost_quality_router import CostQualityRouter
 from .cost_router import QUALITY_TABLE, CostRouter, CostRouterConfig, RouterModelSpec
+from .edge import EdgeFallbackBlockedError, EdgeRuntime, EdgeRouteMetadata, FallbackPolicy
 from .fallback_chain import FallbackChain, FallbackChainConfig
 from .structured import generate_structured
 
@@ -23,9 +24,13 @@ __all__ = [
     "DatabricksLLM",
     "DeepSeekLLM",
     "DynamoDBCacheBackend",
+    "EdgeFallbackBlockedError",
+    "EdgeRouteMetadata",
+    "EdgeRuntime",
     "ErnieLLM",
     "FallbackChain",
     "FallbackChainConfig",
+    "FallbackPolicy",
     "FireworksLLM",
     "GeminiLLM",
     "GPT4AllLLM",
@@ -36,6 +41,7 @@ __all__ = [
     "LMStudioLLM",
     "MemcachedCacheBackend",
     "MinimaxLLM",
+    "MLXLLM",
     "MistralLLM",
     "MoonshotLLM",
     "NovitaLLM",
@@ -88,6 +94,7 @@ _PROVIDERS = {
     "VLLMLLM": ".vllm",
     "MoonshotLLM": ".moonshot",
     "MinimaxLLM": ".minimax",
+    "MLXLLM": ".mlx",
     "XaiLLM": ".xai",
     "WriterLLM": ".writer",
     "ZhipuLLM": ".zhipu",

--- a/src/synapsekit/llm/_factory.py
+++ b/src/synapsekit/llm/_factory.py
@@ -160,11 +160,15 @@ def make_llm(
         from .gpt4all import GPT4AllLLM
 
         return GPT4AllLLM(config)
+    elif provider == "mlx":
+        from .mlx import MLXLLM
+
+        return MLXLLM(config)
     else:
         raise ValueError(
             f"Unknown provider: {provider!r}. "
             "Use 'openai', 'anthropic', 'ollama', 'ai21', 'cohere', 'mistral', 'gemini', "
             "'bedrock', 'groq', 'deepseek', 'openrouter', 'together', 'fireworks', "
             "'moonshot', 'minimax', 'zhipu', 'cloudflare', 'databricks', 'ernie', 'sambanova', "
-            "'aleph-alpha', 'llamacpp', 'vllm', or 'gpt4all'."
+            "'aleph-alpha', 'llamacpp', 'vllm', 'gpt4all', or 'mlx'."
         )

--- a/src/synapsekit/llm/edge.py
+++ b/src/synapsekit/llm/edge.py
@@ -1,0 +1,382 @@
+"""EdgeRuntime: local-first inference with explicit cloud fallback gates."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from ..agents.pii_redactor import PIIRedactor, RedactionResult
+from .base import BaseLLM, LLMConfig, _messages_to_prompt
+
+EdgeRoute = Literal["local", "cloud"]
+FallbackReason = Literal["context_exceeds", "tool_unsupported", "user_opt_in", "local_error"]
+
+
+class EdgeFallbackBlockedError(RuntimeError):
+    """Raised when a request needs cloud fallback but policy does not permit it."""
+
+
+@dataclass(frozen=True)
+class FallbackDecision:
+    """Decision object returned by ``FallbackPolicy.evaluate``."""
+
+    allowed: bool
+    reason: FallbackReason | None = None
+    blocked_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class FallbackPolicy:
+    """Declarative routing rules for local-first edge inference.
+
+    Cloud fallback is default-deny. A fallback route is available only when a
+    specific gate is enabled and the runtime has a configured cloud model.
+    """
+
+    if_context_exceeds: int | None = None
+    if_tool_unsupported_locally: bool = False
+    if_user_opts_in: bool = False
+    require_pii_redaction_before_fallback: bool = True
+    fallback_on_local_error: bool = False
+
+    def evaluate(
+        self,
+        *,
+        estimated_context_tokens: int,
+        tool_unsupported: bool = False,
+        user_opted_in: bool = False,
+        local_error: BaseException | None = None,
+    ) -> FallbackDecision:
+        """Return whether cloud fallback is allowed for the current call."""
+
+        if (
+            self.if_context_exceeds is not None
+            and estimated_context_tokens > self.if_context_exceeds
+        ):
+            return FallbackDecision(True, "context_exceeds")
+
+        if tool_unsupported:
+            if self.if_tool_unsupported_locally:
+                return FallbackDecision(True, "tool_unsupported")
+            return FallbackDecision(
+                False,
+                blocked_reason=(
+                    "local model does not support tools and "
+                    "if_tool_unsupported_locally is disabled"
+                ),
+            )
+
+        if user_opted_in:
+            if self.if_user_opts_in:
+                return FallbackDecision(True, "user_opt_in")
+            return FallbackDecision(
+                False,
+                blocked_reason="user requested cloud fallback but if_user_opts_in is disabled",
+            )
+
+        if local_error is not None:
+            if self.fallback_on_local_error:
+                return FallbackDecision(True, "local_error")
+            return FallbackDecision(
+                False,
+                blocked_reason=f"local model failed and fallback_on_local_error is disabled: {local_error}",
+            )
+
+        return FallbackDecision(False, blocked_reason="no fallback condition matched")
+
+
+@dataclass(frozen=True)
+class EdgeRouteMetadata:
+    """Metadata describing the most recent edge runtime call."""
+
+    route: EdgeRoute
+    fallback_reason: FallbackReason | None = None
+    estimated_context_tokens: int = 0
+    pii_types_found: tuple[str, ...] = ()
+
+
+class EdgeRuntime(BaseLLM):
+    """Local-first LLM wrapper with policy-controlled cloud fallback.
+
+    ``EdgeRuntime`` is itself a ``BaseLLM`` so it can be passed anywhere a
+    regular SynapseKit model is accepted, including agents and RAG pipelines.
+    It delegates to the local model by default and only calls the cloud model
+    after a ``FallbackPolicy`` gate permits that route.
+    """
+
+    def __init__(
+        self,
+        *,
+        local_llm: BaseLLM,
+        cloud_llm: BaseLLM | None = None,
+        fallback: FallbackPolicy | None = None,
+        local_embeddings: Any | None = None,
+        pii_redactor: PIIRedactor | None = None,
+        token_chars: int = 4,
+    ) -> None:
+        super().__init__(
+            LLMConfig(
+                model=f"edge:{local_llm.config.model}",
+                api_key="",
+                provider="edge",
+                system_prompt=local_llm.config.system_prompt,
+                temperature=local_llm.config.temperature,
+                max_tokens=local_llm.config.max_tokens,
+            )
+        )
+        if token_chars <= 0:
+            raise ValueError("token_chars must be positive")
+
+        self.local_llm = local_llm
+        self.cloud_llm = cloud_llm
+        self.fallback = fallback or FallbackPolicy()
+        self.local_embeddings = local_embeddings
+        self._pii_redactor = pii_redactor or PIIRedactor()
+        self._token_chars = token_chars
+        self._last_metadata = EdgeRouteMetadata(route="local")
+        self._last_redaction: RedactionResult | None = None
+
+    @property
+    def last_route(self) -> EdgeRoute:
+        """Route used by the most recent call."""
+
+        return self._last_metadata.route
+
+    @property
+    def last_fallback_reason(self) -> FallbackReason | None:
+        """Fallback reason for the most recent cloud call, if any."""
+
+        return self._last_metadata.fallback_reason
+
+    @property
+    def last_metadata(self) -> EdgeRouteMetadata:
+        """Structured metadata for the most recent call."""
+
+        return self._last_metadata
+
+    @property
+    def last_redaction(self) -> RedactionResult | None:
+        """PII redaction result from the most recent cloud fallback."""
+
+        return self._last_redaction
+
+    def _estimate_tokens(self, text: str) -> int:
+        compact = " ".join(text.split())
+        if not compact:
+            return 0
+        return max(1, (len(compact) + self._token_chars - 1) // self._token_chars)
+
+    def _estimate_message_tokens(self, messages: list[dict[str, Any]]) -> int:
+        return self._estimate_tokens(_messages_to_prompt(messages))
+
+    def _evaluate_fallback(
+        self,
+        *,
+        estimated_context_tokens: int,
+        tool_unsupported: bool = False,
+        user_opted_in: bool = False,
+        local_error: BaseException | None = None,
+    ) -> FallbackDecision:
+        decision = self.fallback.evaluate(
+            estimated_context_tokens=estimated_context_tokens,
+            tool_unsupported=tool_unsupported,
+            user_opted_in=user_opted_in,
+            local_error=local_error,
+        )
+        if decision.allowed and self.cloud_llm is None:
+            raise EdgeFallbackBlockedError("cloud fallback was allowed but no cloud_llm is configured")
+        return decision
+
+    def _select_for_prompt(self, prompt: str, kw: dict[str, Any]) -> tuple[BaseLLM, FallbackDecision]:
+        estimated = self._estimate_tokens(prompt)
+        user_opted_in = bool(kw.pop("allow_cloud_fallback", False))
+        decision = self._evaluate_fallback(
+            estimated_context_tokens=estimated,
+            user_opted_in=user_opted_in,
+        )
+        if decision.allowed:
+            return self._require_cloud(decision, estimated), decision
+        return self.local_llm, FallbackDecision(False)
+
+    def _select_for_messages(
+        self,
+        messages: list[dict[str, Any]],
+        kw: dict[str, Any],
+    ) -> tuple[BaseLLM, FallbackDecision]:
+        estimated = self._estimate_message_tokens(messages)
+        user_opted_in = bool(kw.pop("allow_cloud_fallback", False))
+        decision = self._evaluate_fallback(
+            estimated_context_tokens=estimated,
+            user_opted_in=user_opted_in,
+        )
+        if decision.allowed:
+            return self._require_cloud(decision, estimated), decision
+        return self.local_llm, FallbackDecision(False)
+
+    def _require_cloud(self, decision: FallbackDecision, estimated: int) -> BaseLLM:
+        if self.cloud_llm is None:
+            raise EdgeFallbackBlockedError("cloud fallback requested but cloud_llm is not configured")
+        self._last_metadata = EdgeRouteMetadata(
+            route="cloud",
+            fallback_reason=decision.reason,
+            estimated_context_tokens=estimated,
+        )
+        return self.cloud_llm
+
+    def _record_local(self, estimated: int) -> None:
+        self._last_redaction = None
+        self._last_metadata = EdgeRouteMetadata(
+            route="local",
+            fallback_reason=None,
+            estimated_context_tokens=estimated,
+        )
+
+    def _redact_text_for_cloud(self, text: str) -> str:
+        if not self.fallback.require_pii_redaction_before_fallback:
+            self._last_redaction = None
+            return text
+        redaction = self._pii_redactor.redact(text)
+        self._last_redaction = redaction
+        self._last_metadata = EdgeRouteMetadata(
+            route="cloud",
+            fallback_reason=self._last_metadata.fallback_reason,
+            estimated_context_tokens=self._last_metadata.estimated_context_tokens,
+            pii_types_found=tuple(redaction.pii_types_found),
+        )
+        return redaction.redacted_text
+
+    def _redact_messages_for_cloud(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        if not self.fallback.require_pii_redaction_before_fallback:
+            self._last_redaction = None
+            return messages
+
+        combined_mapping: dict[str, str] = {}
+        pii_types: set[str] = set()
+        redacted_messages: list[dict[str, Any]] = []
+
+        for message in messages:
+            copied = dict(message)
+            content = copied.get("content")
+            if isinstance(content, str):
+                redaction = self._pii_redactor.redact(content)
+                copied["content"] = redaction.redacted_text
+                combined_mapping.update(redaction.mapping)
+                pii_types.update(redaction.pii_types_found)
+            redacted_messages.append(copied)
+
+        self._last_redaction = RedactionResult(
+            redacted_text=_messages_to_prompt(redacted_messages),
+            mapping=combined_mapping,
+            pii_types_found=sorted(pii_types),
+        )
+        self._last_metadata = EdgeRouteMetadata(
+            route="cloud",
+            fallback_reason=self._last_metadata.fallback_reason,
+            estimated_context_tokens=self._last_metadata.estimated_context_tokens,
+            pii_types_found=tuple(sorted(pii_types)),
+        )
+        return redacted_messages
+
+    async def _fallback_after_error(
+        self,
+        *,
+        prompt: str,
+        kw: dict[str, Any],
+        error: BaseException,
+    ) -> str:
+        estimated = self._estimate_tokens(prompt)
+        decision = self._evaluate_fallback(
+            estimated_context_tokens=estimated,
+            local_error=error,
+        )
+        if not decision.allowed:
+            raise error
+        cloud = self._require_cloud(decision, estimated)
+        return await cloud.generate(self._redact_text_for_cloud(prompt), **kw)
+
+    async def stream(self, prompt: str, **kw: Any) -> AsyncGenerator[str]:
+        call_kw = dict(kw)
+        estimated = self._estimate_tokens(prompt)
+        llm, decision = self._select_for_prompt(prompt, call_kw)
+        if decision.allowed:
+            async for token in llm.stream(self._redact_text_for_cloud(prompt), **call_kw):
+                yield token
+            return
+
+        self._record_local(estimated)
+        try:
+            async for token in self.local_llm.stream(prompt, **call_kw):
+                yield token
+        except Exception as exc:
+            fallback_text = await self._fallback_after_error(prompt=prompt, kw=call_kw, error=exc)
+            for token in fallback_text:
+                yield token
+
+    async def generate(self, prompt: str, **kw: Any) -> str:  # type: ignore[override]
+        call_kw = dict(kw)
+        estimated = self._estimate_tokens(prompt)
+        llm, decision = self._select_for_prompt(prompt, call_kw)
+        if decision.allowed:
+            return await llm.generate(self._redact_text_for_cloud(prompt), **call_kw)
+
+        self._record_local(estimated)
+        try:
+            return await self.local_llm.generate(prompt, **call_kw)
+        except Exception as exc:
+            return await self._fallback_after_error(prompt=prompt, kw=call_kw, error=exc)
+
+    async def stream_with_messages(
+        self,
+        messages: list[dict[str, Any]],
+        **kw: Any,
+    ) -> AsyncGenerator[str]:
+        call_kw = dict(kw)
+        estimated = self._estimate_message_tokens(messages)
+        llm, decision = self._select_for_messages(messages, call_kw)
+        if decision.allowed:
+            safe_messages = self._redact_messages_for_cloud(messages)
+            async for token in llm.stream_with_messages(safe_messages, **call_kw):
+                yield token
+            return
+
+        self._record_local(estimated)
+        async for token in self.local_llm.stream_with_messages(messages, **call_kw):
+            yield token
+
+    async def generate_with_messages(
+        self,
+        messages: list[dict[str, Any]],
+        **kw: Any,
+    ) -> str:
+        call_kw = dict(kw)
+        estimated = self._estimate_message_tokens(messages)
+        llm, decision = self._select_for_messages(messages, call_kw)
+        if decision.allowed:
+            return await llm.generate_with_messages(
+                self._redact_messages_for_cloud(messages),
+                **call_kw,
+            )
+
+        self._record_local(estimated)
+        return await self.local_llm.generate_with_messages(messages, **call_kw)
+
+    async def call_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        estimated = self._estimate_message_tokens(messages)
+        try:
+            self._record_local(estimated)
+            return await self.local_llm.call_with_tools(messages, tools)
+        except NotImplementedError as exc:
+            decision = self._evaluate_fallback(
+                estimated_context_tokens=estimated,
+                tool_unsupported=True,
+            )
+            if not decision.allowed:
+                blocked = decision.blocked_reason or "tool fallback denied"
+                raise EdgeFallbackBlockedError(blocked) from exc
+            cloud = self._require_cloud(decision, estimated)
+            return await cloud.call_with_tools(self._redact_messages_for_cloud(messages), tools)

--- a/src/synapsekit/llm/edge.py
+++ b/src/synapsekit/llm/edge.py
@@ -62,8 +62,7 @@ class FallbackPolicy:
             return FallbackDecision(
                 False,
                 blocked_reason=(
-                    "local model does not support tools and "
-                    "if_tool_unsupported_locally is disabled"
+                    "local model does not support tools and if_tool_unsupported_locally is disabled"
                 ),
             )
 
@@ -185,10 +184,14 @@ class EdgeRuntime(BaseLLM):
             local_error=local_error,
         )
         if decision.allowed and self.cloud_llm is None:
-            raise EdgeFallbackBlockedError("cloud fallback was allowed but no cloud_llm is configured")
+            raise EdgeFallbackBlockedError(
+                "cloud fallback was allowed but no cloud_llm is configured"
+            )
         return decision
 
-    def _select_for_prompt(self, prompt: str, kw: dict[str, Any]) -> tuple[BaseLLM, FallbackDecision]:
+    def _select_for_prompt(
+        self, prompt: str, kw: dict[str, Any]
+    ) -> tuple[BaseLLM, FallbackDecision]:
         estimated = self._estimate_tokens(prompt)
         user_opted_in = bool(kw.pop("allow_cloud_fallback", False))
         decision = self._evaluate_fallback(
@@ -216,7 +219,9 @@ class EdgeRuntime(BaseLLM):
 
     def _require_cloud(self, decision: FallbackDecision, estimated: int) -> BaseLLM:
         if self.cloud_llm is None:
-            raise EdgeFallbackBlockedError("cloud fallback requested but cloud_llm is not configured")
+            raise EdgeFallbackBlockedError(
+                "cloud fallback requested but cloud_llm is not configured"
+            )
         self._last_metadata = EdgeRouteMetadata(
             route="cloud",
             fallback_reason=decision.reason,

--- a/src/synapsekit/llm/mlx.py
+++ b/src/synapsekit/llm/mlx.py
@@ -1,0 +1,127 @@
+"""Apple Silicon local LLM provider using mlx-lm."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from .base import BaseLLM, LLMConfig, _messages_to_prompt
+
+
+class MLXLLM(BaseLLM):
+    """Local provider for MLX models on Apple Silicon.
+
+    ``mlx-lm`` exposes a few generation APIs across versions, so this wrapper
+    supports both simple string generation and iterable token streams.
+    """
+
+    def __init__(
+        self,
+        config: LLMConfig,
+        *,
+        adapter_path: str | None = None,
+        tokenizer_config: dict[str, Any] | None = None,
+        **load_kwargs: Any,
+    ) -> None:
+        super().__init__(config)
+        self._adapter_path = adapter_path
+        self._tokenizer_config = tokenizer_config or {}
+        self._load_kwargs = load_kwargs
+        self._model: Any = None
+        self._tokenizer: Any = None
+        self._generate: Any = None
+        self._stream_generate: Any = None
+
+    def _load_backend(self) -> tuple[Any, Any]:
+        if self._model is not None and self._tokenizer is not None:
+            return self._model, self._tokenizer
+
+        try:
+            from mlx_lm import generate, load, stream_generate
+        except ImportError:
+            raise ImportError("mlx-lm required: pip install synapsekit[mlx]") from None
+
+        kwargs = dict(self._load_kwargs)
+        if self._adapter_path is not None:
+            kwargs["adapter_path"] = self._adapter_path
+        if self._tokenizer_config:
+            kwargs["tokenizer_config"] = self._tokenizer_config
+
+        self._model, self._tokenizer = load(self.config.model, **kwargs)
+        self._generate = generate
+        self._stream_generate = stream_generate
+        return self._model, self._tokenizer
+
+    @staticmethod
+    def _extract_text(token: Any) -> str:
+        if isinstance(token, str):
+            return token
+        text = getattr(token, "text", None)
+        if text is not None:
+            return str(text)
+        return str(token)
+
+    async def stream(self, prompt: str, **kw: Any) -> AsyncGenerator[str]:
+        messages = [
+            {"role": "system", "content": self.config.system_prompt},
+            {"role": "user", "content": prompt},
+        ]
+        async for token in self.stream_with_messages(messages, **kw):
+            yield token
+
+    async def stream_with_messages(
+        self,
+        messages: list[dict[str, Any]],
+        **kw: Any,
+    ) -> AsyncGenerator[str]:
+        model, tokenizer = self._load_backend()
+        prompt = _messages_to_prompt(messages)
+        max_tokens = int(kw.get("max_tokens", self.config.max_tokens))
+        temperature = float(kw.get("temperature", self.config.temperature))
+
+        if self._stream_generate is None:
+            raise RuntimeError("MLX stream generator was not initialized")
+
+        def _collect() -> list[str]:
+            tokens: list[str] = []
+            for token in self._stream_generate(
+                model,
+                tokenizer,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temp=temperature,
+            ):
+                text = self._extract_text(token)
+                if text:
+                    tokens.append(text)
+            return tokens
+
+        loop = asyncio.get_running_loop()
+        tokens = await loop.run_in_executor(None, _collect)
+        for token in tokens:
+            self._output_tokens += 1
+            yield token
+
+    async def generate(self, prompt: str, **kw: Any) -> str:  # type: ignore[override]
+        model, tokenizer = self._load_backend()
+        max_tokens = int(kw.get("max_tokens", self.config.max_tokens))
+        temperature = float(kw.get("temperature", self.config.temperature))
+
+        if self._generate is None:
+            return await super().generate(prompt, **kw)
+
+        loop = asyncio.get_running_loop()
+        result = await loop.run_in_executor(
+            None,
+            lambda: self._generate(
+                model,
+                tokenizer,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temp=temperature,
+            ),
+        )
+        text = self._extract_text(result)
+        self._output_tokens += max(1, len(text.split()))
+        return text

--- a/tests/cli/test_edge.py
+++ b/tests/cli/test_edge.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapsekit.cli.edge import MODEL_REGISTRY, run_edge
+
+
+def test_edge_list_outputs_registry(capsys, tmp_path: Path) -> None:
+    args = argparse.Namespace(edge_command="list", cache_dir=str(tmp_path), output_format="table")
+
+    run_edge(args)
+
+    out = capsys.readouterr().out
+    assert "llama-3.2-3b" in out
+    assert "minilm-l6-onnx" in out
+
+
+def test_edge_list_json(capsys, tmp_path: Path) -> None:
+    args = argparse.Namespace(edge_command="list", cache_dir=str(tmp_path), output_format="json")
+
+    run_edge(args)
+
+    out = capsys.readouterr().out
+    assert '"models"' in out
+    assert '"downloaded": false' in out
+
+
+def test_edge_pull_unknown_model(tmp_path: Path) -> None:
+    args = argparse.Namespace(
+        edge_command="pull",
+        cache_dir=str(tmp_path),
+        model="missing-model",
+        force=False,
+    )
+
+    with pytest.raises(SystemExit, match="Unknown edge model"):
+        run_edge(args)
+
+
+def test_edge_pull_uses_huggingface_hub(capsys, tmp_path: Path) -> None:
+    model = MODEL_REGISTRY["llama-3.2-3b"]
+    target = tmp_path / model.name / model.local_filename
+    target.parent.mkdir(parents=True)
+    target.write_text("mock")
+
+    fake_hub = MagicMock()
+    fake_hub.hf_hub_download.return_value = str(target)
+    args = argparse.Namespace(
+        edge_command="pull",
+        cache_dir=str(tmp_path),
+        model=model.name,
+        force=True,
+    )
+
+    with patch.dict("sys.modules", {"huggingface_hub": fake_hub}):
+        run_edge(args)
+
+    assert fake_hub.hf_hub_download.call_args[1]["repo_id"] == model.repo_id
+    assert model.name in capsys.readouterr().out
+
+
+def test_edge_quantize_missing_binary(tmp_path: Path) -> None:
+    input_model = tmp_path / "input.gguf"
+    input_model.write_text("model")
+    args = argparse.Namespace(
+        edge_command="quantize",
+        input_model=str(input_model),
+        output=str(tmp_path / "out.gguf"),
+        quantization="Q4_K_M",
+        llama_quantize=None,
+    )
+
+    with patch("shutil.which", return_value=None):
+        with pytest.raises(SystemExit, match="llama-quantize"):
+            run_edge(args)
+
+
+def test_edge_quantize_runs_external_binary(tmp_path: Path, capsys) -> None:
+    input_model = tmp_path / "input.gguf"
+    input_model.write_text("model")
+    args = argparse.Namespace(
+        edge_command="quantize",
+        input_model=str(input_model),
+        output=str(tmp_path / "out.gguf"),
+        quantization="Q4_K_M",
+        llama_quantize="llama-quantize",
+    )
+
+    with patch("subprocess.run") as run:
+        run_edge(args)
+
+    run.assert_called_once()
+    assert "Q4_K_M" in capsys.readouterr().out

--- a/tests/embeddings/test_onnx.py
+++ b/tests/embeddings/test_onnx.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from synapsekit.embeddings.onnx import ONNXEmbeddings
+
+
+def test_missing_onnxruntime_raises() -> None:
+    embeddings = ONNXEmbeddings("model.onnx")
+    with patch.dict("sys.modules", {"onnxruntime": None}):
+        with pytest.raises(ImportError, match="onnxruntime"):
+            embeddings._get_session()
+
+
+@pytest.mark.asyncio
+async def test_embed_with_mocked_session_normalizes_vectors() -> None:
+    session = MagicMock()
+    session.run.return_value = [
+        np.array(
+            [
+                [[1.0, 0.0], [1.0, 0.0]],
+                [[0.0, 2.0], [0.0, 2.0]],
+            ],
+            dtype=np.float32,
+        )
+    ]
+    embeddings = ONNXEmbeddings(
+        "model.onnx",
+        tokenizer=lambda texts: {
+            "input_ids": np.ones((len(texts), 2), dtype=np.int64),
+            "attention_mask": np.ones((len(texts), 2), dtype=np.int64),
+        },
+    )
+    embeddings._session = session
+
+    result = await embeddings.embed(["a", "b"])
+
+    assert result.shape == (2, 2)
+    assert result.dtype == np.float32
+    np.testing.assert_allclose(np.linalg.norm(result, axis=1), np.array([1.0, 1.0]))
+
+
+@pytest.mark.asyncio
+async def test_embed_one_returns_single_vector() -> None:
+    session = MagicMock()
+    session.run.return_value = [np.array([[3.0, 4.0]], dtype=np.float32)]
+    embeddings = ONNXEmbeddings("model.onnx")
+    embeddings._session = session
+
+    result = await embeddings.embed_one("hello")
+
+    assert result.shape == (2,)
+    np.testing.assert_allclose(result, np.array([0.6, 0.8], dtype=np.float32))

--- a/tests/llm/test_edge_runtime.py
+++ b/tests/llm/test_edge_runtime.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+
+from synapsekit.llm.base import BaseLLM, LLMConfig
+from synapsekit.llm.edge import EdgeFallbackBlockedError, EdgeRuntime, FallbackPolicy
+
+
+class FakeLLM(BaseLLM):
+    def __init__(
+        self,
+        *,
+        name: str,
+        response: str,
+        supports_tools: bool = False,
+        fail_generate: bool = False,
+    ) -> None:
+        super().__init__(LLMConfig(model=name, api_key="", provider=name))
+        self.response = response
+        self.supports_tools = supports_tools
+        self.fail_generate = fail_generate
+        self.prompts: list[str] = []
+        self.messages: list[list[dict[str, Any]]] = []
+
+    async def stream(self, prompt: str, **kw: Any) -> AsyncGenerator[str]:
+        if self.fail_generate:
+            raise RuntimeError("local failed")
+        self.prompts.append(prompt)
+        for token in self.response.split("|"):
+            yield token
+
+    async def generate(self, prompt: str, **kw: Any) -> str:
+        if self.fail_generate:
+            raise RuntimeError("local failed")
+        self.prompts.append(prompt)
+        return self.response.replace("|", "")
+
+    async def generate_with_messages(self, messages: list[dict[str, Any]], **kw: Any) -> str:
+        self.messages.append(messages)
+        return self.response.replace("|", "")
+
+    async def stream_with_messages(
+        self,
+        messages: list[dict[str, Any]],
+        **kw: Any,
+    ) -> AsyncGenerator[str]:
+        self.messages.append(messages)
+        for token in self.response.split("|"):
+            yield token
+
+    async def _call_with_tools_impl(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        if not self.supports_tools:
+            raise NotImplementedError("tools unsupported")
+        self.messages.append(messages)
+        return {"content": self.response, "tool_calls": None}
+
+
+@pytest.mark.asyncio
+async def test_local_generate_is_default() -> None:
+    runtime = EdgeRuntime(local_llm=FakeLLM(name="local", response="ok"))
+
+    result = await runtime.generate("hello")
+
+    assert result == "ok"
+    assert runtime.last_route == "local"
+    assert runtime.last_fallback_reason is None
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_routes_to_cloud() -> None:
+    local = FakeLLM(name="local", response="local")
+    cloud = FakeLLM(name="cloud", response="cloud")
+    runtime = EdgeRuntime(
+        local_llm=local,
+        cloud_llm=cloud,
+        fallback=FallbackPolicy(if_context_exceeds=1),
+    )
+
+    result = await runtime.generate("this is definitely longer than one token")
+
+    assert result == "cloud"
+    assert runtime.last_route == "cloud"
+    assert runtime.last_fallback_reason == "context_exceeds"
+    assert local.prompts == []
+    assert cloud.prompts
+
+
+@pytest.mark.asyncio
+async def test_cloud_fallback_requires_cloud_model() -> None:
+    runtime = EdgeRuntime(
+        local_llm=FakeLLM(name="local", response="local"),
+        fallback=FallbackPolicy(if_context_exceeds=1),
+    )
+
+    with pytest.raises(EdgeFallbackBlockedError, match="no cloud_llm"):
+        await runtime.generate("this prompt exceeds the policy threshold")
+
+
+@pytest.mark.asyncio
+async def test_user_opt_in_gate() -> None:
+    cloud = FakeLLM(name="cloud", response="cloud")
+    runtime = EdgeRuntime(
+        local_llm=FakeLLM(name="local", response="local"),
+        cloud_llm=cloud,
+        fallback=FallbackPolicy(if_user_opts_in=True),
+    )
+
+    assert await runtime.generate("hello") == "local"
+    assert await runtime.generate("hello", allow_cloud_fallback=True) == "cloud"
+    assert runtime.last_fallback_reason == "user_opt_in"
+
+
+@pytest.mark.asyncio
+async def test_pii_is_redacted_before_cloud_generate() -> None:
+    cloud = FakeLLM(name="cloud", response="cloud")
+    runtime = EdgeRuntime(
+        local_llm=FakeLLM(name="local", response="local"),
+        cloud_llm=cloud,
+        fallback=FallbackPolicy(if_user_opts_in=True, require_pii_redaction_before_fallback=True),
+    )
+
+    await runtime.generate(
+        "Email alice@example.com or call 555-123-4567",
+        allow_cloud_fallback=True,
+    )
+
+    sent = cloud.prompts[-1]
+    assert "alice@example.com" not in sent
+    assert "555-123-4567" not in sent
+    assert "[EMAIL_1]" in sent
+    assert "[PHONE_1]" in sent
+    assert runtime.last_redaction is not None
+    assert runtime.last_metadata.pii_types_found == ("email", "phone")
+
+
+@pytest.mark.asyncio
+async def test_pii_is_redacted_before_cloud_messages() -> None:
+    cloud = FakeLLM(name="cloud", response="cloud")
+    runtime = EdgeRuntime(
+        local_llm=FakeLLM(name="local", response="local"),
+        cloud_llm=cloud,
+        fallback=FallbackPolicy(if_user_opts_in=True),
+    )
+
+    await runtime.generate_with_messages(
+        [{"role": "user", "content": "My SSN is 123-45-6789"}],
+        allow_cloud_fallback=True,
+    )
+
+    assert cloud.messages[-1][0]["content"] == "My SSN is [SSN_1]"
+    assert runtime.last_metadata.pii_types_found == ("ssn",)
+
+
+@pytest.mark.asyncio
+async def test_tool_unsupported_falls_back_when_allowed() -> None:
+    cloud = FakeLLM(name="cloud", response="tool", supports_tools=True)
+    runtime = EdgeRuntime(
+        local_llm=FakeLLM(name="local", response="local", supports_tools=False),
+        cloud_llm=cloud,
+        fallback=FallbackPolicy(if_tool_unsupported_locally=True),
+    )
+
+    result = await runtime.call_with_tools(
+        [{"role": "user", "content": "use a tool"}],
+        [{"type": "function", "function": {"name": "lookup", "parameters": {}}}],
+    )
+
+    assert result == {"content": "tool", "tool_calls": None}
+    assert runtime.last_route == "cloud"
+    assert runtime.last_fallback_reason == "tool_unsupported"
+
+
+@pytest.mark.asyncio
+async def test_tool_unsupported_is_blocked_by_default() -> None:
+    runtime = EdgeRuntime(
+        local_llm=FakeLLM(name="local", response="local", supports_tools=False),
+        cloud_llm=FakeLLM(name="cloud", response="cloud", supports_tools=True),
+    )
+
+    with pytest.raises(EdgeFallbackBlockedError, match="if_tool_unsupported_locally"):
+        await runtime.call_with_tools([{"role": "user", "content": "tool"}], [])
+
+
+@pytest.mark.asyncio
+async def test_stream_cloud_preserves_token_order() -> None:
+    runtime = EdgeRuntime(
+        local_llm=FakeLLM(name="local", response="local"),
+        cloud_llm=FakeLLM(name="cloud", response="a|b|c"),
+        fallback=FallbackPolicy(if_user_opts_in=True),
+    )
+
+    tokens = [token async for token in runtime.stream("hello", allow_cloud_fallback=True)]
+
+    assert tokens == ["a", "b", "c"]
+    assert runtime.last_route == "cloud"
+
+
+@pytest.mark.asyncio
+async def test_local_error_fallback_can_be_enabled() -> None:
+    runtime = EdgeRuntime(
+        local_llm=FakeLLM(name="local", response="local", fail_generate=True),
+        cloud_llm=FakeLLM(name="cloud", response="cloud"),
+        fallback=FallbackPolicy(fallback_on_local_error=True),
+    )
+
+    assert await runtime.generate("hello") == "cloud"
+    assert runtime.last_fallback_reason == "local_error"

--- a/tests/llm/test_mlx.py
+++ b/tests/llm/test_mlx.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapsekit.llm.base import LLMConfig
+from synapsekit.llm.mlx import MLXLLM
+
+
+def make_llm() -> MLXLLM:
+    return MLXLLM(LLMConfig(model="mlx-community/test", api_key="", provider="mlx"))
+
+
+def test_missing_mlx_lm_raises() -> None:
+    llm = make_llm()
+    with patch.dict("sys.modules", {"mlx_lm": None}):
+        with pytest.raises(ImportError, match="mlx-lm"):
+            llm._load_backend()
+
+
+@pytest.mark.asyncio
+async def test_generate_uses_mlx_backend() -> None:
+    mock_mlx = MagicMock()
+    mock_mlx.load.return_value = ("model", "tokenizer")
+    mock_mlx.generate.return_value = "hello"
+    mock_mlx.stream_generate.return_value = iter([])
+
+    with patch.dict("sys.modules", {"mlx_lm": mock_mlx}):
+        result = await make_llm().generate("hi")
+
+    assert result == "hello"
+    assert mock_mlx.generate.call_args[1]["prompt"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_stream_yields_tokens() -> None:
+    token = MagicMock()
+    token.text = "world"
+    mock_mlx = MagicMock()
+    mock_mlx.load.return_value = ("model", "tokenizer")
+    mock_mlx.generate.return_value = "unused"
+    mock_mlx.stream_generate.return_value = iter(["hello ", token])
+
+    with patch.dict("sys.modules", {"mlx_lm": mock_mlx}):
+        tokens = [token async for token in make_llm().stream("hi")]
+
+    assert tokens == ["hello ", "world"]


### PR DESCRIPTION
Closes #736

## Summary

This PR adds the first pass of Edge SynapseKit: local-first inference with explicit, policy-gated cloud fallback for privacy-sensitive deployments.

## Changes

- Add `EdgeRuntime`, `FallbackPolicy`, `EdgeRouteMetadata`, and `EdgeFallbackBlockedError`.
- Route local by default and allow cloud fallback only for configured conditions:
  - context overflow
  - unsupported local tool calls
  - explicit user opt-in
  - optional local model errors
- Redact PII before cloud fallback using the existing `PIIRedactor` path.
- Add optional `ONNXEmbeddings` and `MLXLLM` providers behind optional extras.
- Add `synapsekit edge list`, `synapsekit edge pull`, and `synapsekit edge quantize` commands.
- Add edge docs and a runnable local-first example.
- Add focused tests for routing, redaction, provider wrappers, and CLI behavior.


## Notes

- Mobile Swift/Kotlin bindings are documented as future work, matching the issue's post-v2.0 scope note.
- Tests mock downloads and model backends, so CI does not need API keys, network model downloads, or large local binaries.
