### PR TITLE
feat: add property graph RAG

### DIFF
--- a/docs/rag/graph-rag.md
+++ b/docs/rag/graph-rag.md
@@ -1,0 +1,108 @@
+# Graph RAG
+
+SynapseKit property-graph RAG combines vector search with graph traversal. It is useful when a
+question depends on relationships between entities rather than a single semantically similar chunk.
+
+## GraphVectorStore
+
+`GraphVectorStore` implements the same async vector-store interface as the other retrieval
+backends. Documents are embedded into an underlying vector store and also passed through
+`KnowledgeGraphExtractor`, which stores entities and relationships in a property graph.
+
+```python
+from synapsekit.embeddings import SynapsekitEmbeddings
+from synapsekit.retrieval import GraphVectorStore
+
+embeddings = SynapsekitEmbeddings()
+store = GraphVectorStore(embeddings, backend="networkx")
+
+await store.add(
+    ["Dana leads Apollo. Apollo is built by Platform Team."],
+    metadata=[{"source": "apollo-brief"}],
+)
+
+results = await store.search("Who leads the project built by Platform Team?", top_k=3)
+```
+
+Search starts with vector results, selects graph seeds from the query and matching documents,
+traverses the graph, then fuses graph-linked documents back into the ranked results. Returned
+items keep the standard shape:
+
+```python
+{"text": "...", "score": 0.91, "metadata": {"source": "apollo-brief"}}
+```
+
+## KnowledgeGraphExtractor
+
+The extractor accepts an optional LLM. Without one, it uses a deterministic local extractor for
+tests and offline development.
+
+```python
+from synapsekit.retrieval import KnowledgeGraphExtractor, NetworkXPropertyGraphBackend
+
+graph = NetworkXPropertyGraphBackend()
+extractor = KnowledgeGraphExtractor(store=graph)
+
+await extractor.ingest(
+    [{"text": "Dana leads Apollo.", "metadata": {"source": "doc-1"}}]
+)
+```
+
+Nodes and edges include `confidence`, `source_doc`, and `extracted_at` properties. LLM extraction
+expects strict JSON with `entities` and `relationships` arrays, so custom LLM providers can be used
+without changing graph storage.
+
+## Backends
+
+Use the in-memory backend for local development and tests:
+
+```python
+store = GraphVectorStore(embeddings, backend="networkx")
+```
+
+Use Neo4j for production deployments:
+
+```python
+store = GraphVectorStore(
+    embeddings,
+    backend="neo4j",
+    uri="bolt://localhost:7687",
+    username="neo4j",
+    password="password",
+)
+```
+
+Neo4j support is optional. Install the graph extra before using it:
+
+```bash
+uv sync --extra graph
+```
+
+## Agent Memory
+
+`AgentMemory` also accepts a graph backend. Each memory record is stored as a node, and callers can
+connect memories by passing `related_to`, `relation_type`, and `weight` metadata.
+
+```python
+from synapsekit.memory import AgentMemory
+from synapsekit.retrieval import NetworkXPropertyGraphBackend
+
+graph = NetworkXPropertyGraphBackend()
+memory = AgentMemory(backend="graph", store=graph)
+
+first = await memory.store(
+    agent_id="agent-a",
+    content="User prefers concise Python answers",
+    memory_type="semantic",
+)
+
+await memory.store(
+    agent_id="agent-a",
+    content="User is building a graph RAG prototype",
+    memory_type="episodic",
+    metadata={"related_to": [first.id], "relation_type": "supports", "weight": 0.8},
+)
+```
+
+The backend preserves the normal `AgentMemory` methods: `store`, `recall`, `list`, `count`,
+`delete`, `clear`, and TTL pruning.

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -270,6 +270,7 @@ from .loaders.web import WebLoader
 from .loaders.wikipedia import WikipediaLoader
 from .mcp import MCPClient, MCPServer, MCPToolAdapter
 from .memory import AgentMemory as PersistentAgentMemory
+from .memory import GraphAgentMemory, GraphMemoryBackend
 from .memory.buffer import BufferMemory
 from .memory.conversation import ConversationMemory
 from .memory.entity import EntityMemory
@@ -321,6 +322,17 @@ from .retrieval.hyde import HyDERetriever
 from .retrieval.mongodb_atlas import MongoDBAtlasVectorStore
 from .retrieval.multi_step import MultiStepRetriever
 from .retrieval.parent_document import ParentDocumentRetriever
+from .retrieval.property_graph import (
+    ExtractedEntity,
+    ExtractedRelationship,
+    GraphVectorStore,
+    KnowledgeGraphExtraction,
+    KnowledgeGraphExtractor,
+    Neo4jPropertyGraphBackend,
+    NetworkXPropertyGraphBackend,
+    PropertyGraphEdge,
+    PropertyGraphNode,
+)
 from .retrieval.query_decomposition import QueryDecompositionRetriever
 from .retrieval.rag_fusion import RAGFusionRetriever
 from .retrieval.retriever import Retriever
@@ -457,6 +469,7 @@ __all__ = [
     # Vector stores
     "VectorStore",
     "InMemoryVectorStore",
+    "GraphVectorStore",
     "ChromaVectorStore",
     "FAISSVectorStore",
     "LanceDBVectorStore",
@@ -488,6 +501,14 @@ __all__ = [
     "SentenceWindowRetriever",
     "GraphRAGRetriever",
     "KnowledgeGraph",
+    "KnowledgeGraphExtraction",
+    "KnowledgeGraphExtractor",
+    "NetworkXPropertyGraphBackend",
+    "Neo4jPropertyGraphBackend",
+    "PropertyGraphNode",
+    "PropertyGraphEdge",
+    "ExtractedEntity",
+    "ExtractedRelationship",
     "StepBackRetriever",
     "WorldModelRAG",
     "ExtractionPolicy",
@@ -514,6 +535,8 @@ __all__ = [
     "CircuitState",
     # Memory / observability
     "PersistentAgentMemory",
+    "GraphAgentMemory",
+    "GraphMemoryBackend",
     "BufferMemory",
     "ConversationMemory",
     "EntityMemory",

--- a/src/synapsekit/agents/agent_registry.py
+++ b/src/synapsekit/agents/agent_registry.py
@@ -197,7 +197,7 @@ class Reputation:
             snapshot.mean_quality = quality
             snapshot.mean_reward = reward
         else:
-            snapshot.avg_cost = self._ema(snapshot.avg_cost, cost, learning_rate)
+            snapshot.avg_cost = self._ema(snapshot.avg_cost or 0.0, cost, learning_rate)
             snapshot.mean_quality = self._ema(snapshot.mean_quality, quality, learning_rate)
             snapshot.mean_reward = self._ema(snapshot.mean_reward, reward, learning_rate)
 

--- a/src/synapsekit/agents/agent_registry.py
+++ b/src/synapsekit/agents/agent_registry.py
@@ -134,7 +134,7 @@ class ReputationSnapshot:
             task_category=data.get("task_category", "general"),
             attempts=data.get("attempts", 0),
             wins=data.get("wins", 0),
-            avg_cost=data.get("avg_cost", None),
+            avg_cost=data.get("avg_cost"),
             mean_quality=data.get("mean_quality", 0.5),
             mean_reward=data.get("mean_reward", 0.0),
             quality_alpha=data.get("quality_alpha", 1.0),

--- a/src/synapsekit/cli/edge.py
+++ b/src/synapsekit/cli/edge.py
@@ -120,7 +120,6 @@ def _download_model(model: EdgeModel, cache_root: Path, force: bool) -> Path:
         repo_id=model.repo_id,
         filename=model.filename,
         local_dir=str(destination_dir),
-        local_dir_use_symlinks=False,
         force_download=force,
     )
     downloaded_path = Path(downloaded)

--- a/src/synapsekit/computer_use/decorators.py
+++ b/src/synapsekit/computer_use/decorators.py
@@ -19,6 +19,7 @@ def requires_human_confirmation(
 
     def _wrap(func: F, _reason: str | None) -> F:
         if inspect.iscoroutinefunction(func):
+
             @functools.wraps(func)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
                 return await func(*args, **kwargs)
@@ -28,6 +29,7 @@ def requires_human_confirmation(
             async_wrapper._requires_confirmation = True  # type: ignore[attr-defined]
             return cast(F, async_wrapper)
         else:
+
             @functools.wraps(func)
             def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
                 return func(*args, **kwargs)

--- a/src/synapsekit/computer_use/decorators.py
+++ b/src/synapsekit/computer_use/decorators.py
@@ -41,11 +41,11 @@ def requires_human_confirmation(
 
     # Called as @requires_human_confirmation (no parentheses) — reason is the function
     if callable(reason):
-        return _wrap(cast(F, reason), None)
+        return _wrap(reason, None)
 
     # Called as @requires_human_confirmation() or @requires_human_confirmation("text")
     def decorator(func: F) -> F:
-        return _wrap(func, cast("str | None", reason))
+        return _wrap(func, reason)
 
     return decorator
 

--- a/src/synapsekit/computer_use/safety.py
+++ b/src/synapsekit/computer_use/safety.py
@@ -142,7 +142,9 @@ class SafetyPolicy:
             )
             if part
         ).lower()
-        keywords = tuple(self.confirm_before) if self.confirm_before is not None else _DANGEROUS_WORDS
+        keywords = (
+            tuple(self.confirm_before) if self.confirm_before is not None else _DANGEROUS_WORDS
+        )
         if any(re.search(rf"\b{re.escape(word.lower())}\b", text) for word in keywords):
             return True
         if self.require_confirmation_for_text and action.action_type in _SENSITIVE_ACTIONS:

--- a/src/synapsekit/memory/__init__.py
+++ b/src/synapsekit/memory/__init__.py
@@ -1,5 +1,7 @@
 from .agent_memory import AgentMemory
 from .backends import (
+    GraphAgentMemory,
+    GraphMemoryBackend,
     InMemoryMemoryBackend,
     PostgresMemoryBackend,
     RedisMemoryBackend,
@@ -23,6 +25,8 @@ __all__ = [
     "AgentMemory",
     "BaseMemoryBackend",
     "MemoryRecord",
+    "GraphAgentMemory",
+    "GraphMemoryBackend",
     "InMemoryMemoryBackend",
     "SQLiteMemoryBackend",
     "RedisMemoryBackend",

--- a/src/synapsekit/memory/agent_memory.py
+++ b/src/synapsekit/memory/agent_memory.py
@@ -9,7 +9,9 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from typing import Any
 
+from ..retrieval.property_graph import PropertyGraphBackend
 from .backends import (
+    GraphMemoryBackend,
     InMemoryMemoryBackend,
     PostgresMemoryBackend,
     RedisMemoryBackend,
@@ -30,6 +32,7 @@ class AgentMemory:
         path: str | None = None,
         redis_url: str = "redis://localhost:6379",
         postgres_dsn: str | None = None,
+        store: PropertyGraphBackend | None = None,
         embedder: EmbedderFn | None = None,
         llm: Any | None = None,
         max_episodes: int = 100,
@@ -40,6 +43,7 @@ class AgentMemory:
             path=path,
             redis_url=redis_url,
             postgres_dsn=postgres_dsn,
+            graph_store=store,
         )
         self._embedder = embedder
         self._llm = llm
@@ -53,6 +57,7 @@ class AgentMemory:
         path: str | None,
         redis_url: str,
         postgres_dsn: str | None,
+        graph_store: PropertyGraphBackend | None,
     ) -> BaseMemoryBackend:
         if isinstance(backend, BaseMemoryBackend):
             return backend
@@ -66,6 +71,8 @@ class AgentMemory:
             if not postgres_dsn:
                 raise ValueError("postgres_dsn is required when backend='postgres'")
             return PostgresMemoryBackend(postgres_dsn)
+        if backend == "graph":
+            return GraphMemoryBackend(graph_store)
         raise ValueError(f"Unknown backend: {backend!r}")
 
     @staticmethod

--- a/src/synapsekit/memory/backends/__init__.py
+++ b/src/synapsekit/memory/backends/__init__.py
@@ -1,9 +1,12 @@
+from .graph import GraphAgentMemory, GraphMemoryBackend
 from .memory import InMemoryMemoryBackend
 from .postgres import PostgresMemoryBackend
 from .redis import RedisMemoryBackend
 from .sqlite import SQLiteMemoryBackend
 
 __all__ = [
+    "GraphAgentMemory",
+    "GraphMemoryBackend",
     "InMemoryMemoryBackend",
     "SQLiteMemoryBackend",
     "RedisMemoryBackend",

--- a/src/synapsekit/memory/backends/graph.py
+++ b/src/synapsekit/memory/backends/graph.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from ...retrieval.property_graph import (
+    NetworkXPropertyGraphBackend,
+    PropertyGraphBackend,
+    PropertyGraphEdge,
+    PropertyGraphNode,
+)
+from ..base import BaseMemoryBackend, MemoryRecord, MemoryType
+
+
+class GraphMemoryBackend(BaseMemoryBackend):
+    """AgentMemory backend that stores memories as property-graph nodes."""
+
+    def __init__(self, store: PropertyGraphBackend | None = None) -> None:
+        self.graph_store = store or NetworkXPropertyGraphBackend()
+        self._records: dict[str, dict[str, MemoryRecord]] = {}
+
+    async def store(self, record: MemoryRecord) -> None:
+        self._records.setdefault(record.agent_id, {})[record.id] = record
+        self.graph_store.upsert_node(
+            PropertyGraphNode(
+                id=self._node_id(record),
+                label=record.content,
+                type=f"memory_{record.memory_type}",
+                properties=self._record_properties(record),
+            )
+        )
+        for related_id in self._related_ids(record.metadata):
+            if related_id == record.id:
+                continue
+            self.graph_store.upsert_edge(
+                PropertyGraphEdge(
+                    source=self._node_id(record),
+                    target=f"memory:{record.agent_id}:{related_id}",
+                    relation=str(record.metadata.get("relation_type", "related_to")),
+                    properties={
+                        "weight": float(record.metadata.get("weight", 1.0)),
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "relation_type": str(record.metadata.get("relation_type", "related_to")),
+                        "agent_id": record.agent_id,
+                    },
+                )
+            )
+
+    async def fetch(
+        self,
+        agent_id: str,
+        memory_type: MemoryType | None = None,
+        *,
+        include_expired: bool = False,
+    ) -> list[MemoryRecord]:
+        bucket = self._records.get(agent_id, {})
+        now = datetime.now(timezone.utc)
+        records: list[MemoryRecord] = []
+        for record in bucket.values():
+            if memory_type is not None and record.memory_type != memory_type:
+                continue
+            if not include_expired and record.is_expired(now):
+                continue
+            records.append(record)
+        records.sort(key=lambda record: record.created_at)
+        return records
+
+    async def touch(
+        self,
+        agent_id: str,
+        record_id: str,
+        *,
+        accessed_at: datetime | None = None,
+    ) -> None:
+        record = self._records.get(agent_id, {}).get(record_id)
+        if record is None:
+            return
+        record.accessed_at = accessed_at or datetime.now(timezone.utc)
+        record.access_count += 1
+        node = self.graph_store.get_node(self._node_id(record))
+        if node is not None:
+            node.properties["accessed_at"] = record.accessed_at.isoformat()
+            node.properties["access_count"] = record.access_count
+            self.graph_store.upsert_node(node)
+
+    async def delete(self, agent_id: str, record_id: str) -> bool:
+        bucket = self._records.get(agent_id)
+        if bucket is None:
+            return False
+        return bucket.pop(record_id, None) is not None
+
+    async def clear(self, agent_id: str, memory_type: MemoryType | None = None) -> int:
+        bucket = self._records.get(agent_id)
+        if bucket is None:
+            return 0
+        if memory_type is None:
+            removed = len(bucket)
+            bucket.clear()
+            return removed
+        to_remove = [
+            record_id for record_id, record in bucket.items() if record.memory_type == memory_type
+        ]
+        for record_id in to_remove:
+            bucket.pop(record_id, None)
+        return len(to_remove)
+
+    async def count(self, agent_id: str, memory_type: MemoryType | None = None) -> int:
+        bucket = self._records.get(agent_id, {})
+        if memory_type is None:
+            return len(bucket)
+        return sum(1 for record in bucket.values() if record.memory_type == memory_type)
+
+    async def prune_expired(self, *, now: datetime | None = None) -> int:
+        now_utc = now or datetime.now(timezone.utc)
+        removed = 0
+        for agent_id, bucket in list(self._records.items()):
+            expired = [
+                record_id for record_id, record in bucket.items() if record.is_expired(now_utc)
+            ]
+            for record_id in expired:
+                bucket.pop(record_id, None)
+                removed += 1
+            if not bucket:
+                self._records.pop(agent_id, None)
+        return removed
+
+    @staticmethod
+    def _node_id(record: MemoryRecord) -> str:
+        return f"memory:{record.agent_id}:{record.id}"
+
+    @staticmethod
+    def _related_ids(metadata: dict[str, Any]) -> list[str]:
+        related = metadata.get("related_to") or metadata.get("related_ids") or []
+        if isinstance(related, str):
+            return [related]
+        if isinstance(related, list | tuple | set):
+            return [str(item) for item in related]
+        return []
+
+    @staticmethod
+    def _record_properties(record: MemoryRecord) -> dict[str, Any]:
+        return {
+            **record.metadata,
+            "record_id": record.id,
+            "agent_id": record.agent_id,
+            "memory_type": record.memory_type,
+            "created_at": record.created_at.isoformat(),
+            "accessed_at": record.accessed_at.isoformat(),
+            "access_count": record.access_count,
+            "ttl_days": record.ttl_days,
+        }
+
+
+GraphAgentMemory = GraphMemoryBackend

--- a/src/synapsekit/retrieval/__init__.py
+++ b/src/synapsekit/retrieval/__init__.py
@@ -18,6 +18,17 @@ from .late_chunking import LateChunkingRetriever
 from .mongodb_atlas import MongoDBAtlasVectorStore
 from .multi_step import MultiStepRetriever
 from .parent_document import ParentDocumentRetriever
+from .property_graph import (
+    ExtractedEntity,
+    ExtractedRelationship,
+    GraphVectorStore,
+    KnowledgeGraphExtraction,
+    KnowledgeGraphExtractor,
+    Neo4jPropertyGraphBackend,
+    NetworkXPropertyGraphBackend,
+    PropertyGraphEdge,
+    PropertyGraphNode,
+)
 from .query_decomposition import QueryDecompositionRetriever
 from .raptor import RAPTORRetriever
 from .retriever import Retriever
@@ -69,17 +80,24 @@ __all__ = [
     "FLARERetriever",
     "FullContextRetriever",
     "GraphRAGRetriever",
+    "GraphVectorStore",
     "HybridSearchRetriever",
     "HyDERetriever",
     "InMemoryVectorStore",
     "KnowledgeGraph",
+    "KnowledgeGraphExtraction",
+    "KnowledgeGraphExtractor",
     "LanceDBVectorStore",
     "MarqoVectorStore",
     "MilvusVectorStore",
     "MongoDBAtlasVectorStore",
     "MultiStepRetriever",
+    "Neo4jPropertyGraphBackend",
+    "NetworkXPropertyGraphBackend",
     "OpenSearchVectorStore",
     "ParentDocumentRetriever",
+    "PropertyGraphEdge",
+    "PropertyGraphNode",
     "PGVectorStore",
     "PineconeVectorStore",
     "QdrantVectorStore",
@@ -112,6 +130,8 @@ __all__ = [
     "WorldModelNode",
     "WorldModelRAG",
     "WorldModelQueryResult",
+    "ExtractedEntity",
+    "ExtractedRelationship",
     "ZillizVectorStore",
 ]
 

--- a/src/synapsekit/retrieval/property_graph.py
+++ b/src/synapsekit/retrieval/property_graph.py
@@ -1,0 +1,900 @@
+"""Property-graph retrieval primitives for graph-aware RAG."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from itertools import pairwise
+from typing import Any, Literal, Protocol, cast
+
+from ..embeddings.backend import SynapsekitEmbeddings
+from ..llm.base import BaseLLM
+from .base import VectorStore
+from .vectorstore import InMemoryVectorStore
+
+PropertyGraphBackendName = Literal["networkx", "neo4j"]
+
+_ENTITY_RE = re.compile(
+    r"(?:@[A-Za-z][\w.-]*|[A-Z][A-Za-z0-9&.-]*(?:\s+[A-Z][A-Za-z0-9&.-]*){0,4})"
+)
+_RELATION_HINTS: tuple[tuple[str, str], ...] = (
+    ("acquired", "acquired"),
+    ("built", "built"),
+    ("created", "created"),
+    ("depends on", "depends_on"),
+    ("founded", "founded"),
+    ("leads", "leads"),
+    ("led", "led"),
+    ("released", "released"),
+    ("uses", "uses"),
+    ("works on", "works_on"),
+)
+
+
+@dataclass(slots=True)
+class PropertyGraphNode:
+    """A property-graph node with arbitrary metadata."""
+
+    id: str
+    label: str
+    type: str = "entity"
+    properties: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class PropertyGraphEdge:
+    """A directed property-graph edge with arbitrary metadata."""
+
+    source: str
+    target: str
+    relation: str = "related_to"
+    properties: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def id(self) -> str:
+        return f"{self.source}:{self.relation}:{self.target}"
+
+
+@dataclass(slots=True)
+class ExtractedEntity:
+    """Entity extracted from a document."""
+
+    name: str
+    type: str = "entity"
+    confidence: float = 1.0
+    properties: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ExtractedRelationship:
+    """Relationship extracted from a document."""
+
+    source: str
+    target: str
+    relation: str = "related_to"
+    confidence: float = 1.0
+    properties: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class KnowledgeGraphExtraction:
+    """Structured extraction output for one document."""
+
+    entities: list[ExtractedEntity] = field(default_factory=list)
+    relationships: list[ExtractedRelationship] = field(default_factory=list)
+
+
+class PropertyGraphBackend(Protocol):
+    """Storage contract used by graph RAG and graph-backed memory."""
+
+    def upsert_node(self, node: PropertyGraphNode) -> None: ...
+
+    def upsert_edge(self, edge: PropertyGraphEdge) -> None: ...
+
+    def get_node(self, node_id: str) -> PropertyGraphNode | None: ...
+
+    def get_edge(self, edge_id: str) -> PropertyGraphEdge | None: ...
+
+    def neighbors(
+        self, node_id: str, *, direction: Literal["both", "out", "in"] = "both"
+    ) -> list[str]: ...
+
+    def traverse(
+        self,
+        seed_ids: list[str],
+        *,
+        max_hops: int = 2,
+        min_confidence: float = 0.0,
+    ) -> tuple[list[PropertyGraphNode], list[PropertyGraphEdge]]: ...
+
+    def document_ids_for_nodes(self, node_ids: list[str]) -> list[str]: ...
+
+    def nodes(self) -> list[PropertyGraphNode]: ...
+
+    def edges(self) -> list[PropertyGraphEdge]: ...
+
+
+class _AdjacencyGraph:
+    """Small fallback graph used when NetworkX is not installed."""
+
+    def __init__(self) -> None:
+        self.nodes: dict[str, dict[str, Any]] = {}
+        self.edges: dict[tuple[str, str, str], dict[str, Any]] = {}
+        self.outgoing: dict[str, set[str]] = defaultdict(set)
+        self.incoming: dict[str, set[str]] = defaultdict(set)
+
+    def add_node(self, node_id: str, **attrs: Any) -> None:
+        self.nodes.setdefault(node_id, {}).update(attrs)
+
+    def add_edge(self, source: str, target: str, key: str, **attrs: Any) -> None:
+        self.edges[(source, target, key)] = attrs
+        self.outgoing[source].add(target)
+        self.incoming[target].add(source)
+
+
+class NetworkXPropertyGraphBackend:
+    """In-memory property graph backend with a NetworkX-compatible fallback."""
+
+    def __init__(self) -> None:
+        self._nodes: dict[str, PropertyGraphNode] = {}
+        self._edges: dict[str, PropertyGraphEdge] = {}
+        self._label_to_id: dict[str, str] = {}
+        self._documents_by_node: dict[str, set[str]] = defaultdict(set)
+        try:
+            import networkx as nx  # type: ignore[import-not-found]
+        except ImportError:
+            self._graph: Any = _AdjacencyGraph()
+            self.uses_networkx = False
+        else:
+            self._graph = nx.MultiDiGraph()
+            self.uses_networkx = True
+
+    def upsert_node(self, node: PropertyGraphNode) -> None:
+        existing = self._nodes.get(node.id)
+        if existing is None:
+            self._nodes[node.id] = node
+        else:
+            existing.properties.update(node.properties)
+            existing.type = node.type or existing.type
+            existing.label = node.label or existing.label
+        self._label_to_id[_normalize(node.label)] = node.id
+        for alias in node.properties.get("aliases", []) or []:
+            self._label_to_id[_normalize(str(alias))] = node.id
+        source_doc = node.properties.get("source_doc") or node.properties.get("source")
+        if source_doc:
+            self._documents_by_node[node.id].add(str(source_doc))
+        self._graph.add_node(
+            node.id,
+            label=node.label,
+            type=node.type,
+            **node.properties,
+        )
+
+    def upsert_edge(self, edge: PropertyGraphEdge) -> None:
+        self._edges[edge.id] = edge
+        source_doc = edge.properties.get("source_doc") or edge.properties.get("source")
+        if source_doc:
+            self._documents_by_node[edge.source].add(str(source_doc))
+            self._documents_by_node[edge.target].add(str(source_doc))
+        self._graph.add_edge(
+            edge.source,
+            edge.target,
+            key=edge.relation,
+            relation=edge.relation,
+            **edge.properties,
+        )
+
+    def get_node(self, node_id: str) -> PropertyGraphNode | None:
+        return self._nodes.get(node_id)
+
+    def get_edge(self, edge_id: str) -> PropertyGraphEdge | None:
+        return self._edges.get(edge_id)
+
+    def neighbors(
+        self, node_id: str, *, direction: Literal["both", "out", "in"] = "both"
+    ) -> list[str]:
+        if direction not in {"both", "out", "in"}:
+            raise ValueError("direction must be 'both', 'out', or 'in'")
+        if self.uses_networkx:
+            out = set(self._graph.successors(node_id)) if direction in {"both", "out"} else set()
+            inc = set(self._graph.predecessors(node_id)) if direction in {"both", "in"} else set()
+            return sorted(out | inc)
+        out = self._graph.outgoing.get(node_id, set()) if direction in {"both", "out"} else set()
+        inc = self._graph.incoming.get(node_id, set()) if direction in {"both", "in"} else set()
+        return sorted(out | inc)
+
+    def traverse(
+        self,
+        seed_ids: list[str],
+        *,
+        max_hops: int = 2,
+        min_confidence: float = 0.0,
+    ) -> tuple[list[PropertyGraphNode], list[PropertyGraphEdge]]:
+        if max_hops < 0:
+            raise ValueError("max_hops must be non-negative")
+        queue: deque[tuple[str, int]] = deque((seed, 0) for seed in seed_ids if seed in self._nodes)
+        visited: set[str] = set()
+        selected_edges: dict[str, PropertyGraphEdge] = {}
+
+        while queue:
+            node_id, depth = queue.popleft()
+            if node_id in visited:
+                continue
+            visited.add(node_id)
+            if depth >= max_hops:
+                continue
+            for edge in self._incident_edges(node_id):
+                confidence = float(edge.properties.get("confidence", 1.0))
+                if confidence < min_confidence:
+                    continue
+                selected_edges[edge.id] = edge
+                other = edge.target if edge.source == node_id else edge.source
+                if other not in visited:
+                    queue.append((other, depth + 1))
+
+        nodes = [self._nodes[node_id] for node_id in sorted(visited)]
+        edges = [selected_edges[edge_id] for edge_id in sorted(selected_edges)]
+        return nodes, edges
+
+    def document_ids_for_nodes(self, node_ids: list[str]) -> list[str]:
+        docs: set[str] = set()
+        for node_id in node_ids:
+            docs.update(self._documents_by_node.get(node_id, set()))
+        return sorted(docs)
+
+    def nodes(self) -> list[PropertyGraphNode]:
+        return list(self._nodes.values())
+
+    def edges(self) -> list[PropertyGraphEdge]:
+        return list(self._edges.values())
+
+    def node_id_for_label(self, label: str) -> str | None:
+        return self._label_to_id.get(_normalize(label))
+
+    def seed_ids_for_text(self, text: str) -> list[str]:
+        normalized = _normalize(text)
+        seeds = [
+            node_id for label, node_id in self._label_to_id.items() if label and label in normalized
+        ]
+        if seeds:
+            return list(dict.fromkeys(seeds))
+        terms = set(normalized.split())
+        scored: list[tuple[int, str]] = []
+        for node in self._nodes.values():
+            score = len(terms & set(_normalize(node.label).split()))
+            if score:
+                scored.append((score, node.id))
+        return [node_id for _, node_id in sorted(scored, reverse=True)[:5]]
+
+    def _incident_edges(self, node_id: str) -> list[PropertyGraphEdge]:
+        return [
+            edge
+            for edge in self._edges.values()
+            if edge.source == node_id or edge.target == node_id
+        ]
+
+
+class Neo4jPropertyGraphBackend:
+    """Neo4j property graph adapter with lazy optional dependency loading."""
+
+    def __init__(
+        self,
+        uri: str,
+        *,
+        username: str = "neo4j",
+        password: str = "password",
+        database: str | None = None,
+    ) -> None:
+        try:
+            from neo4j import GraphDatabase  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise ImportError(
+                "Neo4jPropertyGraphBackend requires the 'neo4j' package. "
+                "Install SynapseKit with the graph extra."
+            ) from exc
+        self._driver = GraphDatabase.driver(uri, auth=(username, password))
+        self._database = database
+
+    def upsert_node(self, node: PropertyGraphNode) -> None:
+        with self._driver.session(database=self._database) as session:
+            session.run(
+                """
+                MERGE (n:PropertyGraphNode {id: $id})
+                SET n.label = $label, n.type = $type, n += $properties
+                """,
+                id=node.id,
+                label=node.label,
+                type=node.type,
+                properties=node.properties,
+            )
+
+    def upsert_edge(self, edge: PropertyGraphEdge) -> None:
+        with self._driver.session(database=self._database) as session:
+            session.run(
+                """
+                MERGE (a:PropertyGraphNode {id: $source})
+                MERGE (b:PropertyGraphNode {id: $target})
+                MERGE (a)-[r:RELATED {id: $id}]->(b)
+                SET r.relation = $relation, r += $properties
+                """,
+                source=edge.source,
+                target=edge.target,
+                id=edge.id,
+                relation=edge.relation,
+                properties=edge.properties,
+            )
+
+    def get_node(self, node_id: str) -> PropertyGraphNode | None:
+        with self._driver.session(database=self._database) as session:
+            row = session.run(
+                "MATCH (n:PropertyGraphNode {id: $id}) RETURN n",
+                id=node_id,
+            ).single()
+        if row is None:
+            return None
+        data = dict(row["n"])
+        return PropertyGraphNode(
+            id=str(data.pop("id")),
+            label=str(data.pop("label", node_id)),
+            type=str(data.pop("type", "entity")),
+            properties=data,
+        )
+
+    def get_edge(self, edge_id: str) -> PropertyGraphEdge | None:
+        with self._driver.session(database=self._database) as session:
+            row = session.run(
+                """
+                MATCH (a)-[r:RELATED {id: $id}]->(b)
+                RETURN a.id AS source, b.id AS target, r AS rel
+                """,
+                id=edge_id,
+            ).single()
+        if row is None:
+            return None
+        data = dict(row["rel"])
+        return PropertyGraphEdge(
+            source=str(row["source"]),
+            target=str(row["target"]),
+            relation=str(data.pop("relation", "related_to")),
+            properties=data,
+        )
+
+    def neighbors(
+        self, node_id: str, *, direction: Literal["both", "out", "in"] = "both"
+    ) -> list[str]:
+        if direction not in {"both", "out", "in"}:
+            raise ValueError("direction must be 'both', 'out', or 'in'")
+        pattern = {
+            "both": "-[:RELATED]-",
+            "out": "-[:RELATED]->",
+            "in": "<-[:RELATED]-",
+        }[direction]
+        with self._driver.session(database=self._database) as session:
+            rows = session.run(
+                f"MATCH (:PropertyGraphNode {{id: $id}}){pattern}(n) RETURN DISTINCT n.id AS id",
+                id=node_id,
+            )
+            return sorted(str(row["id"]) for row in rows)
+
+    def traverse(
+        self,
+        seed_ids: list[str],
+        *,
+        max_hops: int = 2,
+        min_confidence: float = 0.0,
+    ) -> tuple[list[PropertyGraphNode], list[PropertyGraphEdge]]:
+        memory = NetworkXPropertyGraphBackend()
+        with self._driver.session(database=self._database) as session:
+            rows = session.run(
+                """
+                MATCH path=(n:PropertyGraphNode)-[r:RELATED*0..$hops]-(m:PropertyGraphNode)
+                WHERE n.id IN $ids
+                UNWIND nodes(path) AS node
+                RETURN DISTINCT node
+                """,
+                ids=seed_ids,
+                hops=max_hops,
+            )
+            for row in rows:
+                data = dict(row["node"])
+                node_id = str(data.pop("id"))
+                memory.upsert_node(
+                    PropertyGraphNode(
+                        id=node_id,
+                        label=str(data.pop("label", node_id)),
+                        type=str(data.pop("type", "entity")),
+                        properties=data,
+                    )
+                )
+            edge_rows = session.run(
+                """
+                MATCH path=(n:PropertyGraphNode)-[r:RELATED*1..$hops]-(m:PropertyGraphNode)
+                WHERE n.id IN $ids
+                UNWIND relationships(path) AS rel
+                WITH DISTINCT rel
+                WHERE coalesce(rel.confidence, 1.0) >= $min_confidence
+                RETURN startNode(rel).id AS source, endNode(rel).id AS target, rel
+                """,
+                ids=seed_ids,
+                hops=max_hops,
+                min_confidence=min_confidence,
+            )
+            for row in edge_rows:
+                data = dict(row["rel"])
+                memory.upsert_edge(
+                    PropertyGraphEdge(
+                        source=str(row["source"]),
+                        target=str(row["target"]),
+                        relation=str(data.pop("relation", "related_to")),
+                        properties=data,
+                    )
+                )
+        return memory.nodes(), memory.edges()
+
+    def document_ids_for_nodes(self, node_ids: list[str]) -> list[str]:
+        with self._driver.session(database=self._database) as session:
+            rows = session.run(
+                """
+                MATCH (n:PropertyGraphNode)
+                WHERE n.id IN $ids AND n.source_doc IS NOT NULL
+                RETURN DISTINCT n.source_doc AS doc
+                """,
+                ids=node_ids,
+            )
+            return sorted(str(row["doc"]) for row in rows)
+
+    def nodes(self) -> list[PropertyGraphNode]:
+        with self._driver.session(database=self._database) as session:
+            rows = session.run("MATCH (n:PropertyGraphNode) RETURN n")
+            out: list[PropertyGraphNode] = []
+            for row in rows:
+                data = dict(row["n"])
+                node_id = str(data.pop("id"))
+                out.append(
+                    PropertyGraphNode(
+                        id=node_id,
+                        label=str(data.pop("label", node_id)),
+                        type=str(data.pop("type", "entity")),
+                        properties=data,
+                    )
+                )
+            return out
+
+    def edges(self) -> list[PropertyGraphEdge]:
+        with self._driver.session(database=self._database) as session:
+            rows = session.run(
+                "MATCH (a)-[r:RELATED]->(b) RETURN a.id AS source, b.id AS target, r"
+            )
+            out: list[PropertyGraphEdge] = []
+            for row in rows:
+                data = dict(row["r"])
+                out.append(
+                    PropertyGraphEdge(
+                        source=str(row["source"]),
+                        target=str(row["target"]),
+                        relation=str(data.pop("relation", "related_to")),
+                        properties=data,
+                    )
+                )
+            return out
+
+    def close(self) -> None:
+        self._driver.close()
+
+
+class KnowledgeGraphExtractor:
+    """Extract entities and relationships into a property graph."""
+
+    _PROMPT = """\
+Extract a property graph from the text.
+Return strict JSON with keys "entities" and "relationships".
+Entity: {"name": str, "type": str, "confidence": float, "properties": object}
+Relationship: {"source": str, "target": str, "relation": str, "confidence": float, "properties": object}
+
+Text:
+{text}
+"""
+
+    def __init__(
+        self,
+        llm: BaseLLM | None = None,
+        store: PropertyGraphBackend | None = None,
+        *,
+        min_confidence: float = 0.5,
+    ) -> None:
+        self.llm = llm
+        self.store = store
+        self.min_confidence = min_confidence
+
+    async def extract(self, text: str) -> KnowledgeGraphExtraction:
+        if self.llm is None:
+            return self._heuristic_extract(text)
+        response = await self.llm.generate(self._PROMPT.format(text=text))
+        return self._parse_json(response)
+
+    async def ingest(
+        self,
+        documents: list[str] | list[dict[str, Any]],
+        *,
+        store: PropertyGraphBackend | None = None,
+    ) -> list[KnowledgeGraphExtraction]:
+        target = store or self.store
+        if target is None:
+            raise ValueError("A property graph store is required for ingest().")
+        outputs: list[KnowledgeGraphExtraction] = []
+        for index, document in enumerate(documents):
+            text, metadata = _coerce_document(document)
+            source_doc = str(metadata.get("source") or metadata.get("id") or f"doc_{index + 1}")
+            extraction = await self.extract(text)
+            _store_extraction(target, extraction, source_doc=source_doc)
+            outputs.append(extraction)
+        return outputs
+
+    def _heuristic_extract(self, text: str) -> KnowledgeGraphExtraction:
+        entities: list[ExtractedEntity] = []
+        seen: set[str] = set()
+        for match in _ENTITY_RE.finditer(text):
+            name = match.group(0).strip(" .,;:()[]")
+            if name in {"A", "An", "And", "In", "The", "This", "Who", "What"}:
+                continue
+            key = name.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            entities.append(
+                ExtractedEntity(
+                    name=name,
+                    type=_guess_entity_type(name),
+                    confidence=0.72,
+                )
+            )
+        relationships: list[ExtractedRelationship] = []
+        names = [entity.name for entity in entities]
+        for sentence in re.split(r"(?<=[.!?])\s+", text):
+            present = [name for name in names if name in sentence]
+            if len(present) < 2:
+                continue
+            relation = _relation_for_sentence(sentence)
+            for left, right in pairwise(present):
+                relationships.append(
+                    ExtractedRelationship(
+                        source=left,
+                        target=right,
+                        relation=relation,
+                        confidence=0.7,
+                    )
+                )
+        return KnowledgeGraphExtraction(
+            entities=[entity for entity in entities if entity.confidence >= self.min_confidence],
+            relationships=[rel for rel in relationships if rel.confidence >= self.min_confidence],
+        )
+
+    def _parse_json(self, response: str) -> KnowledgeGraphExtraction:
+        cleaned = response.strip()
+        if cleaned.startswith("```json"):
+            cleaned = cleaned[7:]
+        if cleaned.startswith("```"):
+            cleaned = cleaned[3:]
+        if cleaned.endswith("```"):
+            cleaned = cleaned[:-3]
+        try:
+            payload = json.loads(cleaned.strip())
+        except json.JSONDecodeError:
+            return KnowledgeGraphExtraction()
+        if not isinstance(payload, dict):
+            return KnowledgeGraphExtraction()
+        return KnowledgeGraphExtraction(
+            entities=self._parse_entities(payload.get("entities")),
+            relationships=self._parse_relationships(payload.get("relationships")),
+        )
+
+    def _parse_entities(self, rows: Any) -> list[ExtractedEntity]:
+        if not isinstance(rows, list):
+            return []
+        entities: list[ExtractedEntity] = []
+        for row in rows:
+            if not isinstance(row, dict) or not row.get("name"):
+                continue
+            confidence = _float(row.get("confidence"), default=1.0)
+            if confidence < self.min_confidence:
+                continue
+            properties = row.get("properties")
+            entities.append(
+                ExtractedEntity(
+                    name=str(row["name"]),
+                    type=str(row.get("type", "entity")),
+                    confidence=confidence,
+                    properties=dict(properties) if isinstance(properties, dict) else {},
+                )
+            )
+        return entities
+
+    def _parse_relationships(self, rows: Any) -> list[ExtractedRelationship]:
+        if not isinstance(rows, list):
+            return []
+        relationships: list[ExtractedRelationship] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            source = row.get("source")
+            target = row.get("target")
+            if not source or not target:
+                continue
+            confidence = _float(row.get("confidence"), default=1.0)
+            if confidence < self.min_confidence:
+                continue
+            properties = row.get("properties")
+            relationships.append(
+                ExtractedRelationship(
+                    source=str(source),
+                    target=str(target),
+                    relation=str(row.get("relation", "related_to")),
+                    confidence=confidence,
+                    properties=dict(properties) if isinstance(properties, dict) else {},
+                )
+            )
+        return relationships
+
+
+class GraphVectorStore(VectorStore):
+    """Drop-in vector store that expands vector hits through a property graph."""
+
+    def __init__(
+        self,
+        embedding_backend: SynapsekitEmbeddings | None = None,
+        *,
+        vector_store: VectorStore | None = None,
+        backend: PropertyGraphBackendName | PropertyGraphBackend = "networkx",
+        extractor: KnowledgeGraphExtractor | None = None,
+        max_hops: int = 2,
+        min_confidence: float = 0.0,
+        graph_weight: float = 0.25,
+        uri: str | None = None,
+        username: str = "neo4j",
+        password: str = "password",
+    ) -> None:
+        if vector_store is None:
+            if embedding_backend is None:
+                raise ValueError("embedding_backend is required when vector_store is not provided")
+            vector_store = InMemoryVectorStore(embedding_backend)
+        self.vector_store = vector_store
+        self.graph = self._make_backend(backend, uri=uri, username=username, password=password)
+        self.extractor = extractor or KnowledgeGraphExtractor(store=self.graph)
+        self.max_hops = max_hops
+        self.min_confidence = min_confidence
+        self.graph_weight = graph_weight
+        self._doc_text_by_id: dict[str, str] = {}
+        self._doc_metadata_by_id: dict[str, dict[str, Any]] = {}
+
+    async def add(
+        self,
+        texts: list[str],
+        metadata: list[dict] | None = None,
+    ) -> None:
+        if not texts:
+            return
+        meta = metadata if metadata is not None else [{} for _ in texts]
+        if len(meta) != len(texts):
+            raise ValueError("metadata length must match texts length")
+        enriched: list[dict[str, Any]] = []
+        for index, (text, item_meta) in enumerate(zip(texts, meta, strict=True)):
+            source_doc = str(
+                item_meta.get("source")
+                or item_meta.get("id")
+                or f"doc_{len(self._doc_text_by_id) + index + 1}"
+            )
+            doc_meta = {**item_meta, "source": source_doc}
+            self._doc_text_by_id[source_doc] = text
+            self._doc_metadata_by_id[source_doc] = doc_meta
+            extraction = await self.extractor.extract(text)
+            _store_extraction(self.graph, extraction, source_doc=source_doc)
+            enriched.append(doc_meta)
+        await self.vector_store.add(texts, enriched)
+
+    async def search(
+        self,
+        query: str,
+        top_k: int = 5,
+        metadata_filter: dict | None = None,
+    ) -> list[dict]:
+        if top_k <= 0:
+            return []
+        vector_results = await self.vector_store.search(
+            query,
+            top_k=top_k,
+            metadata_filter=metadata_filter,
+        )
+        seed_ids = self._seed_ids(query, vector_results)
+        if not seed_ids:
+            return cast(list[dict], vector_results[:top_k])
+
+        nodes, edges = self.graph.traverse(
+            seed_ids,
+            max_hops=self.max_hops,
+            min_confidence=self.min_confidence,
+        )
+        graph_doc_ids = self.graph.document_ids_for_nodes([node.id for node in nodes])
+        return self._fuse(vector_results, graph_doc_ids, nodes, edges, top_k, metadata_filter)
+
+    async def search_mmr(
+        self,
+        query: str,
+        top_k: int = 5,
+        lambda_mult: float = 0.5,
+        fetch_k: int = 20,
+        metadata_filter: dict | None = None,
+    ) -> list[dict]:
+        results = await self.vector_store.search_mmr(
+            query,
+            top_k=top_k,
+            lambda_mult=lambda_mult,
+            fetch_k=fetch_k,
+            metadata_filter=metadata_filter,
+        )
+        return cast(list[dict], results)
+
+    def save(self, path: str) -> None:
+        self.vector_store.save(path)
+
+    def load(self, path: str) -> None:
+        self.vector_store.load(path)
+
+    def __len__(self) -> int:
+        length = getattr(self.vector_store, "__len__", None)
+        return int(length()) if callable(length) else len(self._doc_text_by_id)
+
+    @staticmethod
+    def _make_backend(
+        backend: PropertyGraphBackendName | PropertyGraphBackend,
+        *,
+        uri: str | None,
+        username: str,
+        password: str,
+    ) -> PropertyGraphBackend:
+        if not isinstance(backend, str):
+            return backend
+        if backend == "networkx":
+            return NetworkXPropertyGraphBackend()
+        if backend == "neo4j":
+            if uri is None:
+                raise ValueError("uri is required when backend='neo4j'")
+            return Neo4jPropertyGraphBackend(uri, username=username, password=password)
+        raise ValueError(f"Unknown graph backend: {backend!r}")
+
+    def _seed_ids(self, query: str, vector_results: list[dict]) -> list[str]:
+        seed_ids: list[str] = []
+        seed_for_text = getattr(self.graph, "seed_ids_for_text", None)
+        if callable(seed_for_text):
+            seed_ids.extend(seed_for_text(query))
+        for result in vector_results:
+            source = (result.get("metadata") or {}).get("source")
+            if source is None:
+                continue
+            for node in self.graph.nodes():
+                if str(node.properties.get("source_doc")) == str(source):
+                    seed_ids.append(node.id)
+        return list(dict.fromkeys(seed_ids))
+
+    def _fuse(
+        self,
+        vector_results: list[dict],
+        graph_doc_ids: list[str],
+        nodes: list[PropertyGraphNode],
+        edges: list[PropertyGraphEdge],
+        top_k: int,
+        metadata_filter: dict | None,
+    ) -> list[dict]:
+        by_text: dict[str, dict[str, Any]] = {}
+        for rank, result in enumerate(vector_results, start=1):
+            item = dict(result)
+            metadata = dict(item.get("metadata") or {})
+            metadata.setdefault("retrieval_source", "vector")
+            item["metadata"] = metadata
+            item["score"] = float(item.get("score", 0.0)) + 1.0 / (100 + rank)
+            by_text[str(item.get("text", ""))] = item
+
+        for rank, doc_id in enumerate(graph_doc_ids, start=1):
+            metadata = self._doc_metadata_by_id.get(doc_id, {"source": doc_id})
+            if metadata_filter and any(metadata.get(k) != v for k, v in metadata_filter.items()):
+                continue
+            text = self._doc_text_by_id.get(doc_id)
+            if not text:
+                continue
+            current = by_text.get(text, {"text": text, "score": 0.0, "metadata": dict(metadata)})
+            current["score"] = float(current.get("score", 0.0)) + self.graph_weight / rank
+            merged_meta = dict(current.get("metadata") or {})
+            merged_meta.update(
+                {
+                    "retrieval_source": "graph_vector",
+                    "graph_nodes": [node.label for node in nodes],
+                    "graph_edges": [edge.relation for edge in edges],
+                }
+            )
+            current["metadata"] = merged_meta
+            by_text[text] = current
+
+        return sorted(by_text.values(), key=lambda item: item["score"], reverse=True)[:top_k]
+
+
+def _store_extraction(
+    graph: PropertyGraphBackend,
+    extraction: KnowledgeGraphExtraction,
+    *,
+    source_doc: str,
+) -> None:
+    extracted_at = datetime.now(UTC).isoformat()
+    for entity in extraction.entities:
+        node_id = _node_id(entity.name)
+        graph.upsert_node(
+            PropertyGraphNode(
+                id=node_id,
+                label=entity.name,
+                type=entity.type,
+                properties={
+                    **entity.properties,
+                    "confidence": entity.confidence,
+                    "source_doc": source_doc,
+                    "extracted_at": extracted_at,
+                },
+            )
+        )
+    for relationship in extraction.relationships:
+        graph.upsert_edge(
+            PropertyGraphEdge(
+                source=_node_id(relationship.source),
+                target=_node_id(relationship.target),
+                relation=relationship.relation,
+                properties={
+                    **relationship.properties,
+                    "confidence": relationship.confidence,
+                    "source_doc": source_doc,
+                    "extracted_at": extracted_at,
+                },
+            )
+        )
+
+
+def _coerce_document(document: Any) -> tuple[str, dict[str, Any]]:
+    if isinstance(document, str):
+        return document, {}
+    if isinstance(document, dict):
+        return str(document.get("text", "")), dict(document.get("metadata", {}))
+    return str(document), {}
+
+
+def _node_id(name: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "_", name.casefold()).strip("_")
+    return f"pg_{slug or 'node'}"
+
+
+def _normalize(value: str) -> str:
+    value = re.sub(r"^@", "", value.casefold().strip())
+    value = re.sub(r"[^a-z0-9]+", " ", value)
+    return " ".join(value.split())
+
+
+def _guess_entity_type(name: str) -> str:
+    lowered = name.casefold()
+    if lowered.startswith("@"):
+        return "person"
+    if any(token in lowered for token in (" inc", " corp", " labs", " llc", " ltd")):
+        return "org"
+    return "entity"
+
+
+def _relation_for_sentence(sentence: str) -> str:
+    lowered = sentence.casefold()
+    for hint, relation in _RELATION_HINTS:
+        if hint in lowered:
+            return relation
+    return "related_to"
+
+
+def _float(value: Any, *, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default

--- a/src/synapsekit/retrieval/property_graph.py
+++ b/src/synapsekit/retrieval/property_graph.py
@@ -8,7 +8,7 @@ from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from itertools import pairwise
-from typing import Any, Literal, Protocol, cast
+from typing import Any, Literal, Protocol
 
 from ..embeddings.backend import SynapsekitEmbeddings
 from ..llm.base import BaseLLM
@@ -709,7 +709,7 @@ class GraphVectorStore(VectorStore):
         )
         seed_ids = self._seed_ids(query, vector_results)
         if not seed_ids:
-            return cast(list[dict], vector_results[:top_k])
+            return vector_results[:top_k]
 
         nodes, edges = self.graph.traverse(
             seed_ids,
@@ -734,7 +734,7 @@ class GraphVectorStore(VectorStore):
             fetch_k=fetch_k,
             metadata_filter=metadata_filter,
         )
-        return cast(list[dict], results)
+        return results
 
     def save(self, path: str) -> None:
         self.vector_store.save(path)

--- a/src/synapsekit/symbolic/extractor.py
+++ b/src/synapsekit/symbolic/extractor.py
@@ -100,7 +100,9 @@ def _loads_json_object(text: str) -> dict[str, Any]:
         try:
             data = json.loads(match.group(0))
         except json.JSONDecodeError as exc2:
-            raise VerificationFailure("Constraint extractor returned malformed embedded JSON.") from exc2
+            raise VerificationFailure(
+                "Constraint extractor returned malformed embedded JSON."
+            ) from exc2
 
     if not isinstance(data, dict):
         raise VerificationFailure("Constraint extractor JSON must be an object.")

--- a/tests/agents/test_agent_swarm_market.py
+++ b/tests/agents/test_agent_swarm_market.py
@@ -2,7 +2,15 @@ import inspect
 
 import pytest
 
-from synapsekit import AgentSwarm, AuctionResult, AuctionType, Bid, BidStrategy, MarketPolicy, SwarmResult
+from synapsekit import (
+    AgentSwarm,
+    AuctionResult,
+    AuctionType,
+    Bid,
+    BidStrategy,
+    MarketPolicy,
+    SwarmResult,
+)
 from synapsekit.agents import AgentFederation, AgentMetadata, InMemoryAgentRegistry, Reputation
 from synapsekit.agents.agent_swarm import CoalitionFormer
 
@@ -233,9 +241,7 @@ async def test_synthetic_bids_use_reputation_when_agent_has_no_bidder():
         reputation=reputation,
     )
 
-    auction = await swarm.auction(
-        "Review code", swarm.federation.discover(), task_category="code"
-    )
+    auction = await swarm.auction("Review code", swarm.federation.discover(), task_category="code")
 
     assert isinstance(auction, AuctionResult)
     assert auction.bids[0].estimated_quality == 0.9

--- a/tests/llm/test_mlx.py
+++ b/tests/llm/test_mlx.py
@@ -26,11 +26,9 @@ class FakeMLXModule:
         return object(), object()
 
     def generate(self, model, tokenizer, *, prompt: str, max_tokens: int, temp: float) -> str:
-        return f"hello"
+        return "hello"
 
-    def stream_generate(
-        self, model, tokenizer, *, prompt: str, max_tokens: int, temp: float
-    ):
+    def stream_generate(self, model, tokenizer, *, prompt: str, max_tokens: int, temp: float):
         yield _FakeTokenItem("hello ")
         yield _FakeTokenItem("world")
 
@@ -66,7 +64,7 @@ def test_missing_mlx_lm_raises() -> None:
 @pytest.mark.asyncio
 async def test_generate_uses_mlx_backend() -> None:
     original = sys.modules.get("mlx_lm")
-    fake = _inject_fake_mlx()
+    _inject_fake_mlx()
     try:
         result = await make_llm().generate("hi")
     finally:

--- a/tests/memory/test_graph_memory_backend.py
+++ b/tests/memory/test_graph_memory_backend.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from synapsekit.memory import AgentMemory, GraphMemoryBackend
+from synapsekit.retrieval.property_graph import NetworkXPropertyGraphBackend
+
+
+@pytest.mark.asyncio
+async def test_agent_memory_graph_backend_matches_core_interface() -> None:
+    graph = NetworkXPropertyGraphBackend()
+    memory = AgentMemory(backend="graph", store=graph, max_episodes=50)
+
+    first = await memory.store(
+        agent_id="agent-a",
+        content="User prefers graph-aware RAG",
+        memory_type="semantic",
+    )
+    second = await memory.store(
+        agent_id="agent-a",
+        content="Apollo depends on Platform Team",
+        memory_type="episodic",
+        metadata={
+            "related_to": [first.id],
+            "relation_type": "supports",
+            "weight": 0.8,
+        },
+    )
+
+    recalled = await memory.recall(agent_id="agent-a", query="graph RAG", top_k=1)
+
+    assert recalled[0].id == first.id
+    assert await memory.count(agent_id="agent-a") == 2
+    assert graph.get_node(f"memory:agent-a:{first.id}") is not None
+    edge = graph.get_edge(f"memory:agent-a:{second.id}:supports:memory:agent-a:{first.id}")
+    assert edge is not None
+    assert edge.properties["relation_type"] == "supports"
+    assert edge.properties["weight"] == 0.8
+
+
+@pytest.mark.asyncio
+async def test_graph_memory_backend_delete_clear_and_prune() -> None:
+    backend = GraphMemoryBackend()
+    memory = AgentMemory(backend=backend)
+
+    expired = await memory.store(
+        agent_id="agent-a",
+        content="temporary",
+        memory_type="episodic",
+        ttl_days=0,
+    )
+    kept = await memory.store(
+        agent_id="agent-a",
+        content="stable",
+        memory_type="semantic",
+    )
+
+    assert await backend.prune_expired() == 1
+    assert await memory.count(agent_id="agent-a") == 1
+    assert await memory.delete(agent_id="agent-a", record_id=expired.id) is False
+    assert await memory.count(agent_id="agent-a") == 1
+    assert await memory.clear(agent_id="agent-a", memory_type="semantic") == 1
+    assert await memory.delete(agent_id="agent-a", record_id=kept.id) is False

--- a/tests/retrieval/test_property_graph.py
+++ b/tests/retrieval/test_property_graph.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from synapsekit.retrieval.property_graph import (
+    ExtractedEntity,
+    ExtractedRelationship,
+    GraphVectorStore,
+    KnowledgeGraphExtraction,
+    KnowledgeGraphExtractor,
+    Neo4jPropertyGraphBackend,
+    NetworkXPropertyGraphBackend,
+    PropertyGraphEdge,
+    PropertyGraphNode,
+)
+
+
+def make_mock_embeddings(dim: int = 4) -> MagicMock:
+    mock = MagicMock()
+
+    async def embed(texts: list[str]) -> np.ndarray:
+        vecs = []
+        for index, _text in enumerate(texts):
+            vector = np.zeros(dim, dtype=np.float32)
+            vector[index % dim] = 1.0
+            vecs.append(vector)
+        return np.array(vecs, dtype=np.float32)
+
+    async def embed_one(text: str) -> np.ndarray:
+        arr = await embed([text])
+        return arr[0]
+
+    mock.embed = embed
+    mock.embed_one = embed_one
+    return mock
+
+
+class StaticExtractor(KnowledgeGraphExtractor):
+    async def extract(self, text: str) -> KnowledgeGraphExtraction:
+        if "Apollo" in text:
+            return KnowledgeGraphExtraction(
+                entities=[
+                    ExtractedEntity("Apollo", type="project", confidence=0.9),
+                    ExtractedEntity("Dana", type="person", confidence=0.9),
+                    ExtractedEntity("Platform Team", type="org", confidence=0.9),
+                ],
+                relationships=[
+                    ExtractedRelationship("Dana", "Apollo", "leads", confidence=0.9),
+                    ExtractedRelationship(
+                        "Apollo",
+                        "Platform Team",
+                        "built_by",
+                        confidence=0.9,
+                    ),
+                ],
+            )
+        return KnowledgeGraphExtraction(
+            entities=[ExtractedEntity("Billing", type="system", confidence=0.9)]
+        )
+
+
+@pytest.mark.asyncio
+async def test_extractor_ingest_stores_confidence_and_source_doc() -> None:
+    graph = NetworkXPropertyGraphBackend()
+    extractor = KnowledgeGraphExtractor(store=graph)
+
+    await extractor.ingest([{"text": "Dana leads Apollo.", "metadata": {"source": "doc-a"}}])
+
+    assert graph.nodes()
+    assert graph.edges()
+    edge = graph.edges()[0]
+    assert edge.properties["source_doc"] == "doc-a"
+    assert edge.properties["confidence"] >= 0.5
+
+
+def test_backend_traversal_respects_hops_confidence_and_direction() -> None:
+    graph = NetworkXPropertyGraphBackend()
+    graph.upsert_node(PropertyGraphNode("a", "A"))
+    graph.upsert_node(PropertyGraphNode("b", "B"))
+    graph.upsert_node(PropertyGraphNode("c", "C"))
+    graph.upsert_edge(PropertyGraphEdge("a", "b", "knows", {"confidence": 0.9}))
+    graph.upsert_edge(PropertyGraphEdge("b", "c", "knows", {"confidence": 0.2}))
+
+    nodes, edges = graph.traverse(["a"], max_hops=2, min_confidence=0.5)
+
+    assert [node.id for node in nodes] == ["a", "b"]
+    assert [edge.id for edge in edges] == ["a:knows:b"]
+    assert graph.neighbors("b", direction="in") == ["a"]
+    with pytest.raises(ValueError, match="direction"):
+        graph.neighbors("a", direction="sideways")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="max_hops"):
+        graph.traverse(["a"], max_hops=-1)
+
+
+@pytest.mark.asyncio
+async def test_graph_vector_store_is_drop_in_vector_store_and_expands_graph_hits() -> None:
+    store = GraphVectorStore(
+        make_mock_embeddings(),
+        extractor=StaticExtractor(),
+        max_hops=2,
+        graph_weight=1.0,
+    )
+
+    await store.add(
+        [
+            "Apollo is led by Dana and built by Platform Team.",
+            "Billing invoices customers.",
+        ],
+        metadata=[{"source": "apollo", "tenant": "a"}, {"source": "billing", "tenant": "b"}],
+    )
+
+    results = await store.search("Who leads Apollo?", top_k=2)
+
+    assert len(store) == 2
+    assert len(results) == 2
+    assert results[0]["metadata"]["retrieval_source"] == "graph_vector"
+    assert "Apollo" in results[0]["metadata"]["graph_nodes"]
+    assert all("text" in item and "score" in item and "metadata" in item for item in results)
+
+
+@pytest.mark.asyncio
+async def test_graph_vector_store_metadata_filter_and_empty_paths() -> None:
+    store = GraphVectorStore(make_mock_embeddings(), extractor=StaticExtractor())
+
+    assert await store.search("empty") == []
+    await store.add(["Apollo is led by Dana."], metadata=[{"source": "apollo", "tenant": "a"}])
+
+    assert await store.search("Apollo", top_k=0) == []
+    assert await store.search("Apollo", metadata_filter={"tenant": "missing"}) == []
+    with pytest.raises(ValueError, match="metadata length"):
+        await store.add(["one"], metadata=[])
+
+
+def test_neo4j_backend_roundtrip_with_testcontainers() -> None:
+    pytest.importorskip("neo4j")
+    container_mod = pytest.importorskip("testcontainers.core.container")
+    wait_mod = pytest.importorskip("testcontainers.core.waiting_utils")
+    docker_container = container_mod.DockerContainer
+    wait_for_logs = wait_mod.wait_for_logs
+
+    password = "synapsekit-password"
+    with (
+        docker_container("neo4j:5")
+        .with_env("NEO4J_AUTH", f"neo4j/{password}")
+        .with_exposed_ports(7687) as container
+    ):
+        wait_for_logs(container, "Bolt enabled", timeout=60)
+        host = container.get_container_host_ip()
+        port = container.get_exposed_port(7687)
+        backend = Neo4jPropertyGraphBackend(
+            f"bolt://{host}:{port}",
+            username="neo4j",
+            password=password,
+        )
+        try:
+            backend.upsert_node(
+                PropertyGraphNode("apollo", "Apollo", properties={"source_doc": "d1"})
+            )
+            backend.upsert_node(PropertyGraphNode("dana", "Dana", properties={"source_doc": "d1"}))
+            backend.upsert_edge(
+                PropertyGraphEdge(
+                    "dana",
+                    "apollo",
+                    "leads",
+                    {"confidence": 0.9, "source_doc": "d1"},
+                )
+            )
+
+            nodes, edges = backend.traverse(["dana"], max_hops=1, min_confidence=0.5)
+
+            assert {node.id for node in nodes} == {"apollo", "dana"}
+            assert [edge.relation for edge in edges] == ["leads"]
+            assert backend.document_ids_for_nodes(["apollo", "dana"]) == ["d1"]
+        finally:
+            backend.close()

--- a/tests/symbolic/test_neuro_symbolic.py
+++ b/tests/symbolic/test_neuro_symbolic.py
@@ -270,7 +270,7 @@ def test_agent_rejects_zero_max_proposals() -> None:
 
 
 def test_parse_constraint_response_rejects_bare_invalid_json() -> None:
-    with pytest.raises(VerificationFailure, match="[Jj][Ss][Oo][Nn]"):
+    with pytest.raises(VerificationFailure, match=r"[Jj][Ss][Oo][Nn]"):
         parse_constraint_response("{not valid json at all}")
 
 

--- a/tests/symbolic/test_symbolic_backends.py
+++ b/tests/symbolic/test_symbolic_backends.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import pytest
 
-from synapsekit.symbolic import ConstraintSet, PrologBackend, SympyBackend, Z3Backend
+from synapsekit.symbolic import ConstraintSet, PrologBackend, SympyBackend
 
 
 def test_z3_missing_dependency_error_message_is_actionable():
     """When z3 is absent, missing_optional_dependency returns an actionable message."""
     from synapsekit.symbolic.types import missing_optional_dependency
+
     err = missing_optional_dependency("z3-solver", "z3")
     assert "z3-solver" in str(err) or "z3" in str(err)
     assert isinstance(err, ImportError)


### PR DESCRIPTION
## Summary

Adds first-class property graph RAG support with a graph-aware vector store, knowledge graph extraction, and a graph-backed AgentMemory backend.

Closes #762

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / internal improvement
- [x] Dependency / tooling update

## Changes

- Adds `GraphVectorStore`, `KnowledgeGraphExtractor`, property graph node/edge models, and NetworkX/Neo4j graph backends.
- Adds graph traversal fusion for vector search results, including confidence/source/timestamp properties for extracted graph facts.
- Adds `GraphMemoryBackend` / `GraphAgentMemory` and wires `AgentMemory(backend="graph", store=...)`.
- Adds graph RAG docs at `docs/rag/graph-rag.md` and focused retrieval/memory coverage.
- Cleans up repo-wide Ruff/mypy issues that blocked local CI checks.

## Testing

- [ ] All existing tests pass (`uv run pytest tests/ -q`)
- [x] New tests added for new behaviour
- [x] No API keys or secrets in the code

Local checks run:

- `python -m ruff check src/ tests/` - passed
- `python -m ruff format --check src/ tests/` - passed
- `python -m mypy` - passed
- `python -m deptry src/` - passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=E:\My Github\SynapseKit\src python -m pytest -p pytest_asyncio.plugin -p no:cacheprovider tests\retrieval\test_property_graph.py tests\memory\test_graph_memory_backend.py -q` - 6 passed, 1 skipped
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=E:\My Github\SynapseKit\src python -m pytest -p pytest_asyncio.plugin -p no:cacheprovider tests/ -q` - 4341 passed, 29 skipped, 3 local environment failures:
  - `tests/cli/test_edge.py::test_edge_quantize_runs_external_binary` fails on Windows because the temp shebang script is not a Win32 executable.
  - `tests/embeddings/test_onnx.py::test_missing_onnxruntime_raises` fails because local `onnxruntime` is installed and then attempts to load a missing dummy model path.
  - `tests/retrieval/test_token_counting.py::test_tiktoken_backend_counts_tokens` fails because local `tiktoken` tries to download an encoding while sandbox networking is blocked.

## Documentation

- [x] Docstrings updated (if public API changed)
- [x] [synapsekit-docs](https://github.com/SynapseKit/synapsekit-docs) updated (if new feature)
- [ ] CHANGELOG.md updated

## Notes for reviewer

Neo4j coverage is optional and uses `testcontainers` when `neo4j` and `testcontainers` are installed; otherwise it skips in the base dev environment.
