### PR TITLE
feat(memory): implement Living Memory Files (Issue #741)

### DIFF
--- a/docs/rag/graph-rag.md
+++ b/docs/rag/graph-rag.md
@@ -1,0 +1,108 @@
+# Graph RAG
+
+SynapseKit property-graph RAG combines vector search with graph traversal. It is useful when a
+question depends on relationships between entities rather than a single semantically similar chunk.
+
+## GraphVectorStore
+
+`GraphVectorStore` implements the same async vector-store interface as the other retrieval
+backends. Documents are embedded into an underlying vector store and also passed through
+`KnowledgeGraphExtractor`, which stores entities and relationships in a property graph.
+
+```python
+from synapsekit.embeddings import SynapsekitEmbeddings
+from synapsekit.retrieval import GraphVectorStore
+
+embeddings = SynapsekitEmbeddings()
+store = GraphVectorStore(embeddings, backend="networkx")
+
+await store.add(
+    ["Dana leads Apollo. Apollo is built by Platform Team."],
+    metadata=[{"source": "apollo-brief"}],
+)
+
+results = await store.search("Who leads the project built by Platform Team?", top_k=3)
+```
+
+Search starts with vector results, selects graph seeds from the query and matching documents,
+traverses the graph, then fuses graph-linked documents back into the ranked results. Returned
+items keep the standard shape:
+
+```python
+{"text": "...", "score": 0.91, "metadata": {"source": "apollo-brief"}}
+```
+
+## KnowledgeGraphExtractor
+
+The extractor accepts an optional LLM. Without one, it uses a deterministic local extractor for
+tests and offline development.
+
+```python
+from synapsekit.retrieval import KnowledgeGraphExtractor, NetworkXPropertyGraphBackend
+
+graph = NetworkXPropertyGraphBackend()
+extractor = KnowledgeGraphExtractor(store=graph)
+
+await extractor.ingest(
+    [{"text": "Dana leads Apollo.", "metadata": {"source": "doc-1"}}]
+)
+```
+
+Nodes and edges include `confidence`, `source_doc`, and `extracted_at` properties. LLM extraction
+expects strict JSON with `entities` and `relationships` arrays, so custom LLM providers can be used
+without changing graph storage.
+
+## Backends
+
+Use the in-memory backend for local development and tests:
+
+```python
+store = GraphVectorStore(embeddings, backend="networkx")
+```
+
+Use Neo4j for production deployments:
+
+```python
+store = GraphVectorStore(
+    embeddings,
+    backend="neo4j",
+    uri="bolt://localhost:7687",
+    username="neo4j",
+    password="password",
+)
+```
+
+Neo4j support is optional. Install the graph extra before using it:
+
+```bash
+uv sync --extra graph
+```
+
+## Agent Memory
+
+`AgentMemory` also accepts a graph backend. Each memory record is stored as a node, and callers can
+connect memories by passing `related_to`, `relation_type`, and `weight` metadata.
+
+```python
+from synapsekit.memory import AgentMemory
+from synapsekit.retrieval import NetworkXPropertyGraphBackend
+
+graph = NetworkXPropertyGraphBackend()
+memory = AgentMemory(backend="graph", store=graph)
+
+first = await memory.store(
+    agent_id="agent-a",
+    content="User prefers concise Python answers",
+    memory_type="semantic",
+)
+
+await memory.store(
+    agent_id="agent-a",
+    content="User is building a graph RAG prototype",
+    memory_type="episodic",
+    metadata={"related_to": [first.id], "relation_type": "supports", "weight": 0.8},
+)
+```
+
+The backend preserves the normal `AgentMemory` methods: `store`, `recall`, `list`, `count`,
+`delete`, `clear`, and TTL pruning.

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -270,7 +270,22 @@ from .loaders.web import WebLoader
 from .loaders.wikipedia import WikipediaLoader
 from .mcp import MCPClient, MCPServer, MCPToolAdapter
 from .memory import AgentMemory as PersistentAgentMemory
-from .memory import GraphAgentMemory, GraphMemoryBackend
+from .memory import (
+    DiffConflictError,
+    FileDiffEngine,
+    GraphAgentMemory,
+    GraphMemoryBackend,
+    LivingMemory,
+    MemoryFileCategory,
+    MemoryFileRouter,
+    MemoryPatch,
+    MemoryPIIFilter,
+    OccurrenceRecord,
+    OccurrenceTracker,
+    PatchStatus,
+    PatchStore,
+    PIIFilterResult,
+)
 from .memory.buffer import BufferMemory
 from .memory.conversation import ConversationMemory
 from .memory.entity import EntityMemory
@@ -546,6 +561,18 @@ __all__ = [
     "SQLiteConversationMemory",
     "SummaryBufferMemory",
     "TokenBufferMemory",
+    "LivingMemory",
+    "MemoryPatch",
+    "OccurrenceRecord",
+    "MemoryFileCategory",
+    "PatchStatus",
+    "FileDiffEngine",
+    "DiffConflictError",
+    "PatchStore",
+    "OccurrenceTracker",
+    "MemoryPIIFilter",
+    "PIIFilterResult",
+    "MemoryFileRouter",
     "TokenTracer",
     "PrometheusMetrics",
     # Loaders

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -270,6 +270,7 @@ from .loaders.web import WebLoader
 from .loaders.wikipedia import WikipediaLoader
 from .mcp import MCPClient, MCPServer, MCPToolAdapter
 from .memory import AgentMemory as PersistentAgentMemory
+from .memory import GraphAgentMemory, GraphMemoryBackend
 from .memory.buffer import BufferMemory
 from .memory.conversation import ConversationMemory
 from .memory.entity import EntityMemory
@@ -321,6 +322,17 @@ from .retrieval.hyde import HyDERetriever
 from .retrieval.mongodb_atlas import MongoDBAtlasVectorStore
 from .retrieval.multi_step import MultiStepRetriever
 from .retrieval.parent_document import ParentDocumentRetriever
+from .retrieval.property_graph import (
+    ExtractedEntity,
+    ExtractedRelationship,
+    GraphVectorStore,
+    KnowledgeGraphExtraction,
+    KnowledgeGraphExtractor,
+    Neo4jPropertyGraphBackend,
+    NetworkXPropertyGraphBackend,
+    PropertyGraphEdge,
+    PropertyGraphNode,
+)
 from .retrieval.query_decomposition import QueryDecompositionRetriever
 from .retrieval.rag_fusion import RAGFusionRetriever
 from .retrieval.retriever import Retriever
@@ -457,6 +469,7 @@ __all__ = [
     # Vector stores
     "VectorStore",
     "InMemoryVectorStore",
+    "GraphVectorStore",
     "ChromaVectorStore",
     "FAISSVectorStore",
     "LanceDBVectorStore",
@@ -488,6 +501,14 @@ __all__ = [
     "SentenceWindowRetriever",
     "GraphRAGRetriever",
     "KnowledgeGraph",
+    "KnowledgeGraphExtraction",
+    "KnowledgeGraphExtractor",
+    "NetworkXPropertyGraphBackend",
+    "Neo4jPropertyGraphBackend",
+    "PropertyGraphNode",
+    "PropertyGraphEdge",
+    "ExtractedEntity",
+    "ExtractedRelationship",
     "StepBackRetriever",
     "WorldModelRAG",
     "ExtractionPolicy",
@@ -514,6 +535,8 @@ __all__ = [
     "CircuitState",
     # Memory / observability
     "PersistentAgentMemory",
+    "GraphAgentMemory",
+    "GraphMemoryBackend",
     "BufferMemory",
     "ConversationMemory",
     "EntityMemory",

--- a/src/synapsekit/agents/agent_registry.py
+++ b/src/synapsekit/agents/agent_registry.py
@@ -197,7 +197,7 @@ class Reputation:
             snapshot.mean_quality = quality
             snapshot.mean_reward = reward
         else:
-            snapshot.avg_cost = self._ema(snapshot.avg_cost, cost, learning_rate)
+            snapshot.avg_cost = self._ema(snapshot.avg_cost or 0.0, cost, learning_rate)
             snapshot.mean_quality = self._ema(snapshot.mean_quality, quality, learning_rate)
             snapshot.mean_reward = self._ema(snapshot.mean_reward, reward, learning_rate)
 

--- a/src/synapsekit/agents/agent_registry.py
+++ b/src/synapsekit/agents/agent_registry.py
@@ -134,7 +134,7 @@ class ReputationSnapshot:
             task_category=data.get("task_category", "general"),
             attempts=data.get("attempts", 0),
             wins=data.get("wins", 0),
-            avg_cost=data.get("avg_cost", None),
+            avg_cost=data.get("avg_cost"),
             mean_quality=data.get("mean_quality", 0.5),
             mean_reward=data.get("mean_reward", 0.0),
             quality_alpha=data.get("quality_alpha", 1.0),

--- a/src/synapsekit/cli/edge.py
+++ b/src/synapsekit/cli/edge.py
@@ -120,7 +120,6 @@ def _download_model(model: EdgeModel, cache_root: Path, force: bool) -> Path:
         repo_id=model.repo_id,
         filename=model.filename,
         local_dir=str(destination_dir),
-        local_dir_use_symlinks=False,
         force_download=force,
     )
     downloaded_path = Path(downloaded)

--- a/src/synapsekit/cli/main.py
+++ b/src/synapsekit/cli/main.py
@@ -179,6 +179,51 @@ def _add_agent_parser(subparsers: argparse._SubParsersAction) -> None:  # type: 
     )
 
 
+def _add_memory_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    p = subparsers.add_parser("memory", help="Manage Living Memory patches")
+    mem_sub = p.add_subparsers(dest="memory_command")
+
+    review = mem_sub.add_parser("review", help="Review pending memory patches")
+    review.add_argument("--patch-id", default=None, help="Review a specific patch")
+    review.add_argument(
+        "--store-path",
+        default=".synapsekit_memory_patches.jsonl",
+        help="Patch store file path",
+    )
+
+    apply_cmd = mem_sub.add_parser("apply", help="Apply a pending memory patch")
+    apply_cmd.add_argument("patch_id", help="Patch ID to apply")
+    apply_cmd.add_argument(
+        "--store-path",
+        default=".synapsekit_memory_patches.jsonl",
+        help="Patch store file path",
+    )
+
+    revert_cmd = mem_sub.add_parser("revert", help="Revert an applied memory patch")
+    revert_cmd.add_argument("patch_id", help="Patch ID to revert")
+    revert_cmd.add_argument(
+        "--store-path",
+        default=".synapsekit_memory_patches.jsonl",
+        help="Patch store file path",
+    )
+
+    log_cmd = mem_sub.add_parser("log", help="View memory patch history")
+    log_cmd.add_argument("--status", default=None, help="Filter by status")
+    log_cmd.add_argument("--limit", type=int, default=20, help="Max patches to show")
+    log_cmd.add_argument(
+        "--format",
+        dest="output_format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format",
+    )
+    log_cmd.add_argument(
+        "--store-path",
+        default=".synapsekit_memory_patches.jsonl",
+        help="Patch store file path",
+    )
+
+
 def main(argv: list[str] | None = None) -> None:
     """CLI entry point."""
     from .._loop import install_fast_loop
@@ -201,6 +246,7 @@ def main(argv: list[str] | None = None) -> None:
     _add_bench_parser(subparsers)
     _add_edge_parser(subparsers)
     _add_agent_parser(subparsers)
+    _add_memory_parser(subparsers)
     _add_ui_parser(subparsers)
     _add_plugin_parser(subparsers)
 
@@ -248,6 +294,10 @@ def main(argv: list[str] | None = None) -> None:
         from .agent import run_agent
 
         run_agent(args)
+    elif args.command == "memory":
+        from .memory import run_memory
+
+        run_memory(args)
     elif args.command == "ui":
         from .ui import run_ui
 

--- a/src/synapsekit/cli/memory.py
+++ b/src/synapsekit/cli/memory.py
@@ -1,0 +1,166 @@
+"""CLI handler for ``synapsekit memory`` subcommands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def run_memory(args: argparse.Namespace) -> None:
+    """Dispatch memory subcommands."""
+    cmd = getattr(args, "memory_command", None)
+    if cmd == "review":
+        _run_review(args)
+    elif cmd == "apply":
+        _run_apply(args)
+    elif cmd == "revert":
+        _run_revert(args)
+    elif cmd == "log":
+        _run_log(args)
+    else:
+        print("Usage: synapsekit memory {review,apply,revert,log}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _run_review(args: argparse.Namespace) -> None:
+    from ..memory.patch_store import PatchStore
+
+    store = PatchStore(args.store_path)
+    pending = store.pending_patches()
+
+    patch_id = getattr(args, "patch_id", None)
+    if patch_id:
+        # Review a specific patch
+        patch = store.get(patch_id)
+        if patch is None:
+            print(f"Patch {patch_id!r} not found.", file=sys.stderr)
+            sys.exit(1)
+        _display_patch(patch)
+        return
+
+    if not pending:
+        print("No pending memory patches to review.")
+        return
+
+    # List all pending patches
+    print(f"{'ID':<18} {'File':<30} {'Category':<12} {'Created':<22} Rationale")
+    print("-" * 100)
+    for p in pending:
+        rationale_preview = (
+            p.rationale[:40] + "…" if len(p.rationale) > 40 else p.rationale
+        )
+        print(
+            f"{p.patch_id:<18} {p.file_path:<30} {p.category:<12} "
+            f"{p.created_at[:19]:<22} {rationale_preview}"
+        )
+    print(f"\n{len(pending)} pending patch(es). Use --patch-id <ID> to review details.")
+
+
+def _run_apply(args: argparse.Namespace) -> None:
+    from datetime import datetime, timezone
+
+    from ..memory.diff_engine import FileDiffEngine
+    from ..memory.patch_store import PatchStore
+
+    store = PatchStore(args.store_path)
+    patch = store.get(args.patch_id)
+    if patch is None:
+        print(f"Patch {args.patch_id!r} not found.", file=sys.stderr)
+        sys.exit(1)
+
+    if patch.status != "pending":
+        print(
+            f"Patch {args.patch_id} has status {patch.status!r}, cannot apply.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    applicable, reason = FileDiffEngine.validate_patch_applicable(
+        patch.file_path, patch.before_content
+    )
+    if not applicable:
+        print(f"Cannot apply: {reason}", file=sys.stderr)
+        sys.exit(1)
+
+    FileDiffEngine.apply_patch(patch.file_path, patch.after_content)
+    patch.status = "applied"
+    patch.applied_at = datetime.now(timezone.utc).isoformat()
+    patch.sign()
+    store.update(patch)
+    print(f"Applied patch {patch.patch_id} to {patch.file_path}")
+
+
+def _run_revert(args: argparse.Namespace) -> None:
+    from datetime import datetime, timezone
+
+    from ..memory.diff_engine import FileDiffEngine
+    from ..memory.patch_store import PatchStore
+
+    store = PatchStore(args.store_path)
+    patch = store.get(args.patch_id)
+    if patch is None:
+        print(f"Patch {args.patch_id!r} not found.", file=sys.stderr)
+        sys.exit(1)
+
+    if patch.status != "applied":
+        print(
+            f"Patch {args.patch_id} has status {patch.status!r}, cannot revert.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    FileDiffEngine.revert_to_content(patch.file_path, patch.before_content)
+    patch.status = "reverted"
+    patch.reverted_at = datetime.now(timezone.utc).isoformat()
+    patch.sign()
+    store.update(patch)
+    print(f"Reverted patch {patch.patch_id} — restored {patch.file_path}")
+
+
+def _run_log(args: argparse.Namespace) -> None:
+    from ..memory.patch_store import PatchStore
+
+    store = PatchStore(args.store_path)
+    status_filter = getattr(args, "status", None)
+    limit = getattr(args, "limit", 20)
+    fmt = getattr(args, "output_format", "table")
+
+    patches = store.list_by_status(status_filter, limit=limit)
+    if not patches:
+        print("No patches found.")
+        return
+
+    if fmt == "json":
+        print(json.dumps([p.to_dict() for p in patches], indent=2, default=str))
+        return
+
+    print(f"{'ID':<18} {'Status':<12} {'File':<30} {'Created':<22} Rationale")
+    print("-" * 100)
+    for p in patches:
+        rationale_preview = (
+            p.rationale[:35] + "…" if len(p.rationale) > 35 else p.rationale
+        )
+        print(
+            f"{p.patch_id:<18} {p.status:<12} {p.file_path:<30} "
+            f"{p.created_at[:19]:<22} {rationale_preview}"
+        )
+
+
+def _display_patch(patch) -> None:  # type: ignore[no-untyped-def]
+    """Display a single patch in detail."""
+    print(f"Patch ID:     {patch.patch_id}")
+    print(f"File:         {patch.file_path}")
+    print(f"Status:       {patch.status}")
+    print(f"Category:     {patch.category}")
+    print(f"Created:      {patch.created_at}")
+    if patch.signature:
+        print(f"Signature:    {patch.signature[:16]}…")
+    else:
+        print("Signature:    (none)")
+    print(f"Rationale:    {patch.rationale}")
+    if patch.evidence_refs:
+        print(f"Evidence:     {'; '.join(patch.evidence_refs[:3])}")
+    print()
+    print("--- Unified Diff ---")
+    print(patch.unified_diff)

--- a/src/synapsekit/computer_use/decorators.py
+++ b/src/synapsekit/computer_use/decorators.py
@@ -19,6 +19,7 @@ def requires_human_confirmation(
 
     def _wrap(func: F, _reason: str | None) -> F:
         if inspect.iscoroutinefunction(func):
+
             @functools.wraps(func)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
                 return await func(*args, **kwargs)
@@ -28,6 +29,7 @@ def requires_human_confirmation(
             async_wrapper._requires_confirmation = True  # type: ignore[attr-defined]
             return cast(F, async_wrapper)
         else:
+
             @functools.wraps(func)
             def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
                 return func(*args, **kwargs)

--- a/src/synapsekit/computer_use/decorators.py
+++ b/src/synapsekit/computer_use/decorators.py
@@ -41,11 +41,11 @@ def requires_human_confirmation(
 
     # Called as @requires_human_confirmation (no parentheses) — reason is the function
     if callable(reason):
-        return _wrap(cast(F, reason), None)
+        return _wrap(reason, None)
 
     # Called as @requires_human_confirmation() or @requires_human_confirmation("text")
     def decorator(func: F) -> F:
-        return _wrap(func, cast("str | None", reason))
+        return _wrap(func, reason)
 
     return decorator
 

--- a/src/synapsekit/computer_use/safety.py
+++ b/src/synapsekit/computer_use/safety.py
@@ -142,7 +142,9 @@ class SafetyPolicy:
             )
             if part
         ).lower()
-        keywords = tuple(self.confirm_before) if self.confirm_before is not None else _DANGEROUS_WORDS
+        keywords = (
+            tuple(self.confirm_before) if self.confirm_before is not None else _DANGEROUS_WORDS
+        )
         if any(re.search(rf"\b{re.escape(word.lower())}\b", text) for word in keywords):
             return True
         if self.require_confirmation_for_text and action.action_type in _SENSITIVE_ACTIONS:

--- a/src/synapsekit/memory/__init__.py
+++ b/src/synapsekit/memory/__init__.py
@@ -10,9 +10,15 @@ from .backends import (
 from .base import BaseMemoryBackend, MemoryRecord
 from .buffer import BufferMemory
 from .conversation import ConversationMemory
+from .diff_engine import DiffConflictError, FileDiffEngine
 from .entity import EntityMemory
+from .file_router import MemoryFileRouter
 from .hybrid import HybridMemory
 from .knowledge_graph_memory import KnowledgeGraphMemory
+from .living_memory import LivingMemory
+from .living_types import MemoryFileCategory, MemoryPatch, OccurrenceRecord, PatchStatus
+from .patch_store import OccurrenceTracker, PatchStore
+from .pii_filter import MemoryPIIFilter, PIIFilterResult
 from .readonly_shared_memory import ReadOnlySharedMemory
 from .redis import RedisConversationMemory
 from .smart_context import SmartContextManager
@@ -43,4 +49,16 @@ __all__ = [
     "SummaryBufferMemory",
     "TokenBufferMemory",
     "VectorConversationMemory",
+    "LivingMemory",
+    "MemoryPatch",
+    "OccurrenceRecord",
+    "MemoryFileCategory",
+    "PatchStatus",
+    "FileDiffEngine",
+    "DiffConflictError",
+    "PatchStore",
+    "OccurrenceTracker",
+    "MemoryPIIFilter",
+    "PIIFilterResult",
+    "MemoryFileRouter",
 ]

--- a/src/synapsekit/memory/__init__.py
+++ b/src/synapsekit/memory/__init__.py
@@ -1,5 +1,7 @@
 from .agent_memory import AgentMemory
 from .backends import (
+    GraphAgentMemory,
+    GraphMemoryBackend,
     InMemoryMemoryBackend,
     PostgresMemoryBackend,
     RedisMemoryBackend,
@@ -23,6 +25,8 @@ __all__ = [
     "AgentMemory",
     "BaseMemoryBackend",
     "MemoryRecord",
+    "GraphAgentMemory",
+    "GraphMemoryBackend",
     "InMemoryMemoryBackend",
     "SQLiteMemoryBackend",
     "RedisMemoryBackend",

--- a/src/synapsekit/memory/agent_memory.py
+++ b/src/synapsekit/memory/agent_memory.py
@@ -9,7 +9,9 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from typing import Any
 
+from ..retrieval.property_graph import PropertyGraphBackend
 from .backends import (
+    GraphMemoryBackend,
     InMemoryMemoryBackend,
     PostgresMemoryBackend,
     RedisMemoryBackend,
@@ -30,6 +32,7 @@ class AgentMemory:
         path: str | None = None,
         redis_url: str = "redis://localhost:6379",
         postgres_dsn: str | None = None,
+        store: PropertyGraphBackend | None = None,
         embedder: EmbedderFn | None = None,
         llm: Any | None = None,
         max_episodes: int = 100,
@@ -40,6 +43,7 @@ class AgentMemory:
             path=path,
             redis_url=redis_url,
             postgres_dsn=postgres_dsn,
+            graph_store=store,
         )
         self._embedder = embedder
         self._llm = llm
@@ -53,6 +57,7 @@ class AgentMemory:
         path: str | None,
         redis_url: str,
         postgres_dsn: str | None,
+        graph_store: PropertyGraphBackend | None,
     ) -> BaseMemoryBackend:
         if isinstance(backend, BaseMemoryBackend):
             return backend
@@ -66,6 +71,8 @@ class AgentMemory:
             if not postgres_dsn:
                 raise ValueError("postgres_dsn is required when backend='postgres'")
             return PostgresMemoryBackend(postgres_dsn)
+        if backend == "graph":
+            return GraphMemoryBackend(graph_store)
         raise ValueError(f"Unknown backend: {backend!r}")
 
     @staticmethod

--- a/src/synapsekit/memory/backends/__init__.py
+++ b/src/synapsekit/memory/backends/__init__.py
@@ -1,9 +1,12 @@
+from .graph import GraphAgentMemory, GraphMemoryBackend
 from .memory import InMemoryMemoryBackend
 from .postgres import PostgresMemoryBackend
 from .redis import RedisMemoryBackend
 from .sqlite import SQLiteMemoryBackend
 
 __all__ = [
+    "GraphAgentMemory",
+    "GraphMemoryBackend",
     "InMemoryMemoryBackend",
     "SQLiteMemoryBackend",
     "RedisMemoryBackend",

--- a/src/synapsekit/memory/backends/graph.py
+++ b/src/synapsekit/memory/backends/graph.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from ...retrieval.property_graph import (
+    NetworkXPropertyGraphBackend,
+    PropertyGraphBackend,
+    PropertyGraphEdge,
+    PropertyGraphNode,
+)
+from ..base import BaseMemoryBackend, MemoryRecord, MemoryType
+
+
+class GraphMemoryBackend(BaseMemoryBackend):
+    """AgentMemory backend that stores memories as property-graph nodes."""
+
+    def __init__(self, store: PropertyGraphBackend | None = None) -> None:
+        self.graph_store = store or NetworkXPropertyGraphBackend()
+        self._records: dict[str, dict[str, MemoryRecord]] = {}
+
+    async def store(self, record: MemoryRecord) -> None:
+        self._records.setdefault(record.agent_id, {})[record.id] = record
+        self.graph_store.upsert_node(
+            PropertyGraphNode(
+                id=self._node_id(record),
+                label=record.content,
+                type=f"memory_{record.memory_type}",
+                properties=self._record_properties(record),
+            )
+        )
+        for related_id in self._related_ids(record.metadata):
+            if related_id == record.id:
+                continue
+            self.graph_store.upsert_edge(
+                PropertyGraphEdge(
+                    source=self._node_id(record),
+                    target=f"memory:{record.agent_id}:{related_id}",
+                    relation=str(record.metadata.get("relation_type", "related_to")),
+                    properties={
+                        "weight": float(record.metadata.get("weight", 1.0)),
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "relation_type": str(record.metadata.get("relation_type", "related_to")),
+                        "agent_id": record.agent_id,
+                    },
+                )
+            )
+
+    async def fetch(
+        self,
+        agent_id: str,
+        memory_type: MemoryType | None = None,
+        *,
+        include_expired: bool = False,
+    ) -> list[MemoryRecord]:
+        bucket = self._records.get(agent_id, {})
+        now = datetime.now(timezone.utc)
+        records: list[MemoryRecord] = []
+        for record in bucket.values():
+            if memory_type is not None and record.memory_type != memory_type:
+                continue
+            if not include_expired and record.is_expired(now):
+                continue
+            records.append(record)
+        records.sort(key=lambda record: record.created_at)
+        return records
+
+    async def touch(
+        self,
+        agent_id: str,
+        record_id: str,
+        *,
+        accessed_at: datetime | None = None,
+    ) -> None:
+        record = self._records.get(agent_id, {}).get(record_id)
+        if record is None:
+            return
+        record.accessed_at = accessed_at or datetime.now(timezone.utc)
+        record.access_count += 1
+        node = self.graph_store.get_node(self._node_id(record))
+        if node is not None:
+            node.properties["accessed_at"] = record.accessed_at.isoformat()
+            node.properties["access_count"] = record.access_count
+            self.graph_store.upsert_node(node)
+
+    async def delete(self, agent_id: str, record_id: str) -> bool:
+        bucket = self._records.get(agent_id)
+        if bucket is None:
+            return False
+        return bucket.pop(record_id, None) is not None
+
+    async def clear(self, agent_id: str, memory_type: MemoryType | None = None) -> int:
+        bucket = self._records.get(agent_id)
+        if bucket is None:
+            return 0
+        if memory_type is None:
+            removed = len(bucket)
+            bucket.clear()
+            return removed
+        to_remove = [
+            record_id for record_id, record in bucket.items() if record.memory_type == memory_type
+        ]
+        for record_id in to_remove:
+            bucket.pop(record_id, None)
+        return len(to_remove)
+
+    async def count(self, agent_id: str, memory_type: MemoryType | None = None) -> int:
+        bucket = self._records.get(agent_id, {})
+        if memory_type is None:
+            return len(bucket)
+        return sum(1 for record in bucket.values() if record.memory_type == memory_type)
+
+    async def prune_expired(self, *, now: datetime | None = None) -> int:
+        now_utc = now or datetime.now(timezone.utc)
+        removed = 0
+        for agent_id, bucket in list(self._records.items()):
+            expired = [
+                record_id for record_id, record in bucket.items() if record.is_expired(now_utc)
+            ]
+            for record_id in expired:
+                bucket.pop(record_id, None)
+                removed += 1
+            if not bucket:
+                self._records.pop(agent_id, None)
+        return removed
+
+    @staticmethod
+    def _node_id(record: MemoryRecord) -> str:
+        return f"memory:{record.agent_id}:{record.id}"
+
+    @staticmethod
+    def _related_ids(metadata: dict[str, Any]) -> list[str]:
+        related = metadata.get("related_to") or metadata.get("related_ids") or []
+        if isinstance(related, str):
+            return [related]
+        if isinstance(related, list | tuple | set):
+            return [str(item) for item in related]
+        return []
+
+    @staticmethod
+    def _record_properties(record: MemoryRecord) -> dict[str, Any]:
+        return {
+            **record.metadata,
+            "record_id": record.id,
+            "agent_id": record.agent_id,
+            "memory_type": record.memory_type,
+            "created_at": record.created_at.isoformat(),
+            "accessed_at": record.accessed_at.isoformat(),
+            "access_count": record.access_count,
+            "ttl_days": record.ttl_days,
+        }
+
+
+GraphAgentMemory = GraphMemoryBackend

--- a/src/synapsekit/memory/diff_engine.py
+++ b/src/synapsekit/memory/diff_engine.py
@@ -1,0 +1,126 @@
+"""File-level diff engine for Living Memory patches."""
+
+from __future__ import annotations
+
+import difflib
+from pathlib import Path
+
+
+class DiffConflictError(Exception):
+    """Raised when a patch cannot be applied due to file changes since proposal."""
+
+    def __init__(self, file_path: str, expected_hash: str, actual_hash: str) -> None:
+        self.file_path = file_path
+        self.expected_hash = expected_hash
+        self.actual_hash = actual_hash
+        super().__init__(
+            f"Conflict in {file_path}: expected content hash "
+            f"{expected_hash[:12]}… but found {actual_hash[:12]}…"
+        )
+
+
+class FileDiffEngine:
+    """Generate and apply unified diffs against memory files.
+
+    Provides utilities for creating unified diffs, validating that a
+    patch is still applicable (the file hasn't diverged), applying
+    patches, and reverting them.
+    """
+
+    @staticmethod
+    def generate_unified_diff(
+        before: str,
+        after: str,
+        file_path: str = "memory.md",
+        *,
+        context_lines: int = 3,
+    ) -> str:
+        """Create a unified diff string between *before* and *after* content."""
+        before_lines = before.splitlines(keepends=True)
+        after_lines = after.splitlines(keepends=True)
+
+        # Ensure trailing newlines for clean diff output
+        if before_lines and not before_lines[-1].endswith("\n"):
+            before_lines[-1] += "\n"
+        if after_lines and not after_lines[-1].endswith("\n"):
+            after_lines[-1] += "\n"
+
+        diff_lines = difflib.unified_diff(
+            before_lines,
+            after_lines,
+            fromfile=f"a/{file_path}",
+            tofile=f"b/{file_path}",
+            n=context_lines,
+        )
+        return "".join(diff_lines)
+
+    @staticmethod
+    def compute_similarity(before: str, after: str) -> float:
+        """Return a 0.0-1.0 similarity ratio between two strings."""
+        matcher = difflib.SequenceMatcher(None, before, after)
+        return matcher.ratio()
+
+    @staticmethod
+    def validate_patch_applicable(
+        file_path: str | Path,
+        expected_before: str,
+    ) -> tuple[bool, str]:
+        """Check whether the file's current content matches the expected snapshot.
+
+        Returns a ``(is_applicable, reason)`` tuple.  A patch is considered
+        applicable when the current file content exactly matches, matches
+        after whitespace normalization, or is >95% similar.
+        """
+        path = Path(file_path)
+        if not path.exists():
+            return False, f"File does not exist: {path}"
+
+        current = path.read_text(encoding="utf-8")
+        if current == expected_before:
+            return True, "content matches"
+
+        # Allow minor whitespace drift
+        if current.strip() == expected_before.strip():
+            return True, "content matches (whitespace-normalized)"
+
+        similarity = FileDiffEngine.compute_similarity(current, expected_before)
+        if similarity > 0.95:
+            return True, f"content closely matches (similarity={similarity:.3f})"
+
+        return False, (
+            f"content has diverged (similarity={similarity:.3f}); "
+            "file may have been edited since the patch was proposed"
+        )
+
+    @staticmethod
+    def apply_patch(file_path: str | Path, after_content: str) -> str:
+        """Write the *after* content to the file.  Returns the previous content."""
+        path = Path(file_path)
+        previous = ""
+        if path.exists():
+            previous = path.read_text(encoding="utf-8")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(after_content, encoding="utf-8")
+        return previous
+
+    @staticmethod
+    def revert_to_content(file_path: str | Path, before_content: str) -> str:
+        """Revert a file to the given content snapshot.  Returns the reverted-from content."""
+        path = Path(file_path)
+        current = ""
+        if path.exists():
+            current = path.read_text(encoding="utf-8")
+        path.write_text(before_content, encoding="utf-8")
+        return current
+
+    @staticmethod
+    def count_changed_lines(unified_diff: str) -> dict[str, int]:
+        """Parse a unified diff and count additions, deletions, and net change."""
+        added = 0
+        removed = 0
+        for line in unified_diff.splitlines():
+            if line.startswith("+") and not line.startswith("+++"):
+                added += 1
+            elif line.startswith("-") and not line.startswith("---"):
+                removed += 1
+        return {"added": added, "removed": removed, "net": added - removed}

--- a/src/synapsekit/memory/file_router.py
+++ b/src/synapsekit/memory/file_router.py
@@ -1,0 +1,117 @@
+"""Route facts to the appropriate memory file based on content category."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .living_types import MemoryFileCategory
+
+
+class MemoryFileRouter:
+    """Determine which memory file a new fact should be written to.
+
+    Routes based on content analysis and configured path mappings.
+    Falls back to the primary memory file when no specific route matches.
+
+    Parameters
+    ----------
+    path_map:
+        Explicit mapping of category to file path, e.g.
+        ``{"user": "./memory/user_prefs.md"}``.
+    primary_path:
+        Default file path when no category-specific route matches.
+    allow_new_files:
+        When True, the router may suggest paths for files that don't
+        yet exist on disk.  Defaults to False.
+    """
+
+    # Keyword patterns that suggest content category
+    _CATEGORY_SIGNALS: dict[MemoryFileCategory, list[str]] = {
+        "user": [
+            r"\bprefer(?:s|ence|red)\b",
+            r"\balways\s+(?:use|choose|want)\b",
+            r"\bmy\s+(?:style|workflow|setup)\b",
+            r"\bI\s+(?:like|dislike|want|need)\b",
+        ],
+        "feedback": [
+            r"\bcorrect(?:ion|ed|ing)\b",
+            r"\bfix(?:ed)?\b",
+            r"\bwrong\b",
+            r"\bmistake\b",
+            r"\bbetter\s+(?:to|if)\b",
+        ],
+        "project": [
+            r"\barchitecture\b",
+            r"\bstack\b",
+            r"\bdependenc(?:y|ies)\b",
+            r"\bconvention\b",
+            r"\bcodebase\b",
+            r"\brepository\b",
+        ],
+    }
+
+    def __init__(
+        self,
+        path_map: dict[MemoryFileCategory, str] | None = None,
+        *,
+        primary_path: str = "./CLAUDE.md",
+        allow_new_files: bool = False,
+    ) -> None:
+        self._primary = primary_path
+        self._allow_new = allow_new_files
+        self._path_map: dict[MemoryFileCategory, str] = path_map or {}
+        self._compiled: dict[MemoryFileCategory, list[re.Pattern[str]]] = {}
+        for cat, patterns in self._CATEGORY_SIGNALS.items():
+            self._compiled[cat] = [re.compile(p, re.IGNORECASE) for p in patterns]
+
+    def categorize(self, content: str) -> MemoryFileCategory:
+        """Determine the category of a piece of content.
+
+        Scores each category by counting regex hits and returns the
+        best match, falling back to ``'general'`` when nothing matches.
+        """
+        scores: dict[MemoryFileCategory, int] = {
+            "user": 0,
+            "feedback": 0,
+            "project": 0,
+            "general": 0,
+        }
+
+        for category, patterns in self._compiled.items():
+            for pattern in patterns:
+                hits = len(pattern.findall(content))
+                scores[category] += hits
+
+        best_category = max(scores, key=scores.get)  # type: ignore[arg-type]
+        if scores[best_category] == 0:
+            return "general"
+        return best_category
+
+    def resolve_target_path(
+        self,
+        category: MemoryFileCategory,
+        managed_paths: list[str],
+    ) -> str:
+        """Determine which file path a fact should be routed to.
+
+        Resolution order:
+        1. Explicit ``path_map`` entry for the category.
+        2. A managed file whose basename starts with the category name.
+        3. The primary memory file as fallback.
+        """
+        # Check explicit path map first
+        if category in self._path_map:
+            candidate = self._path_map[category]
+            if candidate in managed_paths or self._allow_new:
+                return candidate
+
+        # Try to find a managed file whose name suggests this category
+        category_prefix = f"{category}_"
+        for managed in managed_paths:
+            basename = Path(managed).stem.lower()
+            if basename.startswith(category_prefix) or basename == category:
+                return managed
+
+        # Fall back to primary
+        return self._primary

--- a/src/synapsekit/memory/living_memory.py
+++ b/src/synapsekit/memory/living_memory.py
@@ -1,0 +1,500 @@
+"""Living Memory — bidirectional agent memory file management."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .diff_engine import FileDiffEngine
+from .file_router import MemoryFileRouter
+from .living_types import MemoryPatch, PatchStatus
+from .patch_store import OccurrenceTracker, PatchStore
+from .pii_filter import MemoryPIIFilter
+
+_log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# LLM prompt for proposing memory patches
+# ---------------------------------------------------------------------------
+_PROPOSAL_PROMPT = """\
+You are a Memory Writer agent. Analyze the session transcript below and propose \
+updates to the user's memory files.
+
+## Current Memory Files
+{file_contents}
+
+## Session Transcript
+{transcript}
+
+## Instructions
+1. Identify facts, preferences, corrections, or decisions that should be persisted.
+2. For each proposed change, output a JSON object with:
+   - "file_path": which file to update
+   - "section": which section heading the change belongs under (or "new" for a new section)
+   - "fact_key": a short stable identifier for this fact (snake_case, ≤40 chars)
+   - "proposed_addition": the markdown text to add or modify
+   - "rationale": why this should be recorded
+   - "evidence": quote from the transcript supporting this change
+3. Only propose changes for durable, reusable information — not one-off requests.
+4. Do NOT propose changes that are already present in the memory files.
+5. Return a JSON array of proposed changes. If no changes needed, return [].
+"""
+
+
+class LivingMemory:
+    """Orchestrate bidirectional memory file management.
+
+    Observes agent sessions, proposes signed diffs to memory files,
+    and manages the review / apply / revert lifecycle.
+
+    Parameters
+    ----------
+    paths:
+        Glob patterns or explicit paths to managed memory files.
+    proposer:
+        An LLM instance used to generate patch proposals.  Should support
+        ``generate(prompt)`` or ``agenerate(prompt)``.
+    require_approval:
+        If True (default), patches are stored as ``"pending"`` for human
+        review.  If False, patches are auto-applied after PII filtering.
+    sign:
+        Whether to cryptographically sign patches.
+    signature_secret:
+        Secret used for HMAC-style patch signing.
+    store_path:
+        Path for the JSONL patch store file.
+    occurrence_path:
+        Path for the occurrence tracker JSON file.
+    occurrence_threshold:
+        Minimum times a fact must be observed before proposing a patch.
+    pii_filter:
+        Custom PII filter instance.  Uses default if None.
+    file_router:
+        Custom file router instance.  Uses default if None.
+    """
+
+    def __init__(
+        self,
+        paths: list[str],
+        proposer: Any | None = None,
+        *,
+        require_approval: bool = True,
+        sign: bool = True,
+        signature_secret: str = "",
+        store_path: str = ".synapsekit_memory_patches.jsonl",
+        occurrence_path: str | None = ".synapsekit_memory_occurrences.json",
+        occurrence_threshold: int = 3,
+        pii_filter: MemoryPIIFilter | None = None,
+        file_router: MemoryFileRouter | None = None,
+    ) -> None:
+        self._raw_paths = paths
+        self._proposer = proposer
+        self._require_approval = require_approval
+        self._sign = sign
+        self._secret = signature_secret
+        self._occurrence_threshold = occurrence_threshold
+
+        self._store = PatchStore(store_path)
+        self._tracker = OccurrenceTracker(occurrence_path)
+        self._pii_filter = pii_filter or MemoryPIIFilter()
+        self._diff = FileDiffEngine()
+        self._router = file_router or MemoryFileRouter(
+            primary_path=paths[0] if paths else "./CLAUDE.md"
+        )
+
+    # ------------------------------------------------------------------
+    # Public properties
+    # ------------------------------------------------------------------
+
+    @property
+    def managed_paths(self) -> list[str]:
+        """Resolve glob patterns to actual file paths."""
+        resolved: list[str] = []
+        seen: set[str] = set()
+        for raw in self._raw_paths:
+            path = Path(raw)
+            if "*" in raw or "?" in raw:
+                parent = path.parent
+                pattern = path.name
+                if parent.exists():
+                    for match in sorted(parent.glob(pattern)):
+                        if match.is_file():
+                            norm = str(match)
+                            if norm not in seen:
+                                seen.add(norm)
+                                resolved.append(norm)
+            elif path.is_file():
+                norm = str(path)
+                if norm not in seen:
+                    seen.add(norm)
+                    resolved.append(norm)
+        return resolved
+
+    # ------------------------------------------------------------------
+    # Session analysis
+    # ------------------------------------------------------------------
+
+    async def propose_from_session(
+        self,
+        session_id: str,
+        *,
+        transcript: str | None = None,
+        session_records: list[dict[str, Any]] | None = None,
+    ) -> list[MemoryPatch]:
+        """Analyze a session and propose memory file patches.
+
+        Returns a list of :class:`MemoryPatch` objects.  Their status will
+        be ``"pending"`` when *require_approval* is True, otherwise
+        ``"applied"``.
+        """
+        if self._proposer is None:
+            _log.warning("No proposer LLM configured — skipping patch proposal")
+            return []
+
+        # Build transcript from records if not provided directly
+        if transcript is None and session_records:
+            transcript = self._format_session_records(session_records)
+        if not transcript:
+            return []
+
+        file_contents = self._read_managed_files()
+        if not file_contents:
+            _log.warning("No managed memory files found at configured paths")
+            return []
+
+        # Build the proposal prompt
+        files_section = self._format_file_contents(file_contents)
+        prompt = _PROPOSAL_PROMPT.format(
+            file_contents=files_section,
+            transcript=transcript[:8000],  # Cap transcript length
+        )
+
+        # Get proposals from LLM
+        raw_proposals = await self._generate_proposals(prompt)
+        if not raw_proposals:
+            return []
+
+        # Process each proposal through the pipeline
+        patches: list[MemoryPatch] = []
+        for proposal in raw_proposals:
+            patch = await self._process_single_proposal(
+                proposal=proposal,
+                file_contents=file_contents,
+                session_id=session_id,
+            )
+            if patch is not None:
+                patches.append(patch)
+
+        return patches
+
+    # ------------------------------------------------------------------
+    # Review / apply / revert
+    # ------------------------------------------------------------------
+
+    def review(self, patch: MemoryPatch | str) -> dict[str, Any]:
+        """Prepare a patch for interactive review.
+
+        Returns a dict with the diff, rationale, and review metadata
+        suitable for display in a CLI or editor.
+        """
+        if isinstance(patch, str):
+            resolved = self._store.get(patch)
+            if resolved is None:
+                raise KeyError(f"Patch {patch!r} not found")
+            patch = resolved
+
+        stats = self._diff.count_changed_lines(patch.unified_diff)
+        return {
+            "patch_id": patch.patch_id,
+            "file_path": patch.file_path,
+            "status": patch.status,
+            "rationale": patch.rationale,
+            "evidence": patch.evidence_refs,
+            "category": patch.category,
+            "diff": patch.unified_diff,
+            "stats": stats,
+            "created_at": patch.created_at,
+            "signature_valid": patch.verify(self._secret) if patch.signature else None,
+        }
+
+    def apply(self, patch: MemoryPatch | str) -> MemoryPatch:
+        """Apply an approved patch to the target file."""
+        if isinstance(patch, str):
+            resolved = self._store.get(patch)
+            if resolved is None:
+                raise KeyError(f"Patch {patch!r} not found")
+            patch = resolved
+
+        if patch.status not in ("pending", "approved"):
+            raise ValueError(
+                f"Cannot apply patch {patch.patch_id!r} with status {patch.status!r}"
+            )
+
+        # Validate the file hasn't changed
+        applicable, reason = self._diff.validate_patch_applicable(
+            patch.file_path, patch.before_content
+        )
+        if not applicable:
+            patch.status = "conflict"
+            patch.metadata["conflict_reason"] = reason
+            self._store.update(patch)
+            raise RuntimeError(
+                f"Cannot apply patch {patch.patch_id}: {reason}"
+            )
+
+        self._apply_patch_to_file(patch)
+        return patch
+
+    def revert(self, patch_id: str) -> MemoryPatch:
+        """Revert a previously applied patch."""
+        patch = self._store.get(patch_id)
+        if patch is None:
+            raise KeyError(f"Patch {patch_id!r} not found")
+
+        if patch.status != "applied":
+            raise ValueError(
+                f"Cannot revert patch {patch_id!r} with status {patch.status!r}"
+            )
+
+        self._diff.revert_to_content(patch.file_path, patch.before_content)
+        patch.status = "reverted"
+        patch.reverted_at = datetime.now(timezone.utc).isoformat()
+        if self._sign:
+            patch.sign(self._secret)
+        self._store.update(patch)
+
+        _log.info("Reverted patch %s on %s", patch_id, patch.file_path)
+        return patch
+
+    def pending_patches(self) -> list[MemoryPatch]:
+        """Return all patches awaiting review."""
+        return self._store.pending_patches()
+
+    def patch_history(
+        self,
+        *,
+        status: PatchStatus | None = None,
+        limit: int | None = None,
+    ) -> list[MemoryPatch]:
+        """Return patch history, newest first."""
+        return self._store.list_by_status(status, limit=limit)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _read_managed_files(self) -> dict[str, str]:
+        """Read current content of all managed memory files."""
+        contents: dict[str, str] = {}
+        for file_path in self.managed_paths:
+            try:
+                contents[file_path] = Path(file_path).read_text(encoding="utf-8")
+            except OSError as exc:
+                _log.warning("Could not read %s: %s", file_path, exc)
+        return contents
+
+    async def _generate_proposals(self, prompt: str) -> list[dict[str, Any]]:
+        """Call the proposer LLM and parse the JSON response."""
+        try:
+            if hasattr(self._proposer, "agenerate"):
+                raw = await self._proposer.agenerate(prompt)
+            elif hasattr(self._proposer, "generate"):
+                result = self._proposer.generate(prompt)
+                if inspect.isawaitable(result):
+                    raw = await result
+                else:
+                    raw = result
+            else:
+                _log.error("Proposer LLM has no generate/agenerate method")
+                return []
+        except Exception:
+            _log.exception("LLM proposal generation failed")
+            return []
+
+        return self._parse_proposal_json(str(raw))
+
+    async def _process_single_proposal(
+        self,
+        proposal: dict[str, Any],
+        file_contents: dict[str, str],
+        session_id: str,
+    ) -> MemoryPatch | None:
+        """Transform a raw LLM proposal into a validated MemoryPatch."""
+        fact_key = str(proposal.get("fact_key", ""))
+        if not fact_key:
+            return None
+
+        evidence = str(proposal.get("evidence", ""))
+        self._tracker.record_occurrence(fact_key, session_id, evidence)
+
+        # Check occurrence threshold
+        if not self._tracker.has_reached_threshold(
+            fact_key, self._occurrence_threshold
+        ):
+            current_count = self._tracker.get_count(fact_key)
+            _log.debug(
+                "Fact %r has not reached threshold (%d/%d) — deferring",
+                fact_key,
+                current_count,
+                self._occurrence_threshold,
+            )
+            return None
+
+        # Determine target file
+        content_text = str(proposal.get("proposed_addition", ""))
+        category = self._router.categorize(content_text)
+        target_path = self._router.resolve_target_path(
+            category, list(file_contents.keys())
+        )
+
+        # Build the patch
+        before = file_contents.get(target_path, "")
+        after = self._insert_content(
+            before,
+            content_text,
+            section=str(proposal.get("section", "")),
+        )
+
+        if before == after:
+            return None
+
+        # PII filter
+        pii_result = self._pii_filter.filter_content(after)
+        after = pii_result.filtered_content
+
+        unified = self._diff.generate_unified_diff(before, after, target_path)
+        if not unified.strip():
+            return None
+
+        patch = MemoryPatch(
+            file_path=target_path,
+            before_content=before,
+            after_content=after,
+            unified_diff=unified,
+            rationale=str(proposal.get("rationale", "")),
+            evidence_refs=[evidence] if evidence else [],
+            session_id=session_id,
+            category=category,
+            status="pending" if self._require_approval else "applied",
+            metadata={
+                "fact_key": fact_key,
+                "pii_filtered": not pii_result.is_clean,
+                "diff_stats": self._diff.count_changed_lines(unified),
+            },
+        )
+
+        if self._sign:
+            patch.sign(self._secret)
+
+        self._store.save(patch)
+
+        # Auto-apply if approval not required
+        if not self._require_approval:
+            self._apply_patch_to_file(patch)
+
+        return patch
+
+    def _apply_patch_to_file(self, patch: MemoryPatch) -> None:
+        """Write the patch content to disk and update status."""
+        self._diff.apply_patch(patch.file_path, patch.after_content)
+        patch.status = "applied"
+        patch.applied_at = datetime.now(timezone.utc).isoformat()
+        if self._sign:
+            patch.sign(self._secret)
+        self._store.update(patch)
+        _log.info("Applied patch %s to %s", patch.patch_id, patch.file_path)
+
+    @staticmethod
+    def _insert_content(
+        existing: str,
+        addition: str,
+        section: str = "",
+    ) -> str:
+        """Insert new content into the appropriate section of a file."""
+        addition = addition.strip()
+        if not addition:
+            return existing
+
+        lines = existing.split("\n")
+
+        if section and section != "new":
+            # Find the section heading and insert after it
+            section_lower = section.lower().strip("# ").strip()
+            insert_idx = None
+            for i, line in enumerate(lines):
+                stripped = line.strip().lower().lstrip("# ").strip()
+                if stripped == section_lower:
+                    # Find the end of this section (next heading or EOF)
+                    insert_idx = i + 1
+                    while insert_idx < len(lines):
+                        next_line = lines[insert_idx].strip()
+                        if next_line.startswith("#"):
+                            break
+                        insert_idx += 1
+                    break
+
+            if insert_idx is not None:
+                # If inserting at the end of the file and it has a trailing newline (empty string in lines),
+                # insert before it to preserve the single trailing newline properly.
+                if insert_idx == len(lines) and len(lines) > 1 and lines[-1] == "":
+                    lines.insert(len(lines) - 1, addition)
+                else:
+                    lines.insert(insert_idx, addition)
+                return "\n".join(lines)
+
+        # Default: append at end
+        if existing and not existing.endswith("\n"):
+            return existing + "\n\n" + addition + "\n"
+        return existing + "\n" + addition + "\n"
+
+    @staticmethod
+    def _format_file_contents(contents: dict[str, str]) -> str:
+        """Format managed file contents for the LLM prompt."""
+        parts: list[str] = []
+        for path, content in contents.items():
+            parts.append(f"### File: `{path}`\n```markdown\n{content}\n```")
+        return "\n\n".join(parts)
+
+    @staticmethod
+    def _format_session_records(records: list[dict[str, Any]]) -> str:
+        """Format session records into a readable transcript."""
+        lines: list[str] = []
+        for record in records:
+            role = record.get("role", "unknown")
+            content = record.get("content", "")
+            lines.append(f"[{role}]: {content}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _parse_proposal_json(text: str) -> list[dict[str, Any]]:
+        """Extract JSON array from LLM response text."""
+        cleaned = text.strip()
+        if cleaned.startswith("```"):
+            cleaned = cleaned[3:]
+            if cleaned.endswith("```"):
+                cleaned = cleaned[:-3]
+            if cleaned.startswith("json"):
+                cleaned = cleaned[4:].strip()
+            cleaned = cleaned.strip()
+
+        try:
+            parsed = json.loads(cleaned)
+        except json.JSONDecodeError:
+            start = cleaned.find("[")
+            end = cleaned.rfind("]")
+            if start == -1 or end == -1 or end <= start:
+                return []
+            try:
+                parsed = json.loads(cleaned[start : end + 1])
+            except json.JSONDecodeError:
+                return []
+
+        if isinstance(parsed, dict):
+            parsed = [parsed]
+        if not isinstance(parsed, list):
+            return []
+        return [item for item in parsed if isinstance(item, dict)]

--- a/src/synapsekit/memory/living_types.py
+++ b/src/synapsekit/memory/living_types.py
@@ -1,0 +1,113 @@
+"""Data types for Living Memory — file-level patches with signatures."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+PatchStatus = Literal[
+    "pending",
+    "approved",
+    "applied",
+    "rejected",
+    "reverted",
+    "conflict",
+]
+
+MemoryFileCategory = Literal[
+    "user",
+    "feedback",
+    "project",
+    "general",
+]
+
+
+@dataclass
+class MemoryPatch:
+    """A proposed diff to a memory file, with provenance and signature.
+
+    Each patch captures the full before/after content of the target file,
+    along with a unified diff, rationale for the change, evidence from
+    the originating session, and a SHA-256 signature for integrity.
+    """
+
+    file_path: str
+    before_content: str
+    after_content: str
+    unified_diff: str
+    rationale: str
+    evidence_refs: list[str] = field(default_factory=list)
+    patch_id: str = field(default_factory=lambda: uuid.uuid4().hex[:16])
+    created_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    status: PatchStatus = "pending"
+    category: MemoryFileCategory = "general"
+    session_id: str | None = None
+    author: str = "living-memory"
+    signature: str = ""
+    applied_at: str | None = None
+    reverted_at: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def sign(self, secret: str = "") -> str:
+        """Compute and store a SHA-256 signature over patch content."""
+        payload = self._signature_material()
+        raw = json.dumps(payload, sort_keys=True, default=str, separators=(",", ":"))
+        self.signature = hashlib.sha256(f"{secret}:{raw}".encode()).hexdigest()
+        return self.signature
+
+    def verify(self, secret: str = "") -> bool:
+        """Check that the stored signature matches the current content."""
+        payload = self._signature_material()
+        raw = json.dumps(payload, sort_keys=True, default=str, separators=(",", ":"))
+        expected = hashlib.sha256(f"{secret}:{raw}".encode()).hexdigest()
+        return self.signature == expected
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MemoryPatch:
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+    def _signature_material(self) -> dict[str, Any]:
+        data = asdict(self)
+        data.pop("signature", None)
+        data.pop("applied_at", None)
+        data.pop("reverted_at", None)
+        return data
+
+
+@dataclass
+class OccurrenceRecord:
+    """Tracks how many times a particular fact or pattern has been observed.
+
+    Used by the occurrence threshold system to prevent memory pollution
+    from single observations — a fact must be seen at least N times
+    across different sessions before a patch is proposed.
+    """
+
+    fact_key: str
+    count: int = 0
+    first_seen: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    last_seen: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    session_ids: list[str] = field(default_factory=list)
+    sample_evidence: list[str] = field(default_factory=list)
+
+    def increment(self, session_id: str, evidence: str = "") -> None:
+        """Record a new observation of this fact."""
+        self.count += 1
+        self.last_seen = datetime.now(timezone.utc).isoformat()
+        if session_id and session_id not in self.session_ids:
+            self.session_ids.append(session_id)
+        if evidence and len(self.sample_evidence) < 5:
+            self.sample_evidence.append(evidence[:500])

--- a/src/synapsekit/memory/patch_store.py
+++ b/src/synapsekit/memory/patch_store.py
@@ -1,0 +1,164 @@
+"""JSONL-backed patch storage for Living Memory."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from .living_types import MemoryPatch, OccurrenceRecord, PatchStatus
+
+_log = logging.getLogger(__name__)
+
+
+class PatchStore:
+    """Append-only JSONL store for memory patches with query helpers.
+
+    Patches are persisted as one JSON object per line.  Updates to an
+    existing patch (e.g. status change) are appended as new lines;
+    queries always return the latest version for each ``patch_id``.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._patches: list[MemoryPatch] = []
+        if self._path.exists():
+            self._load()
+
+    def save(self, patch: MemoryPatch) -> MemoryPatch:
+        """Sign and append a new patch to the store."""
+        if not patch.signature:
+            patch.sign()
+        self._patches.append(patch)
+        self._append_line(patch.to_dict())
+        return patch
+
+    def update(self, patch: MemoryPatch) -> None:
+        """Re-sign and persist the updated patch by appending a new line."""
+        patch.sign()
+        self._append_line(patch.to_dict())
+
+    def get(self, patch_id: str) -> MemoryPatch | None:
+        """Retrieve the latest version of a patch by its ID."""
+        for patch in reversed(self._patches):
+            if patch.patch_id == patch_id:
+                return patch
+        return None
+
+    def list_by_status(
+        self,
+        status: PatchStatus | None = None,
+        *,
+        limit: int | None = None,
+    ) -> list[MemoryPatch]:
+        """Return patches filtered by status, newest first, deduplicated by ID."""
+        result = [
+            p for p in reversed(self._patches)
+            if status is None or p.status == status
+        ]
+        # Deduplicate by patch_id (keep latest)
+        seen: set[str] = set()
+        deduped: list[MemoryPatch] = []
+        for p in result:
+            if p.patch_id not in seen:
+                seen.add(p.patch_id)
+                deduped.append(p)
+        if limit is not None:
+            return deduped[:limit]
+        return deduped
+
+    def pending_patches(self) -> list[MemoryPatch]:
+        """Shorthand for listing all patches with status ``'pending'``."""
+        return self.list_by_status("pending")
+
+    def count(self, status: PatchStatus | None = None) -> int:
+        """Count patches, optionally filtered by status."""
+        return len(self.list_by_status(status))
+
+    def _append_line(self, data: dict[str, Any]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(data, sort_keys=True, default=str) + "\n")
+
+    def _load(self) -> None:
+        with self._path.open("r", encoding="utf-8") as f:
+            for line_num, line in enumerate(f, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    self._patches.append(MemoryPatch.from_dict(json.loads(line)))
+                except (json.JSONDecodeError, TypeError) as exc:
+                    _log.warning("Skipping corrupt patch at line %d: %s", line_num, exc)
+
+
+class OccurrenceTracker:
+    """Track fact occurrences across sessions to avoid single-observation noise.
+
+    Facts must be observed at least ``min_occurrences`` times (across
+    different sessions) before they are eligible for patch proposals.
+    State is persisted as a JSON file.
+    """
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self._path = Path(path) if path else None
+        self._records: dict[str, OccurrenceRecord] = {}
+        if self._path and self._path.exists():
+            self._load()
+
+    def record_occurrence(
+        self,
+        fact_key: str,
+        session_id: str,
+        evidence: str = "",
+    ) -> OccurrenceRecord:
+        """Record one observation of *fact_key* in the given session."""
+        if fact_key not in self._records:
+            self._records[fact_key] = OccurrenceRecord(fact_key=fact_key)
+        rec = self._records[fact_key]
+        rec.increment(session_id, evidence)
+        self._persist()
+        return rec
+
+    def get_mature_facts(self, min_occurrences: int = 3) -> list[OccurrenceRecord]:
+        """Return facts that have been observed at least *min_occurrences* times."""
+        return [
+            r for r in self._records.values()
+            if r.count >= min_occurrences
+        ]
+
+    def has_reached_threshold(self, fact_key: str, threshold: int = 3) -> bool:
+        """Check whether a fact has met the occurrence threshold."""
+        rec = self._records.get(fact_key)
+        return rec is not None and rec.count >= threshold
+
+    def get_count(self, fact_key: str) -> int:
+        """Return the current occurrence count for a fact, or 0 if unseen."""
+        rec = self._records.get(fact_key)
+        return rec.count if rec is not None else 0
+
+    def remove(self, fact_key: str) -> None:
+        """Delete tracking data for a fact."""
+        self._records.pop(fact_key, None)
+        self._persist()
+
+    def _persist(self) -> None:
+        if self._path is None:
+            return
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        data = {k: vars(v) for k, v in self._records.items()}
+        self._path.write_text(
+            json.dumps(data, sort_keys=True, default=str, indent=2),
+            encoding="utf-8",
+        )
+
+    def _load(self) -> None:
+        if self._path is None:
+            return
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+            for key, val in raw.items():
+                self._records[key] = OccurrenceRecord(**val)
+        except (json.JSONDecodeError, TypeError):
+            _log.warning("Could not parse occurrence tracker at %s", self._path)

--- a/src/synapsekit/memory/pii_filter.py
+++ b/src/synapsekit/memory/pii_filter.py
@@ -1,0 +1,130 @@
+"""PII filtering for Living Memory patches."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from ..agents.guardrails import GuardrailResult, PIIDetector
+
+
+@dataclass
+class PIIFilterResult:
+    """Result of PII filtering on a memory patch.
+
+    When ``is_clean`` is True the content contained no detectable PII.
+    Otherwise ``filtered_content`` holds the redacted version and
+    ``redaction_types`` lists which categories were found.
+    """
+
+    is_clean: bool
+    original_content: str
+    filtered_content: str
+    redacted_count: int = 0
+    redaction_types: list[str] = field(default_factory=list)
+
+
+class MemoryPIIFilter:
+    """Filter PII from proposed memory patches before they reach storage.
+
+    Leverages the existing :class:`PIIDetector` from the guardrails module
+    and adds active redaction — replacing detected PII with placeholder
+    tokens so that memory files never contain sensitive information.
+
+    Parameters
+    ----------
+    detect:
+        List of PII types to scan for.  Defaults to all known types.
+    redact:
+        When True (default), detected PII is replaced with placeholders.
+        When False, the filter only reports findings without modifying content.
+    """
+
+    _REDACTION_PATTERNS: dict[str, tuple[str, str]] = {
+        "email": (
+            r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
+            "[REDACTED_EMAIL]",
+        ),
+        "phone": (
+            r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b",
+            "[REDACTED_PHONE]",
+        ),
+        "ssn": (
+            r"\b\d{3}-\d{2}-\d{4}\b",
+            "[REDACTED_SSN]",
+        ),
+        "credit_card": (
+            r"\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b",
+            "[REDACTED_CC]",
+        ),
+        "ip_address": (
+            r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b",
+            "[REDACTED_IP]",
+        ),
+        "api_key": (
+            r"\b(?:sk|pk|api|key|token|secret)[-_]?[A-Za-z0-9]{20,}\b",
+            "[REDACTED_KEY]",
+        ),
+    }
+
+    def __init__(
+        self,
+        detect: list[str] | None = None,
+        *,
+        redact: bool = True,
+    ) -> None:
+        active_types = detect or list(self._REDACTION_PATTERNS.keys())
+        self._detector = PIIDetector(
+            detect=[t for t in active_types if t in PIIDetector._PATTERNS]
+        )
+        self._redact = redact
+        self._compiled: dict[str, tuple[re.Pattern[str], str]] = {}
+        for name, (pattern, replacement) in self._REDACTION_PATTERNS.items():
+            if name in active_types:
+                self._compiled[name] = (re.compile(pattern), replacement)
+
+    def check(self, text: str) -> GuardrailResult:
+        """Check for PII without redacting."""
+        return self._detector.check(text)
+
+    def filter_content(self, content: str) -> PIIFilterResult:
+        """Detect and optionally redact PII from content."""
+        check_result = self._detector.check(content)
+
+        if check_result.passed:
+            return PIIFilterResult(
+                is_clean=True,
+                original_content=content,
+                filtered_content=content,
+            )
+
+        if not self._redact:
+            return PIIFilterResult(
+                is_clean=False,
+                original_content=content,
+                filtered_content=content,
+                redaction_types=[
+                    v.split("(")[1].rstrip(")").split(":")[0]
+                    for v in check_result.violations
+                ],
+            )
+
+        # Apply redactions
+        filtered = content
+        total_redacted = 0
+        types_found: list[str] = []
+
+        for pii_type, (pattern, replacement) in self._compiled.items():
+            matches = pattern.findall(filtered)
+            if matches:
+                filtered = pattern.sub(replacement, filtered)
+                total_redacted += len(matches)
+                types_found.append(pii_type)
+
+        return PIIFilterResult(
+            is_clean=False,
+            original_content=content,
+            filtered_content=filtered,
+            redacted_count=total_redacted,
+            redaction_types=types_found,
+        )

--- a/src/synapsekit/retrieval/__init__.py
+++ b/src/synapsekit/retrieval/__init__.py
@@ -18,6 +18,17 @@ from .late_chunking import LateChunkingRetriever
 from .mongodb_atlas import MongoDBAtlasVectorStore
 from .multi_step import MultiStepRetriever
 from .parent_document import ParentDocumentRetriever
+from .property_graph import (
+    ExtractedEntity,
+    ExtractedRelationship,
+    GraphVectorStore,
+    KnowledgeGraphExtraction,
+    KnowledgeGraphExtractor,
+    Neo4jPropertyGraphBackend,
+    NetworkXPropertyGraphBackend,
+    PropertyGraphEdge,
+    PropertyGraphNode,
+)
 from .query_decomposition import QueryDecompositionRetriever
 from .raptor import RAPTORRetriever
 from .retriever import Retriever
@@ -69,17 +80,24 @@ __all__ = [
     "FLARERetriever",
     "FullContextRetriever",
     "GraphRAGRetriever",
+    "GraphVectorStore",
     "HybridSearchRetriever",
     "HyDERetriever",
     "InMemoryVectorStore",
     "KnowledgeGraph",
+    "KnowledgeGraphExtraction",
+    "KnowledgeGraphExtractor",
     "LanceDBVectorStore",
     "MarqoVectorStore",
     "MilvusVectorStore",
     "MongoDBAtlasVectorStore",
     "MultiStepRetriever",
+    "Neo4jPropertyGraphBackend",
+    "NetworkXPropertyGraphBackend",
     "OpenSearchVectorStore",
     "ParentDocumentRetriever",
+    "PropertyGraphEdge",
+    "PropertyGraphNode",
     "PGVectorStore",
     "PineconeVectorStore",
     "QdrantVectorStore",
@@ -112,6 +130,8 @@ __all__ = [
     "WorldModelNode",
     "WorldModelRAG",
     "WorldModelQueryResult",
+    "ExtractedEntity",
+    "ExtractedRelationship",
     "ZillizVectorStore",
 ]
 

--- a/src/synapsekit/retrieval/property_graph.py
+++ b/src/synapsekit/retrieval/property_graph.py
@@ -1,0 +1,900 @@
+"""Property-graph retrieval primitives for graph-aware RAG."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from itertools import pairwise
+from typing import Any, Literal, Protocol, cast
+
+from ..embeddings.backend import SynapsekitEmbeddings
+from ..llm.base import BaseLLM
+from .base import VectorStore
+from .vectorstore import InMemoryVectorStore
+
+PropertyGraphBackendName = Literal["networkx", "neo4j"]
+
+_ENTITY_RE = re.compile(
+    r"(?:@[A-Za-z][\w.-]*|[A-Z][A-Za-z0-9&.-]*(?:\s+[A-Z][A-Za-z0-9&.-]*){0,4})"
+)
+_RELATION_HINTS: tuple[tuple[str, str], ...] = (
+    ("acquired", "acquired"),
+    ("built", "built"),
+    ("created", "created"),
+    ("depends on", "depends_on"),
+    ("founded", "founded"),
+    ("leads", "leads"),
+    ("led", "led"),
+    ("released", "released"),
+    ("uses", "uses"),
+    ("works on", "works_on"),
+)
+
+
+@dataclass(slots=True)
+class PropertyGraphNode:
+    """A property-graph node with arbitrary metadata."""
+
+    id: str
+    label: str
+    type: str = "entity"
+    properties: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class PropertyGraphEdge:
+    """A directed property-graph edge with arbitrary metadata."""
+
+    source: str
+    target: str
+    relation: str = "related_to"
+    properties: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def id(self) -> str:
+        return f"{self.source}:{self.relation}:{self.target}"
+
+
+@dataclass(slots=True)
+class ExtractedEntity:
+    """Entity extracted from a document."""
+
+    name: str
+    type: str = "entity"
+    confidence: float = 1.0
+    properties: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ExtractedRelationship:
+    """Relationship extracted from a document."""
+
+    source: str
+    target: str
+    relation: str = "related_to"
+    confidence: float = 1.0
+    properties: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class KnowledgeGraphExtraction:
+    """Structured extraction output for one document."""
+
+    entities: list[ExtractedEntity] = field(default_factory=list)
+    relationships: list[ExtractedRelationship] = field(default_factory=list)
+
+
+class PropertyGraphBackend(Protocol):
+    """Storage contract used by graph RAG and graph-backed memory."""
+
+    def upsert_node(self, node: PropertyGraphNode) -> None: ...
+
+    def upsert_edge(self, edge: PropertyGraphEdge) -> None: ...
+
+    def get_node(self, node_id: str) -> PropertyGraphNode | None: ...
+
+    def get_edge(self, edge_id: str) -> PropertyGraphEdge | None: ...
+
+    def neighbors(
+        self, node_id: str, *, direction: Literal["both", "out", "in"] = "both"
+    ) -> list[str]: ...
+
+    def traverse(
+        self,
+        seed_ids: list[str],
+        *,
+        max_hops: int = 2,
+        min_confidence: float = 0.0,
+    ) -> tuple[list[PropertyGraphNode], list[PropertyGraphEdge]]: ...
+
+    def document_ids_for_nodes(self, node_ids: list[str]) -> list[str]: ...
+
+    def nodes(self) -> list[PropertyGraphNode]: ...
+
+    def edges(self) -> list[PropertyGraphEdge]: ...
+
+
+class _AdjacencyGraph:
+    """Small fallback graph used when NetworkX is not installed."""
+
+    def __init__(self) -> None:
+        self.nodes: dict[str, dict[str, Any]] = {}
+        self.edges: dict[tuple[str, str, str], dict[str, Any]] = {}
+        self.outgoing: dict[str, set[str]] = defaultdict(set)
+        self.incoming: dict[str, set[str]] = defaultdict(set)
+
+    def add_node(self, node_id: str, **attrs: Any) -> None:
+        self.nodes.setdefault(node_id, {}).update(attrs)
+
+    def add_edge(self, source: str, target: str, key: str, **attrs: Any) -> None:
+        self.edges[(source, target, key)] = attrs
+        self.outgoing[source].add(target)
+        self.incoming[target].add(source)
+
+
+class NetworkXPropertyGraphBackend:
+    """In-memory property graph backend with a NetworkX-compatible fallback."""
+
+    def __init__(self) -> None:
+        self._nodes: dict[str, PropertyGraphNode] = {}
+        self._edges: dict[str, PropertyGraphEdge] = {}
+        self._label_to_id: dict[str, str] = {}
+        self._documents_by_node: dict[str, set[str]] = defaultdict(set)
+        try:
+            import networkx as nx  # type: ignore[import-not-found]
+        except ImportError:
+            self._graph: Any = _AdjacencyGraph()
+            self.uses_networkx = False
+        else:
+            self._graph = nx.MultiDiGraph()
+            self.uses_networkx = True
+
+    def upsert_node(self, node: PropertyGraphNode) -> None:
+        existing = self._nodes.get(node.id)
+        if existing is None:
+            self._nodes[node.id] = node
+        else:
+            existing.properties.update(node.properties)
+            existing.type = node.type or existing.type
+            existing.label = node.label or existing.label
+        self._label_to_id[_normalize(node.label)] = node.id
+        for alias in node.properties.get("aliases", []) or []:
+            self._label_to_id[_normalize(str(alias))] = node.id
+        source_doc = node.properties.get("source_doc") or node.properties.get("source")
+        if source_doc:
+            self._documents_by_node[node.id].add(str(source_doc))
+        self._graph.add_node(
+            node.id,
+            label=node.label,
+            type=node.type,
+            **node.properties,
+        )
+
+    def upsert_edge(self, edge: PropertyGraphEdge) -> None:
+        self._edges[edge.id] = edge
+        source_doc = edge.properties.get("source_doc") or edge.properties.get("source")
+        if source_doc:
+            self._documents_by_node[edge.source].add(str(source_doc))
+            self._documents_by_node[edge.target].add(str(source_doc))
+        self._graph.add_edge(
+            edge.source,
+            edge.target,
+            key=edge.relation,
+            relation=edge.relation,
+            **edge.properties,
+        )
+
+    def get_node(self, node_id: str) -> PropertyGraphNode | None:
+        return self._nodes.get(node_id)
+
+    def get_edge(self, edge_id: str) -> PropertyGraphEdge | None:
+        return self._edges.get(edge_id)
+
+    def neighbors(
+        self, node_id: str, *, direction: Literal["both", "out", "in"] = "both"
+    ) -> list[str]:
+        if direction not in {"both", "out", "in"}:
+            raise ValueError("direction must be 'both', 'out', or 'in'")
+        if self.uses_networkx:
+            out = set(self._graph.successors(node_id)) if direction in {"both", "out"} else set()
+            inc = set(self._graph.predecessors(node_id)) if direction in {"both", "in"} else set()
+            return sorted(out | inc)
+        out = self._graph.outgoing.get(node_id, set()) if direction in {"both", "out"} else set()
+        inc = self._graph.incoming.get(node_id, set()) if direction in {"both", "in"} else set()
+        return sorted(out | inc)
+
+    def traverse(
+        self,
+        seed_ids: list[str],
+        *,
+        max_hops: int = 2,
+        min_confidence: float = 0.0,
+    ) -> tuple[list[PropertyGraphNode], list[PropertyGraphEdge]]:
+        if max_hops < 0:
+            raise ValueError("max_hops must be non-negative")
+        queue: deque[tuple[str, int]] = deque((seed, 0) for seed in seed_ids if seed in self._nodes)
+        visited: set[str] = set()
+        selected_edges: dict[str, PropertyGraphEdge] = {}
+
+        while queue:
+            node_id, depth = queue.popleft()
+            if node_id in visited:
+                continue
+            visited.add(node_id)
+            if depth >= max_hops:
+                continue
+            for edge in self._incident_edges(node_id):
+                confidence = float(edge.properties.get("confidence", 1.0))
+                if confidence < min_confidence:
+                    continue
+                selected_edges[edge.id] = edge
+                other = edge.target if edge.source == node_id else edge.source
+                if other not in visited:
+                    queue.append((other, depth + 1))
+
+        nodes = [self._nodes[node_id] for node_id in sorted(visited)]
+        edges = [selected_edges[edge_id] for edge_id in sorted(selected_edges)]
+        return nodes, edges
+
+    def document_ids_for_nodes(self, node_ids: list[str]) -> list[str]:
+        docs: set[str] = set()
+        for node_id in node_ids:
+            docs.update(self._documents_by_node.get(node_id, set()))
+        return sorted(docs)
+
+    def nodes(self) -> list[PropertyGraphNode]:
+        return list(self._nodes.values())
+
+    def edges(self) -> list[PropertyGraphEdge]:
+        return list(self._edges.values())
+
+    def node_id_for_label(self, label: str) -> str | None:
+        return self._label_to_id.get(_normalize(label))
+
+    def seed_ids_for_text(self, text: str) -> list[str]:
+        normalized = _normalize(text)
+        seeds = [
+            node_id for label, node_id in self._label_to_id.items() if label and label in normalized
+        ]
+        if seeds:
+            return list(dict.fromkeys(seeds))
+        terms = set(normalized.split())
+        scored: list[tuple[int, str]] = []
+        for node in self._nodes.values():
+            score = len(terms & set(_normalize(node.label).split()))
+            if score:
+                scored.append((score, node.id))
+        return [node_id for _, node_id in sorted(scored, reverse=True)[:5]]
+
+    def _incident_edges(self, node_id: str) -> list[PropertyGraphEdge]:
+        return [
+            edge
+            for edge in self._edges.values()
+            if edge.source == node_id or edge.target == node_id
+        ]
+
+
+class Neo4jPropertyGraphBackend:
+    """Neo4j property graph adapter with lazy optional dependency loading."""
+
+    def __init__(
+        self,
+        uri: str,
+        *,
+        username: str = "neo4j",
+        password: str = "password",
+        database: str | None = None,
+    ) -> None:
+        try:
+            from neo4j import GraphDatabase  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise ImportError(
+                "Neo4jPropertyGraphBackend requires the 'neo4j' package. "
+                "Install SynapseKit with the graph extra."
+            ) from exc
+        self._driver = GraphDatabase.driver(uri, auth=(username, password))
+        self._database = database
+
+    def upsert_node(self, node: PropertyGraphNode) -> None:
+        with self._driver.session(database=self._database) as session:
+            session.run(
+                """
+                MERGE (n:PropertyGraphNode {id: $id})
+                SET n.label = $label, n.type = $type, n += $properties
+                """,
+                id=node.id,
+                label=node.label,
+                type=node.type,
+                properties=node.properties,
+            )
+
+    def upsert_edge(self, edge: PropertyGraphEdge) -> None:
+        with self._driver.session(database=self._database) as session:
+            session.run(
+                """
+                MERGE (a:PropertyGraphNode {id: $source})
+                MERGE (b:PropertyGraphNode {id: $target})
+                MERGE (a)-[r:RELATED {id: $id}]->(b)
+                SET r.relation = $relation, r += $properties
+                """,
+                source=edge.source,
+                target=edge.target,
+                id=edge.id,
+                relation=edge.relation,
+                properties=edge.properties,
+            )
+
+    def get_node(self, node_id: str) -> PropertyGraphNode | None:
+        with self._driver.session(database=self._database) as session:
+            row = session.run(
+                "MATCH (n:PropertyGraphNode {id: $id}) RETURN n",
+                id=node_id,
+            ).single()
+        if row is None:
+            return None
+        data = dict(row["n"])
+        return PropertyGraphNode(
+            id=str(data.pop("id")),
+            label=str(data.pop("label", node_id)),
+            type=str(data.pop("type", "entity")),
+            properties=data,
+        )
+
+    def get_edge(self, edge_id: str) -> PropertyGraphEdge | None:
+        with self._driver.session(database=self._database) as session:
+            row = session.run(
+                """
+                MATCH (a)-[r:RELATED {id: $id}]->(b)
+                RETURN a.id AS source, b.id AS target, r AS rel
+                """,
+                id=edge_id,
+            ).single()
+        if row is None:
+            return None
+        data = dict(row["rel"])
+        return PropertyGraphEdge(
+            source=str(row["source"]),
+            target=str(row["target"]),
+            relation=str(data.pop("relation", "related_to")),
+            properties=data,
+        )
+
+    def neighbors(
+        self, node_id: str, *, direction: Literal["both", "out", "in"] = "both"
+    ) -> list[str]:
+        if direction not in {"both", "out", "in"}:
+            raise ValueError("direction must be 'both', 'out', or 'in'")
+        pattern = {
+            "both": "-[:RELATED]-",
+            "out": "-[:RELATED]->",
+            "in": "<-[:RELATED]-",
+        }[direction]
+        with self._driver.session(database=self._database) as session:
+            rows = session.run(
+                f"MATCH (:PropertyGraphNode {{id: $id}}){pattern}(n) RETURN DISTINCT n.id AS id",
+                id=node_id,
+            )
+            return sorted(str(row["id"]) for row in rows)
+
+    def traverse(
+        self,
+        seed_ids: list[str],
+        *,
+        max_hops: int = 2,
+        min_confidence: float = 0.0,
+    ) -> tuple[list[PropertyGraphNode], list[PropertyGraphEdge]]:
+        memory = NetworkXPropertyGraphBackend()
+        with self._driver.session(database=self._database) as session:
+            rows = session.run(
+                """
+                MATCH path=(n:PropertyGraphNode)-[r:RELATED*0..$hops]-(m:PropertyGraphNode)
+                WHERE n.id IN $ids
+                UNWIND nodes(path) AS node
+                RETURN DISTINCT node
+                """,
+                ids=seed_ids,
+                hops=max_hops,
+            )
+            for row in rows:
+                data = dict(row["node"])
+                node_id = str(data.pop("id"))
+                memory.upsert_node(
+                    PropertyGraphNode(
+                        id=node_id,
+                        label=str(data.pop("label", node_id)),
+                        type=str(data.pop("type", "entity")),
+                        properties=data,
+                    )
+                )
+            edge_rows = session.run(
+                """
+                MATCH path=(n:PropertyGraphNode)-[r:RELATED*1..$hops]-(m:PropertyGraphNode)
+                WHERE n.id IN $ids
+                UNWIND relationships(path) AS rel
+                WITH DISTINCT rel
+                WHERE coalesce(rel.confidence, 1.0) >= $min_confidence
+                RETURN startNode(rel).id AS source, endNode(rel).id AS target, rel
+                """,
+                ids=seed_ids,
+                hops=max_hops,
+                min_confidence=min_confidence,
+            )
+            for row in edge_rows:
+                data = dict(row["rel"])
+                memory.upsert_edge(
+                    PropertyGraphEdge(
+                        source=str(row["source"]),
+                        target=str(row["target"]),
+                        relation=str(data.pop("relation", "related_to")),
+                        properties=data,
+                    )
+                )
+        return memory.nodes(), memory.edges()
+
+    def document_ids_for_nodes(self, node_ids: list[str]) -> list[str]:
+        with self._driver.session(database=self._database) as session:
+            rows = session.run(
+                """
+                MATCH (n:PropertyGraphNode)
+                WHERE n.id IN $ids AND n.source_doc IS NOT NULL
+                RETURN DISTINCT n.source_doc AS doc
+                """,
+                ids=node_ids,
+            )
+            return sorted(str(row["doc"]) for row in rows)
+
+    def nodes(self) -> list[PropertyGraphNode]:
+        with self._driver.session(database=self._database) as session:
+            rows = session.run("MATCH (n:PropertyGraphNode) RETURN n")
+            out: list[PropertyGraphNode] = []
+            for row in rows:
+                data = dict(row["n"])
+                node_id = str(data.pop("id"))
+                out.append(
+                    PropertyGraphNode(
+                        id=node_id,
+                        label=str(data.pop("label", node_id)),
+                        type=str(data.pop("type", "entity")),
+                        properties=data,
+                    )
+                )
+            return out
+
+    def edges(self) -> list[PropertyGraphEdge]:
+        with self._driver.session(database=self._database) as session:
+            rows = session.run(
+                "MATCH (a)-[r:RELATED]->(b) RETURN a.id AS source, b.id AS target, r"
+            )
+            out: list[PropertyGraphEdge] = []
+            for row in rows:
+                data = dict(row["r"])
+                out.append(
+                    PropertyGraphEdge(
+                        source=str(row["source"]),
+                        target=str(row["target"]),
+                        relation=str(data.pop("relation", "related_to")),
+                        properties=data,
+                    )
+                )
+            return out
+
+    def close(self) -> None:
+        self._driver.close()
+
+
+class KnowledgeGraphExtractor:
+    """Extract entities and relationships into a property graph."""
+
+    _PROMPT = """\
+Extract a property graph from the text.
+Return strict JSON with keys "entities" and "relationships".
+Entity: {"name": str, "type": str, "confidence": float, "properties": object}
+Relationship: {"source": str, "target": str, "relation": str, "confidence": float, "properties": object}
+
+Text:
+{text}
+"""
+
+    def __init__(
+        self,
+        llm: BaseLLM | None = None,
+        store: PropertyGraphBackend | None = None,
+        *,
+        min_confidence: float = 0.5,
+    ) -> None:
+        self.llm = llm
+        self.store = store
+        self.min_confidence = min_confidence
+
+    async def extract(self, text: str) -> KnowledgeGraphExtraction:
+        if self.llm is None:
+            return self._heuristic_extract(text)
+        response = await self.llm.generate(self._PROMPT.format(text=text))
+        return self._parse_json(response)
+
+    async def ingest(
+        self,
+        documents: list[str] | list[dict[str, Any]],
+        *,
+        store: PropertyGraphBackend | None = None,
+    ) -> list[KnowledgeGraphExtraction]:
+        target = store or self.store
+        if target is None:
+            raise ValueError("A property graph store is required for ingest().")
+        outputs: list[KnowledgeGraphExtraction] = []
+        for index, document in enumerate(documents):
+            text, metadata = _coerce_document(document)
+            source_doc = str(metadata.get("source") or metadata.get("id") or f"doc_{index + 1}")
+            extraction = await self.extract(text)
+            _store_extraction(target, extraction, source_doc=source_doc)
+            outputs.append(extraction)
+        return outputs
+
+    def _heuristic_extract(self, text: str) -> KnowledgeGraphExtraction:
+        entities: list[ExtractedEntity] = []
+        seen: set[str] = set()
+        for match in _ENTITY_RE.finditer(text):
+            name = match.group(0).strip(" .,;:()[]")
+            if name in {"A", "An", "And", "In", "The", "This", "Who", "What"}:
+                continue
+            key = name.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            entities.append(
+                ExtractedEntity(
+                    name=name,
+                    type=_guess_entity_type(name),
+                    confidence=0.72,
+                )
+            )
+        relationships: list[ExtractedRelationship] = []
+        names = [entity.name for entity in entities]
+        for sentence in re.split(r"(?<=[.!?])\s+", text):
+            present = [name for name in names if name in sentence]
+            if len(present) < 2:
+                continue
+            relation = _relation_for_sentence(sentence)
+            for left, right in pairwise(present):
+                relationships.append(
+                    ExtractedRelationship(
+                        source=left,
+                        target=right,
+                        relation=relation,
+                        confidence=0.7,
+                    )
+                )
+        return KnowledgeGraphExtraction(
+            entities=[entity for entity in entities if entity.confidence >= self.min_confidence],
+            relationships=[rel for rel in relationships if rel.confidence >= self.min_confidence],
+        )
+
+    def _parse_json(self, response: str) -> KnowledgeGraphExtraction:
+        cleaned = response.strip()
+        if cleaned.startswith("```json"):
+            cleaned = cleaned[7:]
+        if cleaned.startswith("```"):
+            cleaned = cleaned[3:]
+        if cleaned.endswith("```"):
+            cleaned = cleaned[:-3]
+        try:
+            payload = json.loads(cleaned.strip())
+        except json.JSONDecodeError:
+            return KnowledgeGraphExtraction()
+        if not isinstance(payload, dict):
+            return KnowledgeGraphExtraction()
+        return KnowledgeGraphExtraction(
+            entities=self._parse_entities(payload.get("entities")),
+            relationships=self._parse_relationships(payload.get("relationships")),
+        )
+
+    def _parse_entities(self, rows: Any) -> list[ExtractedEntity]:
+        if not isinstance(rows, list):
+            return []
+        entities: list[ExtractedEntity] = []
+        for row in rows:
+            if not isinstance(row, dict) or not row.get("name"):
+                continue
+            confidence = _float(row.get("confidence"), default=1.0)
+            if confidence < self.min_confidence:
+                continue
+            properties = row.get("properties")
+            entities.append(
+                ExtractedEntity(
+                    name=str(row["name"]),
+                    type=str(row.get("type", "entity")),
+                    confidence=confidence,
+                    properties=dict(properties) if isinstance(properties, dict) else {},
+                )
+            )
+        return entities
+
+    def _parse_relationships(self, rows: Any) -> list[ExtractedRelationship]:
+        if not isinstance(rows, list):
+            return []
+        relationships: list[ExtractedRelationship] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            source = row.get("source")
+            target = row.get("target")
+            if not source or not target:
+                continue
+            confidence = _float(row.get("confidence"), default=1.0)
+            if confidence < self.min_confidence:
+                continue
+            properties = row.get("properties")
+            relationships.append(
+                ExtractedRelationship(
+                    source=str(source),
+                    target=str(target),
+                    relation=str(row.get("relation", "related_to")),
+                    confidence=confidence,
+                    properties=dict(properties) if isinstance(properties, dict) else {},
+                )
+            )
+        return relationships
+
+
+class GraphVectorStore(VectorStore):
+    """Drop-in vector store that expands vector hits through a property graph."""
+
+    def __init__(
+        self,
+        embedding_backend: SynapsekitEmbeddings | None = None,
+        *,
+        vector_store: VectorStore | None = None,
+        backend: PropertyGraphBackendName | PropertyGraphBackend = "networkx",
+        extractor: KnowledgeGraphExtractor | None = None,
+        max_hops: int = 2,
+        min_confidence: float = 0.0,
+        graph_weight: float = 0.25,
+        uri: str | None = None,
+        username: str = "neo4j",
+        password: str = "password",
+    ) -> None:
+        if vector_store is None:
+            if embedding_backend is None:
+                raise ValueError("embedding_backend is required when vector_store is not provided")
+            vector_store = InMemoryVectorStore(embedding_backend)
+        self.vector_store = vector_store
+        self.graph = self._make_backend(backend, uri=uri, username=username, password=password)
+        self.extractor = extractor or KnowledgeGraphExtractor(store=self.graph)
+        self.max_hops = max_hops
+        self.min_confidence = min_confidence
+        self.graph_weight = graph_weight
+        self._doc_text_by_id: dict[str, str] = {}
+        self._doc_metadata_by_id: dict[str, dict[str, Any]] = {}
+
+    async def add(
+        self,
+        texts: list[str],
+        metadata: list[dict] | None = None,
+    ) -> None:
+        if not texts:
+            return
+        meta = metadata if metadata is not None else [{} for _ in texts]
+        if len(meta) != len(texts):
+            raise ValueError("metadata length must match texts length")
+        enriched: list[dict[str, Any]] = []
+        for index, (text, item_meta) in enumerate(zip(texts, meta, strict=True)):
+            source_doc = str(
+                item_meta.get("source")
+                or item_meta.get("id")
+                or f"doc_{len(self._doc_text_by_id) + index + 1}"
+            )
+            doc_meta = {**item_meta, "source": source_doc}
+            self._doc_text_by_id[source_doc] = text
+            self._doc_metadata_by_id[source_doc] = doc_meta
+            extraction = await self.extractor.extract(text)
+            _store_extraction(self.graph, extraction, source_doc=source_doc)
+            enriched.append(doc_meta)
+        await self.vector_store.add(texts, enriched)
+
+    async def search(
+        self,
+        query: str,
+        top_k: int = 5,
+        metadata_filter: dict | None = None,
+    ) -> list[dict]:
+        if top_k <= 0:
+            return []
+        vector_results = await self.vector_store.search(
+            query,
+            top_k=top_k,
+            metadata_filter=metadata_filter,
+        )
+        seed_ids = self._seed_ids(query, vector_results)
+        if not seed_ids:
+            return cast(list[dict], vector_results[:top_k])
+
+        nodes, edges = self.graph.traverse(
+            seed_ids,
+            max_hops=self.max_hops,
+            min_confidence=self.min_confidence,
+        )
+        graph_doc_ids = self.graph.document_ids_for_nodes([node.id for node in nodes])
+        return self._fuse(vector_results, graph_doc_ids, nodes, edges, top_k, metadata_filter)
+
+    async def search_mmr(
+        self,
+        query: str,
+        top_k: int = 5,
+        lambda_mult: float = 0.5,
+        fetch_k: int = 20,
+        metadata_filter: dict | None = None,
+    ) -> list[dict]:
+        results = await self.vector_store.search_mmr(
+            query,
+            top_k=top_k,
+            lambda_mult=lambda_mult,
+            fetch_k=fetch_k,
+            metadata_filter=metadata_filter,
+        )
+        return cast(list[dict], results)
+
+    def save(self, path: str) -> None:
+        self.vector_store.save(path)
+
+    def load(self, path: str) -> None:
+        self.vector_store.load(path)
+
+    def __len__(self) -> int:
+        length = getattr(self.vector_store, "__len__", None)
+        return int(length()) if callable(length) else len(self._doc_text_by_id)
+
+    @staticmethod
+    def _make_backend(
+        backend: PropertyGraphBackendName | PropertyGraphBackend,
+        *,
+        uri: str | None,
+        username: str,
+        password: str,
+    ) -> PropertyGraphBackend:
+        if not isinstance(backend, str):
+            return backend
+        if backend == "networkx":
+            return NetworkXPropertyGraphBackend()
+        if backend == "neo4j":
+            if uri is None:
+                raise ValueError("uri is required when backend='neo4j'")
+            return Neo4jPropertyGraphBackend(uri, username=username, password=password)
+        raise ValueError(f"Unknown graph backend: {backend!r}")
+
+    def _seed_ids(self, query: str, vector_results: list[dict]) -> list[str]:
+        seed_ids: list[str] = []
+        seed_for_text = getattr(self.graph, "seed_ids_for_text", None)
+        if callable(seed_for_text):
+            seed_ids.extend(seed_for_text(query))
+        for result in vector_results:
+            source = (result.get("metadata") or {}).get("source")
+            if source is None:
+                continue
+            for node in self.graph.nodes():
+                if str(node.properties.get("source_doc")) == str(source):
+                    seed_ids.append(node.id)
+        return list(dict.fromkeys(seed_ids))
+
+    def _fuse(
+        self,
+        vector_results: list[dict],
+        graph_doc_ids: list[str],
+        nodes: list[PropertyGraphNode],
+        edges: list[PropertyGraphEdge],
+        top_k: int,
+        metadata_filter: dict | None,
+    ) -> list[dict]:
+        by_text: dict[str, dict[str, Any]] = {}
+        for rank, result in enumerate(vector_results, start=1):
+            item = dict(result)
+            metadata = dict(item.get("metadata") or {})
+            metadata.setdefault("retrieval_source", "vector")
+            item["metadata"] = metadata
+            item["score"] = float(item.get("score", 0.0)) + 1.0 / (100 + rank)
+            by_text[str(item.get("text", ""))] = item
+
+        for rank, doc_id in enumerate(graph_doc_ids, start=1):
+            metadata = self._doc_metadata_by_id.get(doc_id, {"source": doc_id})
+            if metadata_filter and any(metadata.get(k) != v for k, v in metadata_filter.items()):
+                continue
+            text = self._doc_text_by_id.get(doc_id)
+            if not text:
+                continue
+            current = by_text.get(text, {"text": text, "score": 0.0, "metadata": dict(metadata)})
+            current["score"] = float(current.get("score", 0.0)) + self.graph_weight / rank
+            merged_meta = dict(current.get("metadata") or {})
+            merged_meta.update(
+                {
+                    "retrieval_source": "graph_vector",
+                    "graph_nodes": [node.label for node in nodes],
+                    "graph_edges": [edge.relation for edge in edges],
+                }
+            )
+            current["metadata"] = merged_meta
+            by_text[text] = current
+
+        return sorted(by_text.values(), key=lambda item: item["score"], reverse=True)[:top_k]
+
+
+def _store_extraction(
+    graph: PropertyGraphBackend,
+    extraction: KnowledgeGraphExtraction,
+    *,
+    source_doc: str,
+) -> None:
+    extracted_at = datetime.now(UTC).isoformat()
+    for entity in extraction.entities:
+        node_id = _node_id(entity.name)
+        graph.upsert_node(
+            PropertyGraphNode(
+                id=node_id,
+                label=entity.name,
+                type=entity.type,
+                properties={
+                    **entity.properties,
+                    "confidence": entity.confidence,
+                    "source_doc": source_doc,
+                    "extracted_at": extracted_at,
+                },
+            )
+        )
+    for relationship in extraction.relationships:
+        graph.upsert_edge(
+            PropertyGraphEdge(
+                source=_node_id(relationship.source),
+                target=_node_id(relationship.target),
+                relation=relationship.relation,
+                properties={
+                    **relationship.properties,
+                    "confidence": relationship.confidence,
+                    "source_doc": source_doc,
+                    "extracted_at": extracted_at,
+                },
+            )
+        )
+
+
+def _coerce_document(document: Any) -> tuple[str, dict[str, Any]]:
+    if isinstance(document, str):
+        return document, {}
+    if isinstance(document, dict):
+        return str(document.get("text", "")), dict(document.get("metadata", {}))
+    return str(document), {}
+
+
+def _node_id(name: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "_", name.casefold()).strip("_")
+    return f"pg_{slug or 'node'}"
+
+
+def _normalize(value: str) -> str:
+    value = re.sub(r"^@", "", value.casefold().strip())
+    value = re.sub(r"[^a-z0-9]+", " ", value)
+    return " ".join(value.split())
+
+
+def _guess_entity_type(name: str) -> str:
+    lowered = name.casefold()
+    if lowered.startswith("@"):
+        return "person"
+    if any(token in lowered for token in (" inc", " corp", " labs", " llc", " ltd")):
+        return "org"
+    return "entity"
+
+
+def _relation_for_sentence(sentence: str) -> str:
+    lowered = sentence.casefold()
+    for hint, relation in _RELATION_HINTS:
+        if hint in lowered:
+            return relation
+    return "related_to"
+
+
+def _float(value: Any, *, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default

--- a/src/synapsekit/retrieval/property_graph.py
+++ b/src/synapsekit/retrieval/property_graph.py
@@ -8,7 +8,7 @@ from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from itertools import pairwise
-from typing import Any, Literal, Protocol, cast
+from typing import Any, Literal, Protocol
 
 from ..embeddings.backend import SynapsekitEmbeddings
 from ..llm.base import BaseLLM
@@ -709,7 +709,7 @@ class GraphVectorStore(VectorStore):
         )
         seed_ids = self._seed_ids(query, vector_results)
         if not seed_ids:
-            return cast(list[dict], vector_results[:top_k])
+            return vector_results[:top_k]
 
         nodes, edges = self.graph.traverse(
             seed_ids,
@@ -734,7 +734,7 @@ class GraphVectorStore(VectorStore):
             fetch_k=fetch_k,
             metadata_filter=metadata_filter,
         )
-        return cast(list[dict], results)
+        return results
 
     def save(self, path: str) -> None:
         self.vector_store.save(path)

--- a/src/synapsekit/symbolic/extractor.py
+++ b/src/synapsekit/symbolic/extractor.py
@@ -100,7 +100,9 @@ def _loads_json_object(text: str) -> dict[str, Any]:
         try:
             data = json.loads(match.group(0))
         except json.JSONDecodeError as exc2:
-            raise VerificationFailure("Constraint extractor returned malformed embedded JSON.") from exc2
+            raise VerificationFailure(
+                "Constraint extractor returned malformed embedded JSON."
+            ) from exc2
 
     if not isinstance(data, dict):
         raise VerificationFailure("Constraint extractor JSON must be an object.")

--- a/tests/agents/test_agent_swarm_market.py
+++ b/tests/agents/test_agent_swarm_market.py
@@ -2,7 +2,15 @@ import inspect
 
 import pytest
 
-from synapsekit import AgentSwarm, AuctionResult, AuctionType, Bid, BidStrategy, MarketPolicy, SwarmResult
+from synapsekit import (
+    AgentSwarm,
+    AuctionResult,
+    AuctionType,
+    Bid,
+    BidStrategy,
+    MarketPolicy,
+    SwarmResult,
+)
 from synapsekit.agents import AgentFederation, AgentMetadata, InMemoryAgentRegistry, Reputation
 from synapsekit.agents.agent_swarm import CoalitionFormer
 
@@ -233,9 +241,7 @@ async def test_synthetic_bids_use_reputation_when_agent_has_no_bidder():
         reputation=reputation,
     )
 
-    auction = await swarm.auction(
-        "Review code", swarm.federation.discover(), task_category="code"
-    )
+    auction = await swarm.auction("Review code", swarm.federation.discover(), task_category="code")
 
     assert isinstance(auction, AuctionResult)
     assert auction.bids[0].estimated_quality == 0.9

--- a/tests/cli/test_memory_cli.py
+++ b/tests/cli/test_memory_cli.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from synapsekit.memory import MemoryPatch, PatchStore
+from synapsekit.cli.memory import run_memory
+
+
+def test_memory_cli_review_empty(tmp_path, capsys) -> None:
+    store_path = tmp_path / "patches.jsonl"
+    args = argparse.Namespace(
+        memory_command="review",
+        patch_id=None,
+        store_path=str(store_path),
+    )
+    run_memory(args)
+    captured = capsys.readouterr()
+    assert "No pending memory patches to review." in captured.out
+
+
+def test_memory_cli_review_list(tmp_path, capsys) -> None:
+    store_path = tmp_path / "patches.jsonl"
+    store = PatchStore(store_path)
+    patch = MemoryPatch(
+        file_path="CLAUDE.md",
+        before_content="A",
+        after_content="B",
+        unified_diff="diff",
+        rationale="Update test",
+    )
+    store.save(patch)
+
+    args = argparse.Namespace(
+        memory_command="review",
+        patch_id=None,
+        store_path=str(store_path),
+    )
+    run_memory(args)
+    captured = capsys.readouterr()
+    assert patch.patch_id in captured.out
+    assert "Update test" in captured.out
+
+
+def test_memory_cli_review_detail(tmp_path, capsys) -> None:
+    store_path = tmp_path / "patches.jsonl"
+    store = PatchStore(store_path)
+    patch = MemoryPatch(
+        file_path="CLAUDE.md",
+        before_content="A",
+        after_content="B",
+        unified_diff="diff content",
+        rationale="Specific patch description",
+    )
+    store.save(patch)
+
+    args = argparse.Namespace(
+        memory_command="review",
+        patch_id=patch.patch_id,
+        store_path=str(store_path),
+    )
+    run_memory(args)
+    captured = capsys.readouterr()
+    assert f"Patch ID:     {patch.patch_id}" in captured.out
+    assert "Specific patch description" in captured.out
+    assert "diff content" in captured.out
+
+
+def test_memory_cli_apply_success(tmp_path, capsys) -> None:
+    store_path = tmp_path / "patches.jsonl"
+    target_file = tmp_path / "CLAUDE.md"
+    target_file.write_text("Hello\n", encoding="utf-8")
+
+    store = PatchStore(store_path)
+    patch = MemoryPatch(
+        file_path=str(target_file),
+        before_content="Hello\n",
+        after_content="Hello World\n",
+        unified_diff="...",
+        rationale="test apply",
+    )
+    store.save(patch)
+
+    args = argparse.Namespace(
+        memory_command="apply",
+        patch_id=patch.patch_id,
+        store_path=str(store_path),
+    )
+    run_memory(args)
+    captured = capsys.readouterr()
+    assert f"Applied patch {patch.patch_id}" in captured.out
+    assert target_file.read_text(encoding="utf-8") == "Hello World\n"
+
+
+def test_memory_cli_revert_success(tmp_path, capsys) -> None:
+    store_path = tmp_path / "patches.jsonl"
+    target_file = tmp_path / "CLAUDE.md"
+    target_file.write_text("Hello World\n", encoding="utf-8")
+
+    store = PatchStore(store_path)
+    patch = MemoryPatch(
+        file_path=str(target_file),
+        before_content="Hello\n",
+        after_content="Hello World\n",
+        unified_diff="...",
+        rationale="test revert",
+        status="applied",
+    )
+    store.save(patch)
+
+    args = argparse.Namespace(
+        memory_command="revert",
+        patch_id=patch.patch_id,
+        store_path=str(store_path),
+    )
+    run_memory(args)
+    captured = capsys.readouterr()
+    assert f"Reverted patch {patch.patch_id}" in captured.out
+    assert target_file.read_text(encoding="utf-8") == "Hello\n"
+
+
+def test_memory_cli_log_table(tmp_path, capsys) -> None:
+    store_path = tmp_path / "patches.jsonl"
+    store = PatchStore(store_path)
+    patch = MemoryPatch(
+        file_path="CLAUDE.md",
+        before_content="A",
+        after_content="B",
+        unified_diff="diff",
+        rationale="History rationale",
+        status="reverted",
+    )
+    store.save(patch)
+
+    args = argparse.Namespace(
+        memory_command="log",
+        status=None,
+        limit=20,
+        output_format="table",
+        store_path=str(store_path),
+    )
+    run_memory(args)
+    captured = capsys.readouterr()
+    assert "History rationale" in captured.out
+    assert "reverted" in captured.out

--- a/tests/llm/test_mlx.py
+++ b/tests/llm/test_mlx.py
@@ -26,11 +26,9 @@ class FakeMLXModule:
         return object(), object()
 
     def generate(self, model, tokenizer, *, prompt: str, max_tokens: int, temp: float) -> str:
-        return f"hello"
+        return "hello"
 
-    def stream_generate(
-        self, model, tokenizer, *, prompt: str, max_tokens: int, temp: float
-    ):
+    def stream_generate(self, model, tokenizer, *, prompt: str, max_tokens: int, temp: float):
         yield _FakeTokenItem("hello ")
         yield _FakeTokenItem("world")
 
@@ -66,7 +64,7 @@ def test_missing_mlx_lm_raises() -> None:
 @pytest.mark.asyncio
 async def test_generate_uses_mlx_backend() -> None:
     original = sys.modules.get("mlx_lm")
-    fake = _inject_fake_mlx()
+    _inject_fake_mlx()
     try:
         result = await make_llm().generate("hi")
     finally:

--- a/tests/memory/test_graph_memory_backend.py
+++ b/tests/memory/test_graph_memory_backend.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from synapsekit.memory import AgentMemory, GraphMemoryBackend
+from synapsekit.retrieval.property_graph import NetworkXPropertyGraphBackend
+
+
+@pytest.mark.asyncio
+async def test_agent_memory_graph_backend_matches_core_interface() -> None:
+    graph = NetworkXPropertyGraphBackend()
+    memory = AgentMemory(backend="graph", store=graph, max_episodes=50)
+
+    first = await memory.store(
+        agent_id="agent-a",
+        content="User prefers graph-aware RAG",
+        memory_type="semantic",
+    )
+    second = await memory.store(
+        agent_id="agent-a",
+        content="Apollo depends on Platform Team",
+        memory_type="episodic",
+        metadata={
+            "related_to": [first.id],
+            "relation_type": "supports",
+            "weight": 0.8,
+        },
+    )
+
+    recalled = await memory.recall(agent_id="agent-a", query="graph RAG", top_k=1)
+
+    assert recalled[0].id == first.id
+    assert await memory.count(agent_id="agent-a") == 2
+    assert graph.get_node(f"memory:agent-a:{first.id}") is not None
+    edge = graph.get_edge(f"memory:agent-a:{second.id}:supports:memory:agent-a:{first.id}")
+    assert edge is not None
+    assert edge.properties["relation_type"] == "supports"
+    assert edge.properties["weight"] == 0.8
+
+
+@pytest.mark.asyncio
+async def test_graph_memory_backend_delete_clear_and_prune() -> None:
+    backend = GraphMemoryBackend()
+    memory = AgentMemory(backend=backend)
+
+    expired = await memory.store(
+        agent_id="agent-a",
+        content="temporary",
+        memory_type="episodic",
+        ttl_days=0,
+    )
+    kept = await memory.store(
+        agent_id="agent-a",
+        content="stable",
+        memory_type="semantic",
+    )
+
+    assert await backend.prune_expired() == 1
+    assert await memory.count(agent_id="agent-a") == 1
+    assert await memory.delete(agent_id="agent-a", record_id=expired.id) is False
+    assert await memory.count(agent_id="agent-a") == 1
+    assert await memory.clear(agent_id="agent-a", memory_type="semantic") == 1
+    assert await memory.delete(agent_id="agent-a", record_id=kept.id) is False

--- a/tests/memory/test_living_memory.py
+++ b/tests/memory/test_living_memory.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import pytest
+
+from synapsekit.memory import (
+    LivingMemory,
+    MemoryPatch,
+    OccurrenceTracker,
+    PatchStore,
+    MemoryPIIFilter,
+    MemoryFileRouter,
+    FileDiffEngine,
+)
+
+
+class MockLLM:
+    """Mock LLM that returns a pre-configured response."""
+
+    def __init__(self, response_text: str) -> None:
+        self.response_text = response_text
+        self.calls: list[str] = []
+
+    async def agenerate(self, prompt: str) -> str:
+        self.calls.append(prompt)
+        return self.response_text
+
+    def generate(self, prompt: str) -> str:
+        self.calls.append(prompt)
+        return self.response_text
+
+
+def test_memory_patch_sign_verify() -> None:
+    patch = MemoryPatch(
+        file_path="CLAUDE.md",
+        before_content="Hello",
+        after_content="Hello World",
+        unified_diff="--- \n+++ \n@@ -1 +1 @@\n-Hello\n+Hello World\n",
+        rationale="Add World",
+    )
+    secret = "test-secret"
+    sig = patch.sign(secret)
+    assert sig != ""
+    assert patch.signature == sig
+    assert patch.verify(secret) is True
+    assert patch.verify("wrong-secret") is False
+
+    # Modify content and verify it fails
+    patch.after_content = "Hello Modified"
+    assert patch.verify(secret) is False
+
+
+def test_diff_engine_unified_diff() -> None:
+    before = "line1\nline2\n"
+    after = "line1\nline2 changed\n"
+    diff = FileDiffEngine.generate_unified_diff(before, after, "test.txt")
+    assert "line2" in diff
+    assert "line2 changed" in diff
+
+    stats = FileDiffEngine.count_changed_lines(diff)
+    assert stats["added"] == 1
+    assert stats["removed"] == 1
+
+
+def test_diff_engine_validation(tmp_path: Path) -> None:
+    file_path = tmp_path / "test.md"
+    content = "Hello World\n"
+    file_path.write_text(content, encoding="utf-8")
+
+    # Content matches exactly
+    ok, reason = FileDiffEngine.validate_patch_applicable(file_path, content)
+    assert ok is True
+
+    # Content matches with trailing whitespace diff
+    ok, reason = FileDiffEngine.validate_patch_applicable(file_path, "Hello World \n")
+    assert ok is True
+
+    # Content diverged
+    ok, reason = FileDiffEngine.validate_patch_applicable(file_path, "Diverged content")
+    assert ok is False
+
+
+def test_patch_store(tmp_path: Path) -> None:
+    store_file = tmp_path / "patches.jsonl"
+    store = PatchStore(store_file)
+
+    patch = MemoryPatch(
+        file_path="CLAUDE.md",
+        before_content="A",
+        after_content="B",
+        unified_diff="...",
+        rationale="Change A to B",
+    )
+    store.save(patch)
+
+    # Reload store
+    store2 = PatchStore(store_file)
+    retrieved = store2.get(patch.patch_id)
+    assert retrieved is not None
+    assert retrieved.rationale == "Change A to B"
+    assert retrieved.status == "pending"
+
+    # Update status
+    retrieved.status = "applied"
+    store2.update(retrieved)
+
+    # Check update persisted
+    store3 = PatchStore(store_file)
+    retrieved2 = store3.get(patch.patch_id)
+    assert retrieved2 is not None
+    assert retrieved2.status == "applied"
+
+
+def test_occurrence_tracker(tmp_path: Path) -> None:
+    tracker_file = tmp_path / "occurrences.json"
+    tracker = OccurrenceTracker(tracker_file)
+
+    fact = "user_prefers_concise_answers"
+    tracker.record_occurrence(fact, "session_1", "evidence 1")
+    assert tracker.has_reached_threshold(fact, 3) is False
+
+    tracker.record_occurrence(fact, "session_2", "evidence 2")
+    tracker.record_occurrence(fact, "session_3", "evidence 3")
+    assert tracker.has_reached_threshold(fact, 3) is True
+
+    # Reload tracker
+    tracker2 = OccurrenceTracker(tracker_file)
+    assert tracker2.has_reached_threshold(fact, 3) is True
+    assert tracker2.get_count(fact) == 3
+
+
+def test_pii_filter() -> None:
+    pii_filter = MemoryPIIFilter()
+
+    # Clean text
+    res = pii_filter.filter_content("Nothing sensitive here.")
+    assert res.is_clean is True
+
+    # Text containing email and credit card
+    res2 = pii_filter.filter_content("Email me at test@example.com or use card 1234-5678-1234-5678")
+    assert res2.is_clean is False
+    assert "[REDACTED_EMAIL]" in res2.filtered_content
+    assert "[REDACTED_CC]" in res2.filtered_content
+    assert "email" in res2.redaction_types
+    assert "credit_card" in res2.redaction_types
+
+
+def test_file_router() -> None:
+    router = MemoryFileRouter(
+        path_map={"user": "user_prefs.md", "feedback": "feedback.md"},
+        primary_path="CLAUDE.md",
+    )
+
+    # Categorization based on signals
+    assert router.categorize("The user prefers tabs over spaces.") == "user"
+    assert router.categorize("That was a mistake, let's fix it.") == "feedback"
+    assert router.categorize("The database architecture is PostgreSQL.") == "project"
+    assert router.categorize("Random fact about spaceships.") == "general"
+
+    managed = ["CLAUDE.md", "user_prefs.md", "project_info.md"]
+    # Path resolution
+    assert router.resolve_target_path("user", managed) == "user_prefs.md"
+    assert router.resolve_target_path("project", managed) == "project_info.md"
+    assert router.resolve_target_path("general", managed) == "CLAUDE.md"
+
+
+@pytest.mark.asyncio
+async def test_living_memory_orchestration(tmp_path: Path) -> None:
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text("# Core Memory\n", encoding="utf-8")
+
+    # Setup proposer response
+    proposals = [
+        {
+            "file_path": str(claude_md),
+            "section": "Core Memory",
+            "fact_key": "user_prefers_pytest",
+            "proposed_addition": "- The user prefers pytest for tests.",
+            "rationale": "Add pytest preference",
+            "evidence": "Use pytest always",
+        }
+    ]
+    proposer = MockLLM(json.dumps(proposals))
+
+    # LivingMemory instance
+    lm = LivingMemory(
+        paths=[str(claude_md)],
+        proposer=proposer,
+        require_approval=True,
+        store_path=str(tmp_path / "patches.jsonl"),
+        occurrence_path=str(tmp_path / "occurrences.json"),
+        occurrence_threshold=1,  # Lower threshold for testing
+    )
+
+    # 1. Propose patch from session
+    patches = await lm.propose_from_session("session_123", transcript="Use pytest always")
+    assert len(patches) == 1
+    patch = patches[0]
+    assert patch.status == "pending"
+    assert patch.file_path == str(claude_md)
+    assert "- The user prefers pytest for tests." in patch.after_content
+
+    # 2. Check pending list
+    pending = lm.pending_patches()
+    assert len(pending) == 1
+    assert pending[0].patch_id == patch.patch_id
+
+    # 3. Apply patch
+    applied = lm.apply(patch.patch_id)
+    assert applied.status == "applied"
+    assert claude_md.read_text(encoding="utf-8") == "# Core Memory\n- The user prefers pytest for tests.\n"
+
+    # 4. Revert patch
+    reverted = lm.revert(patch.patch_id)
+    assert reverted.status == "reverted"
+    assert claude_md.read_text(encoding="utf-8") == "# Core Memory\n"

--- a/tests/retrieval/test_property_graph.py
+++ b/tests/retrieval/test_property_graph.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from synapsekit.retrieval.property_graph import (
+    ExtractedEntity,
+    ExtractedRelationship,
+    GraphVectorStore,
+    KnowledgeGraphExtraction,
+    KnowledgeGraphExtractor,
+    Neo4jPropertyGraphBackend,
+    NetworkXPropertyGraphBackend,
+    PropertyGraphEdge,
+    PropertyGraphNode,
+)
+
+
+def make_mock_embeddings(dim: int = 4) -> MagicMock:
+    mock = MagicMock()
+
+    async def embed(texts: list[str]) -> np.ndarray:
+        vecs = []
+        for index, _text in enumerate(texts):
+            vector = np.zeros(dim, dtype=np.float32)
+            vector[index % dim] = 1.0
+            vecs.append(vector)
+        return np.array(vecs, dtype=np.float32)
+
+    async def embed_one(text: str) -> np.ndarray:
+        arr = await embed([text])
+        return arr[0]
+
+    mock.embed = embed
+    mock.embed_one = embed_one
+    return mock
+
+
+class StaticExtractor(KnowledgeGraphExtractor):
+    async def extract(self, text: str) -> KnowledgeGraphExtraction:
+        if "Apollo" in text:
+            return KnowledgeGraphExtraction(
+                entities=[
+                    ExtractedEntity("Apollo", type="project", confidence=0.9),
+                    ExtractedEntity("Dana", type="person", confidence=0.9),
+                    ExtractedEntity("Platform Team", type="org", confidence=0.9),
+                ],
+                relationships=[
+                    ExtractedRelationship("Dana", "Apollo", "leads", confidence=0.9),
+                    ExtractedRelationship(
+                        "Apollo",
+                        "Platform Team",
+                        "built_by",
+                        confidence=0.9,
+                    ),
+                ],
+            )
+        return KnowledgeGraphExtraction(
+            entities=[ExtractedEntity("Billing", type="system", confidence=0.9)]
+        )
+
+
+@pytest.mark.asyncio
+async def test_extractor_ingest_stores_confidence_and_source_doc() -> None:
+    graph = NetworkXPropertyGraphBackend()
+    extractor = KnowledgeGraphExtractor(store=graph)
+
+    await extractor.ingest([{"text": "Dana leads Apollo.", "metadata": {"source": "doc-a"}}])
+
+    assert graph.nodes()
+    assert graph.edges()
+    edge = graph.edges()[0]
+    assert edge.properties["source_doc"] == "doc-a"
+    assert edge.properties["confidence"] >= 0.5
+
+
+def test_backend_traversal_respects_hops_confidence_and_direction() -> None:
+    graph = NetworkXPropertyGraphBackend()
+    graph.upsert_node(PropertyGraphNode("a", "A"))
+    graph.upsert_node(PropertyGraphNode("b", "B"))
+    graph.upsert_node(PropertyGraphNode("c", "C"))
+    graph.upsert_edge(PropertyGraphEdge("a", "b", "knows", {"confidence": 0.9}))
+    graph.upsert_edge(PropertyGraphEdge("b", "c", "knows", {"confidence": 0.2}))
+
+    nodes, edges = graph.traverse(["a"], max_hops=2, min_confidence=0.5)
+
+    assert [node.id for node in nodes] == ["a", "b"]
+    assert [edge.id for edge in edges] == ["a:knows:b"]
+    assert graph.neighbors("b", direction="in") == ["a"]
+    with pytest.raises(ValueError, match="direction"):
+        graph.neighbors("a", direction="sideways")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="max_hops"):
+        graph.traverse(["a"], max_hops=-1)
+
+
+@pytest.mark.asyncio
+async def test_graph_vector_store_is_drop_in_vector_store_and_expands_graph_hits() -> None:
+    store = GraphVectorStore(
+        make_mock_embeddings(),
+        extractor=StaticExtractor(),
+        max_hops=2,
+        graph_weight=1.0,
+    )
+
+    await store.add(
+        [
+            "Apollo is led by Dana and built by Platform Team.",
+            "Billing invoices customers.",
+        ],
+        metadata=[{"source": "apollo", "tenant": "a"}, {"source": "billing", "tenant": "b"}],
+    )
+
+    results = await store.search("Who leads Apollo?", top_k=2)
+
+    assert len(store) == 2
+    assert len(results) == 2
+    assert results[0]["metadata"]["retrieval_source"] == "graph_vector"
+    assert "Apollo" in results[0]["metadata"]["graph_nodes"]
+    assert all("text" in item and "score" in item and "metadata" in item for item in results)
+
+
+@pytest.mark.asyncio
+async def test_graph_vector_store_metadata_filter_and_empty_paths() -> None:
+    store = GraphVectorStore(make_mock_embeddings(), extractor=StaticExtractor())
+
+    assert await store.search("empty") == []
+    await store.add(["Apollo is led by Dana."], metadata=[{"source": "apollo", "tenant": "a"}])
+
+    assert await store.search("Apollo", top_k=0) == []
+    assert await store.search("Apollo", metadata_filter={"tenant": "missing"}) == []
+    with pytest.raises(ValueError, match="metadata length"):
+        await store.add(["one"], metadata=[])
+
+
+def test_neo4j_backend_roundtrip_with_testcontainers() -> None:
+    pytest.importorskip("neo4j")
+    container_mod = pytest.importorskip("testcontainers.core.container")
+    wait_mod = pytest.importorskip("testcontainers.core.waiting_utils")
+    docker_container = container_mod.DockerContainer
+    wait_for_logs = wait_mod.wait_for_logs
+
+    password = "synapsekit-password"
+    with (
+        docker_container("neo4j:5")
+        .with_env("NEO4J_AUTH", f"neo4j/{password}")
+        .with_exposed_ports(7687) as container
+    ):
+        wait_for_logs(container, "Bolt enabled", timeout=60)
+        host = container.get_container_host_ip()
+        port = container.get_exposed_port(7687)
+        backend = Neo4jPropertyGraphBackend(
+            f"bolt://{host}:{port}",
+            username="neo4j",
+            password=password,
+        )
+        try:
+            backend.upsert_node(
+                PropertyGraphNode("apollo", "Apollo", properties={"source_doc": "d1"})
+            )
+            backend.upsert_node(PropertyGraphNode("dana", "Dana", properties={"source_doc": "d1"}))
+            backend.upsert_edge(
+                PropertyGraphEdge(
+                    "dana",
+                    "apollo",
+                    "leads",
+                    {"confidence": 0.9, "source_doc": "d1"},
+                )
+            )
+
+            nodes, edges = backend.traverse(["dana"], max_hops=1, min_confidence=0.5)
+
+            assert {node.id for node in nodes} == {"apollo", "dana"}
+            assert [edge.relation for edge in edges] == ["leads"]
+            assert backend.document_ids_for_nodes(["apollo", "dana"]) == ["d1"]
+        finally:
+            backend.close()

--- a/tests/symbolic/test_neuro_symbolic.py
+++ b/tests/symbolic/test_neuro_symbolic.py
@@ -270,7 +270,7 @@ def test_agent_rejects_zero_max_proposals() -> None:
 
 
 def test_parse_constraint_response_rejects_bare_invalid_json() -> None:
-    with pytest.raises(VerificationFailure, match="[Jj][Ss][Oo][Nn]"):
+    with pytest.raises(VerificationFailure, match=r"[Jj][Ss][Oo][Nn]"):
         parse_constraint_response("{not valid json at all}")
 
 

--- a/tests/symbolic/test_symbolic_backends.py
+++ b/tests/symbolic/test_symbolic_backends.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import pytest
 
-from synapsekit.symbolic import ConstraintSet, PrologBackend, SympyBackend, Z3Backend
+from synapsekit.symbolic import ConstraintSet, PrologBackend, SympyBackend
 
 
 def test_z3_missing_dependency_error_message_is_actionable():
     """When z3 is absent, missing_optional_dependency returns an actionable message."""
     from synapsekit.symbolic.types import missing_optional_dependency
+
     err = missing_optional_dependency("z3-solver", "z3")
     assert "z3-solver" in str(err) or "z3" in str(err)
     assert isinstance(err, ImportError)


### PR DESCRIPTION
This PR implements the Living Memory Files feature (Issue #741), enabling the agent to observe user sessions, track fact occurrences, route them to appropriate categories/files, and propose signed markdown patches to memory files like CLAUDE.md and memory/*.md with built-in PII redaction and a CLI for reviewing, applying, reverting, and viewing patch logs.