### PR TITLE
feat(memory): implement Living Memory Files (Issue #741)

### DIFF
--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -270,6 +270,20 @@ from .loaders.web import WebLoader
 from .loaders.wikipedia import WikipediaLoader
 from .mcp import MCPClient, MCPServer, MCPToolAdapter
 from .memory import AgentMemory as PersistentAgentMemory
+from .memory import (
+    DiffConflictError,
+    FileDiffEngine,
+    LivingMemory,
+    MemoryFileCategory,
+    MemoryFileRouter,
+    MemoryPatch,
+    MemoryPIIFilter,
+    OccurrenceRecord,
+    OccurrenceTracker,
+    PatchStatus,
+    PatchStore,
+    PIIFilterResult,
+)
 from .memory.buffer import BufferMemory
 from .memory.conversation import ConversationMemory
 from .memory.entity import EntityMemory
@@ -523,6 +537,18 @@ __all__ = [
     "SQLiteConversationMemory",
     "SummaryBufferMemory",
     "TokenBufferMemory",
+    "LivingMemory",
+    "MemoryPatch",
+    "OccurrenceRecord",
+    "MemoryFileCategory",
+    "PatchStatus",
+    "FileDiffEngine",
+    "DiffConflictError",
+    "PatchStore",
+    "OccurrenceTracker",
+    "MemoryPIIFilter",
+    "PIIFilterResult",
+    "MemoryFileRouter",
     "TokenTracer",
     "PrometheusMetrics",
     # Loaders

--- a/src/synapsekit/cli/main.py
+++ b/src/synapsekit/cli/main.py
@@ -179,6 +179,51 @@ def _add_agent_parser(subparsers: argparse._SubParsersAction) -> None:  # type: 
     )
 
 
+def _add_memory_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    p = subparsers.add_parser("memory", help="Manage Living Memory patches")
+    mem_sub = p.add_subparsers(dest="memory_command")
+
+    review = mem_sub.add_parser("review", help="Review pending memory patches")
+    review.add_argument("--patch-id", default=None, help="Review a specific patch")
+    review.add_argument(
+        "--store-path",
+        default=".synapsekit_memory_patches.jsonl",
+        help="Patch store file path",
+    )
+
+    apply_cmd = mem_sub.add_parser("apply", help="Apply a pending memory patch")
+    apply_cmd.add_argument("patch_id", help="Patch ID to apply")
+    apply_cmd.add_argument(
+        "--store-path",
+        default=".synapsekit_memory_patches.jsonl",
+        help="Patch store file path",
+    )
+
+    revert_cmd = mem_sub.add_parser("revert", help="Revert an applied memory patch")
+    revert_cmd.add_argument("patch_id", help="Patch ID to revert")
+    revert_cmd.add_argument(
+        "--store-path",
+        default=".synapsekit_memory_patches.jsonl",
+        help="Patch store file path",
+    )
+
+    log_cmd = mem_sub.add_parser("log", help="View memory patch history")
+    log_cmd.add_argument("--status", default=None, help="Filter by status")
+    log_cmd.add_argument("--limit", type=int, default=20, help="Max patches to show")
+    log_cmd.add_argument(
+        "--format",
+        dest="output_format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format",
+    )
+    log_cmd.add_argument(
+        "--store-path",
+        default=".synapsekit_memory_patches.jsonl",
+        help="Patch store file path",
+    )
+
+
 def main(argv: list[str] | None = None) -> None:
     """CLI entry point."""
     from .._loop import install_fast_loop
@@ -201,6 +246,7 @@ def main(argv: list[str] | None = None) -> None:
     _add_bench_parser(subparsers)
     _add_edge_parser(subparsers)
     _add_agent_parser(subparsers)
+    _add_memory_parser(subparsers)
     _add_ui_parser(subparsers)
     _add_plugin_parser(subparsers)
 
@@ -248,6 +294,10 @@ def main(argv: list[str] | None = None) -> None:
         from .agent import run_agent
 
         run_agent(args)
+    elif args.command == "memory":
+        from .memory import run_memory
+
+        run_memory(args)
     elif args.command == "ui":
         from .ui import run_ui
 

--- a/src/synapsekit/cli/memory.py
+++ b/src/synapsekit/cli/memory.py
@@ -1,0 +1,166 @@
+"""CLI handler for ``synapsekit memory`` subcommands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def run_memory(args: argparse.Namespace) -> None:
+    """Dispatch memory subcommands."""
+    cmd = getattr(args, "memory_command", None)
+    if cmd == "review":
+        _run_review(args)
+    elif cmd == "apply":
+        _run_apply(args)
+    elif cmd == "revert":
+        _run_revert(args)
+    elif cmd == "log":
+        _run_log(args)
+    else:
+        print("Usage: synapsekit memory {review,apply,revert,log}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _run_review(args: argparse.Namespace) -> None:
+    from ..memory.patch_store import PatchStore
+
+    store = PatchStore(args.store_path)
+    pending = store.pending_patches()
+
+    patch_id = getattr(args, "patch_id", None)
+    if patch_id:
+        # Review a specific patch
+        patch = store.get(patch_id)
+        if patch is None:
+            print(f"Patch {patch_id!r} not found.", file=sys.stderr)
+            sys.exit(1)
+        _display_patch(patch)
+        return
+
+    if not pending:
+        print("No pending memory patches to review.")
+        return
+
+    # List all pending patches
+    print(f"{'ID':<18} {'File':<30} {'Category':<12} {'Created':<22} Rationale")
+    print("-" * 100)
+    for p in pending:
+        rationale_preview = (
+            p.rationale[:40] + "…" if len(p.rationale) > 40 else p.rationale
+        )
+        print(
+            f"{p.patch_id:<18} {p.file_path:<30} {p.category:<12} "
+            f"{p.created_at[:19]:<22} {rationale_preview}"
+        )
+    print(f"\n{len(pending)} pending patch(es). Use --patch-id <ID> to review details.")
+
+
+def _run_apply(args: argparse.Namespace) -> None:
+    from datetime import datetime, timezone
+
+    from ..memory.diff_engine import FileDiffEngine
+    from ..memory.patch_store import PatchStore
+
+    store = PatchStore(args.store_path)
+    patch = store.get(args.patch_id)
+    if patch is None:
+        print(f"Patch {args.patch_id!r} not found.", file=sys.stderr)
+        sys.exit(1)
+
+    if patch.status != "pending":
+        print(
+            f"Patch {args.patch_id} has status {patch.status!r}, cannot apply.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    applicable, reason = FileDiffEngine.validate_patch_applicable(
+        patch.file_path, patch.before_content
+    )
+    if not applicable:
+        print(f"Cannot apply: {reason}", file=sys.stderr)
+        sys.exit(1)
+
+    FileDiffEngine.apply_patch(patch.file_path, patch.after_content)
+    patch.status = "applied"
+    patch.applied_at = datetime.now(timezone.utc).isoformat()
+    patch.sign()
+    store.update(patch)
+    print(f"Applied patch {patch.patch_id} to {patch.file_path}")
+
+
+def _run_revert(args: argparse.Namespace) -> None:
+    from datetime import datetime, timezone
+
+    from ..memory.diff_engine import FileDiffEngine
+    from ..memory.patch_store import PatchStore
+
+    store = PatchStore(args.store_path)
+    patch = store.get(args.patch_id)
+    if patch is None:
+        print(f"Patch {args.patch_id!r} not found.", file=sys.stderr)
+        sys.exit(1)
+
+    if patch.status != "applied":
+        print(
+            f"Patch {args.patch_id} has status {patch.status!r}, cannot revert.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    FileDiffEngine.revert_to_content(patch.file_path, patch.before_content)
+    patch.status = "reverted"
+    patch.reverted_at = datetime.now(timezone.utc).isoformat()
+    patch.sign()
+    store.update(patch)
+    print(f"Reverted patch {patch.patch_id} — restored {patch.file_path}")
+
+
+def _run_log(args: argparse.Namespace) -> None:
+    from ..memory.patch_store import PatchStore
+
+    store = PatchStore(args.store_path)
+    status_filter = getattr(args, "status", None)
+    limit = getattr(args, "limit", 20)
+    fmt = getattr(args, "output_format", "table")
+
+    patches = store.list_by_status(status_filter, limit=limit)
+    if not patches:
+        print("No patches found.")
+        return
+
+    if fmt == "json":
+        print(json.dumps([p.to_dict() for p in patches], indent=2, default=str))
+        return
+
+    print(f"{'ID':<18} {'Status':<12} {'File':<30} {'Created':<22} Rationale")
+    print("-" * 100)
+    for p in patches:
+        rationale_preview = (
+            p.rationale[:35] + "…" if len(p.rationale) > 35 else p.rationale
+        )
+        print(
+            f"{p.patch_id:<18} {p.status:<12} {p.file_path:<30} "
+            f"{p.created_at[:19]:<22} {rationale_preview}"
+        )
+
+
+def _display_patch(patch) -> None:  # type: ignore[no-untyped-def]
+    """Display a single patch in detail."""
+    print(f"Patch ID:     {patch.patch_id}")
+    print(f"File:         {patch.file_path}")
+    print(f"Status:       {patch.status}")
+    print(f"Category:     {patch.category}")
+    print(f"Created:      {patch.created_at}")
+    if patch.signature:
+        print(f"Signature:    {patch.signature[:16]}…")
+    else:
+        print("Signature:    (none)")
+    print(f"Rationale:    {patch.rationale}")
+    if patch.evidence_refs:
+        print(f"Evidence:     {'; '.join(patch.evidence_refs[:3])}")
+    print()
+    print("--- Unified Diff ---")
+    print(patch.unified_diff)

--- a/src/synapsekit/memory/__init__.py
+++ b/src/synapsekit/memory/__init__.py
@@ -8,9 +8,15 @@ from .backends import (
 from .base import BaseMemoryBackend, MemoryRecord
 from .buffer import BufferMemory
 from .conversation import ConversationMemory
+from .diff_engine import DiffConflictError, FileDiffEngine
 from .entity import EntityMemory
+from .file_router import MemoryFileRouter
 from .hybrid import HybridMemory
 from .knowledge_graph_memory import KnowledgeGraphMemory
+from .living_memory import LivingMemory
+from .living_types import MemoryFileCategory, MemoryPatch, OccurrenceRecord, PatchStatus
+from .patch_store import OccurrenceTracker, PatchStore
+from .pii_filter import MemoryPIIFilter, PIIFilterResult
 from .readonly_shared_memory import ReadOnlySharedMemory
 from .redis import RedisConversationMemory
 from .smart_context import SmartContextManager
@@ -39,4 +45,16 @@ __all__ = [
     "SummaryBufferMemory",
     "TokenBufferMemory",
     "VectorConversationMemory",
+    "LivingMemory",
+    "MemoryPatch",
+    "OccurrenceRecord",
+    "MemoryFileCategory",
+    "PatchStatus",
+    "FileDiffEngine",
+    "DiffConflictError",
+    "PatchStore",
+    "OccurrenceTracker",
+    "MemoryPIIFilter",
+    "PIIFilterResult",
+    "MemoryFileRouter",
 ]

--- a/src/synapsekit/memory/diff_engine.py
+++ b/src/synapsekit/memory/diff_engine.py
@@ -1,0 +1,126 @@
+"""File-level diff engine for Living Memory patches."""
+
+from __future__ import annotations
+
+import difflib
+from pathlib import Path
+
+
+class DiffConflictError(Exception):
+    """Raised when a patch cannot be applied due to file changes since proposal."""
+
+    def __init__(self, file_path: str, expected_hash: str, actual_hash: str) -> None:
+        self.file_path = file_path
+        self.expected_hash = expected_hash
+        self.actual_hash = actual_hash
+        super().__init__(
+            f"Conflict in {file_path}: expected content hash "
+            f"{expected_hash[:12]}… but found {actual_hash[:12]}…"
+        )
+
+
+class FileDiffEngine:
+    """Generate and apply unified diffs against memory files.
+
+    Provides utilities for creating unified diffs, validating that a
+    patch is still applicable (the file hasn't diverged), applying
+    patches, and reverting them.
+    """
+
+    @staticmethod
+    def generate_unified_diff(
+        before: str,
+        after: str,
+        file_path: str = "memory.md",
+        *,
+        context_lines: int = 3,
+    ) -> str:
+        """Create a unified diff string between *before* and *after* content."""
+        before_lines = before.splitlines(keepends=True)
+        after_lines = after.splitlines(keepends=True)
+
+        # Ensure trailing newlines for clean diff output
+        if before_lines and not before_lines[-1].endswith("\n"):
+            before_lines[-1] += "\n"
+        if after_lines and not after_lines[-1].endswith("\n"):
+            after_lines[-1] += "\n"
+
+        diff_lines = difflib.unified_diff(
+            before_lines,
+            after_lines,
+            fromfile=f"a/{file_path}",
+            tofile=f"b/{file_path}",
+            n=context_lines,
+        )
+        return "".join(diff_lines)
+
+    @staticmethod
+    def compute_similarity(before: str, after: str) -> float:
+        """Return a 0.0-1.0 similarity ratio between two strings."""
+        matcher = difflib.SequenceMatcher(None, before, after)
+        return matcher.ratio()
+
+    @staticmethod
+    def validate_patch_applicable(
+        file_path: str | Path,
+        expected_before: str,
+    ) -> tuple[bool, str]:
+        """Check whether the file's current content matches the expected snapshot.
+
+        Returns a ``(is_applicable, reason)`` tuple.  A patch is considered
+        applicable when the current file content exactly matches, matches
+        after whitespace normalization, or is >95% similar.
+        """
+        path = Path(file_path)
+        if not path.exists():
+            return False, f"File does not exist: {path}"
+
+        current = path.read_text(encoding="utf-8")
+        if current == expected_before:
+            return True, "content matches"
+
+        # Allow minor whitespace drift
+        if current.strip() == expected_before.strip():
+            return True, "content matches (whitespace-normalized)"
+
+        similarity = FileDiffEngine.compute_similarity(current, expected_before)
+        if similarity > 0.95:
+            return True, f"content closely matches (similarity={similarity:.3f})"
+
+        return False, (
+            f"content has diverged (similarity={similarity:.3f}); "
+            "file may have been edited since the patch was proposed"
+        )
+
+    @staticmethod
+    def apply_patch(file_path: str | Path, after_content: str) -> str:
+        """Write the *after* content to the file.  Returns the previous content."""
+        path = Path(file_path)
+        previous = ""
+        if path.exists():
+            previous = path.read_text(encoding="utf-8")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(after_content, encoding="utf-8")
+        return previous
+
+    @staticmethod
+    def revert_to_content(file_path: str | Path, before_content: str) -> str:
+        """Revert a file to the given content snapshot.  Returns the reverted-from content."""
+        path = Path(file_path)
+        current = ""
+        if path.exists():
+            current = path.read_text(encoding="utf-8")
+        path.write_text(before_content, encoding="utf-8")
+        return current
+
+    @staticmethod
+    def count_changed_lines(unified_diff: str) -> dict[str, int]:
+        """Parse a unified diff and count additions, deletions, and net change."""
+        added = 0
+        removed = 0
+        for line in unified_diff.splitlines():
+            if line.startswith("+") and not line.startswith("+++"):
+                added += 1
+            elif line.startswith("-") and not line.startswith("---"):
+                removed += 1
+        return {"added": added, "removed": removed, "net": added - removed}

--- a/src/synapsekit/memory/file_router.py
+++ b/src/synapsekit/memory/file_router.py
@@ -1,0 +1,117 @@
+"""Route facts to the appropriate memory file based on content category."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .living_types import MemoryFileCategory
+
+
+class MemoryFileRouter:
+    """Determine which memory file a new fact should be written to.
+
+    Routes based on content analysis and configured path mappings.
+    Falls back to the primary memory file when no specific route matches.
+
+    Parameters
+    ----------
+    path_map:
+        Explicit mapping of category to file path, e.g.
+        ``{"user": "./memory/user_prefs.md"}``.
+    primary_path:
+        Default file path when no category-specific route matches.
+    allow_new_files:
+        When True, the router may suggest paths for files that don't
+        yet exist on disk.  Defaults to False.
+    """
+
+    # Keyword patterns that suggest content category
+    _CATEGORY_SIGNALS: dict[MemoryFileCategory, list[str]] = {
+        "user": [
+            r"\bprefer(?:s|ence|red)\b",
+            r"\balways\s+(?:use|choose|want)\b",
+            r"\bmy\s+(?:style|workflow|setup)\b",
+            r"\bI\s+(?:like|dislike|want|need)\b",
+        ],
+        "feedback": [
+            r"\bcorrect(?:ion|ed|ing)\b",
+            r"\bfix(?:ed)?\b",
+            r"\bwrong\b",
+            r"\bmistake\b",
+            r"\bbetter\s+(?:to|if)\b",
+        ],
+        "project": [
+            r"\barchitecture\b",
+            r"\bstack\b",
+            r"\bdependenc(?:y|ies)\b",
+            r"\bconvention\b",
+            r"\bcodebase\b",
+            r"\brepository\b",
+        ],
+    }
+
+    def __init__(
+        self,
+        path_map: dict[MemoryFileCategory, str] | None = None,
+        *,
+        primary_path: str = "./CLAUDE.md",
+        allow_new_files: bool = False,
+    ) -> None:
+        self._primary = primary_path
+        self._allow_new = allow_new_files
+        self._path_map: dict[MemoryFileCategory, str] = path_map or {}
+        self._compiled: dict[MemoryFileCategory, list[re.Pattern[str]]] = {}
+        for cat, patterns in self._CATEGORY_SIGNALS.items():
+            self._compiled[cat] = [re.compile(p, re.IGNORECASE) for p in patterns]
+
+    def categorize(self, content: str) -> MemoryFileCategory:
+        """Determine the category of a piece of content.
+
+        Scores each category by counting regex hits and returns the
+        best match, falling back to ``'general'`` when nothing matches.
+        """
+        scores: dict[MemoryFileCategory, int] = {
+            "user": 0,
+            "feedback": 0,
+            "project": 0,
+            "general": 0,
+        }
+
+        for category, patterns in self._compiled.items():
+            for pattern in patterns:
+                hits = len(pattern.findall(content))
+                scores[category] += hits
+
+        best_category = max(scores, key=scores.get)  # type: ignore[arg-type]
+        if scores[best_category] == 0:
+            return "general"
+        return best_category
+
+    def resolve_target_path(
+        self,
+        category: MemoryFileCategory,
+        managed_paths: list[str],
+    ) -> str:
+        """Determine which file path a fact should be routed to.
+
+        Resolution order:
+        1. Explicit ``path_map`` entry for the category.
+        2. A managed file whose basename starts with the category name.
+        3. The primary memory file as fallback.
+        """
+        # Check explicit path map first
+        if category in self._path_map:
+            candidate = self._path_map[category]
+            if candidate in managed_paths or self._allow_new:
+                return candidate
+
+        # Try to find a managed file whose name suggests this category
+        category_prefix = f"{category}_"
+        for managed in managed_paths:
+            basename = Path(managed).stem.lower()
+            if basename.startswith(category_prefix) or basename == category:
+                return managed
+
+        # Fall back to primary
+        return self._primary

--- a/src/synapsekit/memory/living_memory.py
+++ b/src/synapsekit/memory/living_memory.py
@@ -1,0 +1,502 @@
+"""Living Memory — bidirectional agent memory file management."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .diff_engine import FileDiffEngine
+from .file_router import MemoryFileRouter
+from .living_types import MemoryPatch, PatchStatus
+from .patch_store import OccurrenceTracker, PatchStore
+from .pii_filter import MemoryPIIFilter
+
+_log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# LLM prompt for proposing memory patches
+# ---------------------------------------------------------------------------
+_PROPOSAL_PROMPT = """\
+You are a Memory Writer agent. Analyze the session transcript below and propose \
+updates to the user's memory files.
+
+## Current Memory Files
+{file_contents}
+
+## Session Transcript
+{transcript}
+
+## Instructions
+1. Identify facts, preferences, corrections, or decisions that should be persisted.
+2. For each proposed change, output a JSON object with:
+   - "file_path": which file to update
+   - "section": which section heading the change belongs under (or "new" for a new section)
+   - "fact_key": a short stable identifier for this fact (snake_case, ≤40 chars)
+   - "proposed_addition": the markdown text to add or modify
+   - "rationale": why this should be recorded
+   - "evidence": quote from the transcript supporting this change
+3. Only propose changes for durable, reusable information — not one-off requests.
+4. Do NOT propose changes that are already present in the memory files.
+5. Return a JSON array of proposed changes. If no changes needed, return [].
+"""
+
+
+class LivingMemory:
+    """Orchestrate bidirectional memory file management.
+
+    Observes agent sessions, proposes signed diffs to memory files,
+    and manages the review / apply / revert lifecycle.
+
+    Parameters
+    ----------
+    paths:
+        Glob patterns or explicit paths to managed memory files.
+    proposer:
+        An LLM instance used to generate patch proposals.  Should support
+        ``generate(prompt)`` or ``agenerate(prompt)``.
+    require_approval:
+        If True (default), patches are stored as ``"pending"`` for human
+        review.  If False, patches are auto-applied after PII filtering.
+    sign:
+        Whether to cryptographically sign patches.
+    signature_secret:
+        Secret used for HMAC-style patch signing.
+    store_path:
+        Path for the JSONL patch store file.
+    occurrence_path:
+        Path for the occurrence tracker JSON file.
+    occurrence_threshold:
+        Minimum times a fact must be observed before proposing a patch.
+    pii_filter:
+        Custom PII filter instance.  Uses default if None.
+    file_router:
+        Custom file router instance.  Uses default if None.
+    """
+
+    def __init__(
+        self,
+        paths: list[str],
+        proposer: Any | None = None,
+        *,
+        require_approval: bool = True,
+        sign: bool = True,
+        signature_secret: str = "",
+        store_path: str = ".synapsekit_memory_patches.jsonl",
+        occurrence_path: str | None = ".synapsekit_memory_occurrences.json",
+        occurrence_threshold: int = 3,
+        pii_filter: MemoryPIIFilter | None = None,
+        file_router: MemoryFileRouter | None = None,
+    ) -> None:
+        self._raw_paths = paths
+        self._proposer = proposer
+        self._require_approval = require_approval
+        self._sign = sign
+        self._secret = signature_secret
+        self._occurrence_threshold = occurrence_threshold
+
+        self._store = PatchStore(store_path)
+        self._tracker = OccurrenceTracker(occurrence_path)
+        self._pii_filter = pii_filter or MemoryPIIFilter()
+        self._diff = FileDiffEngine()
+        self._router = file_router or MemoryFileRouter(
+            primary_path=paths[0] if paths else "./CLAUDE.md"
+        )
+
+    # ------------------------------------------------------------------
+    # Public properties
+    # ------------------------------------------------------------------
+
+    @property
+    def managed_paths(self) -> list[str]:
+        """Resolve glob patterns to actual file paths."""
+        resolved: list[str] = []
+        seen: set[str] = set()
+        for raw in self._raw_paths:
+            path = Path(raw)
+            if "*" in raw or "?" in raw:
+                parent = path.parent
+                pattern = path.name
+                if parent.exists():
+                    for match in sorted(parent.glob(pattern)):
+                        if match.is_file():
+                            norm = str(match)
+                            if norm not in seen:
+                                seen.add(norm)
+                                resolved.append(norm)
+            elif path.is_file():
+                norm = str(path)
+                if norm not in seen:
+                    seen.add(norm)
+                    resolved.append(norm)
+        return resolved
+
+    # ------------------------------------------------------------------
+    # Session analysis
+    # ------------------------------------------------------------------
+
+    async def propose_from_session(
+        self,
+        session_id: str,
+        *,
+        transcript: str | None = None,
+        session_records: list[dict[str, Any]] | None = None,
+    ) -> list[MemoryPatch]:
+        """Analyze a session and propose memory file patches.
+
+        Returns a list of :class:`MemoryPatch` objects.  Their status will
+        be ``"pending"`` when *require_approval* is True, otherwise
+        ``"applied"``.
+        """
+        if self._proposer is None:
+            _log.warning("No proposer LLM configured — skipping patch proposal")
+            return []
+
+        # Build transcript from records if not provided directly
+        if transcript is None and session_records:
+            transcript = self._format_session_records(session_records)
+        if not transcript:
+            return []
+
+        file_contents = self._read_managed_files()
+        if not file_contents:
+            _log.warning("No managed memory files found at configured paths")
+            return []
+
+        # Build the proposal prompt
+        files_section = self._format_file_contents(file_contents)
+        prompt = _PROPOSAL_PROMPT.format(
+            file_contents=files_section,
+            transcript=transcript[:8000],  # Cap transcript length
+        )
+
+        # Get proposals from LLM
+        raw_proposals = await self._generate_proposals(prompt)
+        if not raw_proposals:
+            return []
+
+        # Process each proposal through the pipeline
+        patches: list[MemoryPatch] = []
+        for proposal in raw_proposals:
+            patch = await self._process_single_proposal(
+                proposal=proposal,
+                file_contents=file_contents,
+                session_id=session_id,
+            )
+            if patch is not None:
+                patches.append(patch)
+
+        return patches
+
+    # ------------------------------------------------------------------
+    # Review / apply / revert
+    # ------------------------------------------------------------------
+
+    def review(self, patch: MemoryPatch | str) -> dict[str, Any]:
+        """Prepare a patch for interactive review.
+
+        Returns a dict with the diff, rationale, and review metadata
+        suitable for display in a CLI or editor.
+        """
+        if isinstance(patch, str):
+            resolved = self._store.get(patch)
+            if resolved is None:
+                raise KeyError(f"Patch {patch!r} not found")
+            patch = resolved
+
+        stats = self._diff.count_changed_lines(patch.unified_diff)
+        return {
+            "patch_id": patch.patch_id,
+            "file_path": patch.file_path,
+            "status": patch.status,
+            "rationale": patch.rationale,
+            "evidence": patch.evidence_refs,
+            "category": patch.category,
+            "diff": patch.unified_diff,
+            "stats": stats,
+            "created_at": patch.created_at,
+            "signature_valid": patch.verify(self._secret) if patch.signature else None,
+        }
+
+    def apply(self, patch: MemoryPatch | str) -> MemoryPatch:
+        """Apply an approved patch to the target file."""
+        if isinstance(patch, str):
+            resolved = self._store.get(patch)
+            if resolved is None:
+                raise KeyError(f"Patch {patch!r} not found")
+            patch = resolved
+
+        if patch.status not in ("pending", "approved"):
+            raise ValueError(
+                f"Cannot apply patch {patch.patch_id!r} with status {patch.status!r}"
+            )
+
+        # Validate the file hasn't changed
+        applicable, reason = self._diff.validate_patch_applicable(
+            patch.file_path, patch.before_content
+        )
+        if not applicable:
+            patch.status = "conflict"
+            patch.metadata["conflict_reason"] = reason
+            self._store.update(patch)
+            raise RuntimeError(
+                f"Cannot apply patch {patch.patch_id}: {reason}"
+            )
+
+        self._apply_patch_to_file(patch)
+        return patch
+
+    def revert(self, patch_id: str) -> MemoryPatch:
+        """Revert a previously applied patch."""
+        patch = self._store.get(patch_id)
+        if patch is None:
+            raise KeyError(f"Patch {patch_id!r} not found")
+
+        if patch.status != "applied":
+            raise ValueError(
+                f"Cannot revert patch {patch_id!r} with status {patch.status!r}"
+            )
+
+        self._diff.revert_to_content(patch.file_path, patch.before_content)
+        patch.status = "reverted"
+        patch.reverted_at = datetime.now(timezone.utc).isoformat()
+        if self._sign:
+            patch.sign(self._secret)
+        self._store.update(patch)
+
+        _log.info("Reverted patch %s on %s", patch_id, patch.file_path)
+        return patch
+
+    def pending_patches(self) -> list[MemoryPatch]:
+        """Return all patches awaiting review."""
+        return self._store.pending_patches()
+
+    def patch_history(
+        self,
+        *,
+        status: PatchStatus | None = None,
+        limit: int | None = None,
+    ) -> list[MemoryPatch]:
+        """Return patch history, newest first."""
+        return self._store.list_by_status(status, limit=limit)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _read_managed_files(self) -> dict[str, str]:
+        """Read current content of all managed memory files."""
+        contents: dict[str, str] = {}
+        for file_path in self.managed_paths:
+            try:
+                contents[file_path] = Path(file_path).read_text(encoding="utf-8")
+            except OSError as exc:
+                _log.warning("Could not read %s: %s", file_path, exc)
+        return contents
+
+    async def _generate_proposals(self, prompt: str) -> list[dict[str, Any]]:
+        """Call the proposer LLM and parse the JSON response."""
+        if self._proposer is None:
+            return []
+        try:
+            if hasattr(self._proposer, "agenerate"):
+                raw = await self._proposer.agenerate(prompt)
+            elif hasattr(self._proposer, "generate"):
+                result = self._proposer.generate(prompt)
+                if inspect.isawaitable(result):
+                    raw = await result
+                else:
+                    raw = result
+            else:
+                _log.error("Proposer LLM has no generate/agenerate method")
+                return []
+        except Exception:
+            _log.exception("LLM proposal generation failed")
+            return []
+
+        return self._parse_proposal_json(str(raw))
+
+    async def _process_single_proposal(
+        self,
+        proposal: dict[str, Any],
+        file_contents: dict[str, str],
+        session_id: str,
+    ) -> MemoryPatch | None:
+        """Transform a raw LLM proposal into a validated MemoryPatch."""
+        fact_key = str(proposal.get("fact_key", ""))
+        if not fact_key:
+            return None
+
+        evidence = str(proposal.get("evidence", ""))
+        self._tracker.record_occurrence(fact_key, session_id, evidence)
+
+        # Check occurrence threshold
+        if not self._tracker.has_reached_threshold(
+            fact_key, self._occurrence_threshold
+        ):
+            current_count = self._tracker.get_count(fact_key)
+            _log.debug(
+                "Fact %r has not reached threshold (%d/%d) — deferring",
+                fact_key,
+                current_count,
+                self._occurrence_threshold,
+            )
+            return None
+
+        # Determine target file
+        content_text = str(proposal.get("proposed_addition", ""))
+        category = self._router.categorize(content_text)
+        target_path = self._router.resolve_target_path(
+            category, list(file_contents.keys())
+        )
+
+        # Build the patch
+        before = file_contents.get(target_path, "")
+        after = self._insert_content(
+            before,
+            content_text,
+            section=str(proposal.get("section", "")),
+        )
+
+        if before == after:
+            return None
+
+        # PII filter
+        pii_result = self._pii_filter.filter_content(after)
+        after = pii_result.filtered_content
+
+        unified = self._diff.generate_unified_diff(before, after, target_path)
+        if not unified.strip():
+            return None
+
+        patch = MemoryPatch(
+            file_path=target_path,
+            before_content=before,
+            after_content=after,
+            unified_diff=unified,
+            rationale=str(proposal.get("rationale", "")),
+            evidence_refs=[evidence] if evidence else [],
+            session_id=session_id,
+            category=category,
+            status="pending" if self._require_approval else "applied",
+            metadata={
+                "fact_key": fact_key,
+                "pii_filtered": not pii_result.is_clean,
+                "diff_stats": self._diff.count_changed_lines(unified),
+            },
+        )
+
+        if self._sign:
+            patch.sign(self._secret)
+
+        self._store.save(patch)
+
+        # Auto-apply if approval not required
+        if not self._require_approval:
+            self._apply_patch_to_file(patch)
+
+        return patch
+
+    def _apply_patch_to_file(self, patch: MemoryPatch) -> None:
+        """Write the patch content to disk and update status."""
+        self._diff.apply_patch(patch.file_path, patch.after_content)
+        patch.status = "applied"
+        patch.applied_at = datetime.now(timezone.utc).isoformat()
+        if self._sign:
+            patch.sign(self._secret)
+        self._store.update(patch)
+        _log.info("Applied patch %s to %s", patch.patch_id, patch.file_path)
+
+    @staticmethod
+    def _insert_content(
+        existing: str,
+        addition: str,
+        section: str = "",
+    ) -> str:
+        """Insert new content into the appropriate section of a file."""
+        addition = addition.strip()
+        if not addition:
+            return existing
+
+        lines = existing.split("\n")
+
+        if section and section != "new":
+            # Find the section heading and insert after it
+            section_lower = section.lower().strip("# ").strip()
+            insert_idx = None
+            for i, line in enumerate(lines):
+                stripped = line.strip().lower().lstrip("# ").strip()
+                if stripped == section_lower:
+                    # Find the end of this section (next heading or EOF)
+                    insert_idx = i + 1
+                    while insert_idx < len(lines):
+                        next_line = lines[insert_idx].strip()
+                        if next_line.startswith("#"):
+                            break
+                        insert_idx += 1
+                    break
+
+            if insert_idx is not None:
+                # If inserting at the end of the file and it has a trailing newline (empty string in lines),
+                # insert before it to preserve the single trailing newline properly.
+                if insert_idx == len(lines) and len(lines) > 1 and lines[-1] == "":
+                    lines.insert(len(lines) - 1, addition)
+                else:
+                    lines.insert(insert_idx, addition)
+                return "\n".join(lines)
+
+        # Default: append at end
+        if existing and not existing.endswith("\n"):
+            return existing + "\n\n" + addition + "\n"
+        return existing + "\n" + addition + "\n"
+
+    @staticmethod
+    def _format_file_contents(contents: dict[str, str]) -> str:
+        """Format managed file contents for the LLM prompt."""
+        parts: list[str] = []
+        for path, content in contents.items():
+            parts.append(f"### File: `{path}`\n```markdown\n{content}\n```")
+        return "\n\n".join(parts)
+
+    @staticmethod
+    def _format_session_records(records: list[dict[str, Any]]) -> str:
+        """Format session records into a readable transcript."""
+        lines: list[str] = []
+        for record in records:
+            role = record.get("role", "unknown")
+            content = record.get("content", "")
+            lines.append(f"[{role}]: {content}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _parse_proposal_json(text: str) -> list[dict[str, Any]]:
+        """Extract JSON array from LLM response text."""
+        cleaned = text.strip()
+        if cleaned.startswith("```"):
+            cleaned = cleaned[3:]
+            if cleaned.endswith("```"):
+                cleaned = cleaned[:-3]
+            if cleaned.startswith("json"):
+                cleaned = cleaned[4:].strip()
+            cleaned = cleaned.strip()
+
+        try:
+            parsed = json.loads(cleaned)
+        except json.JSONDecodeError:
+            start = cleaned.find("[")
+            end = cleaned.rfind("]")
+            if start == -1 or end == -1 or end <= start:
+                return []
+            try:
+                parsed = json.loads(cleaned[start : end + 1])
+            except json.JSONDecodeError:
+                return []
+
+        if isinstance(parsed, dict):
+            parsed = [parsed]
+        if not isinstance(parsed, list):
+            return []
+        return [item for item in parsed if isinstance(item, dict)]

--- a/src/synapsekit/memory/living_types.py
+++ b/src/synapsekit/memory/living_types.py
@@ -1,0 +1,113 @@
+"""Data types for Living Memory — file-level patches with signatures."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+PatchStatus = Literal[
+    "pending",
+    "approved",
+    "applied",
+    "rejected",
+    "reverted",
+    "conflict",
+]
+
+MemoryFileCategory = Literal[
+    "user",
+    "feedback",
+    "project",
+    "general",
+]
+
+
+@dataclass
+class MemoryPatch:
+    """A proposed diff to a memory file, with provenance and signature.
+
+    Each patch captures the full before/after content of the target file,
+    along with a unified diff, rationale for the change, evidence from
+    the originating session, and a SHA-256 signature for integrity.
+    """
+
+    file_path: str
+    before_content: str
+    after_content: str
+    unified_diff: str
+    rationale: str
+    evidence_refs: list[str] = field(default_factory=list)
+    patch_id: str = field(default_factory=lambda: uuid.uuid4().hex[:16])
+    created_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    status: PatchStatus = "pending"
+    category: MemoryFileCategory = "general"
+    session_id: str | None = None
+    author: str = "living-memory"
+    signature: str = ""
+    applied_at: str | None = None
+    reverted_at: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def sign(self, secret: str = "") -> str:
+        """Compute and store a SHA-256 signature over patch content."""
+        payload = self._signature_material()
+        raw = json.dumps(payload, sort_keys=True, default=str, separators=(",", ":"))
+        self.signature = hashlib.sha256(f"{secret}:{raw}".encode()).hexdigest()
+        return self.signature
+
+    def verify(self, secret: str = "") -> bool:
+        """Check that the stored signature matches the current content."""
+        payload = self._signature_material()
+        raw = json.dumps(payload, sort_keys=True, default=str, separators=(",", ":"))
+        expected = hashlib.sha256(f"{secret}:{raw}".encode()).hexdigest()
+        return self.signature == expected
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MemoryPatch:
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+    def _signature_material(self) -> dict[str, Any]:
+        data = asdict(self)
+        data.pop("signature", None)
+        data.pop("applied_at", None)
+        data.pop("reverted_at", None)
+        return data
+
+
+@dataclass
+class OccurrenceRecord:
+    """Tracks how many times a particular fact or pattern has been observed.
+
+    Used by the occurrence threshold system to prevent memory pollution
+    from single observations — a fact must be seen at least N times
+    across different sessions before a patch is proposed.
+    """
+
+    fact_key: str
+    count: int = 0
+    first_seen: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    last_seen: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    session_ids: list[str] = field(default_factory=list)
+    sample_evidence: list[str] = field(default_factory=list)
+
+    def increment(self, session_id: str, evidence: str = "") -> None:
+        """Record a new observation of this fact."""
+        self.count += 1
+        self.last_seen = datetime.now(timezone.utc).isoformat()
+        if session_id and session_id not in self.session_ids:
+            self.session_ids.append(session_id)
+        if evidence and len(self.sample_evidence) < 5:
+            self.sample_evidence.append(evidence[:500])

--- a/src/synapsekit/memory/patch_store.py
+++ b/src/synapsekit/memory/patch_store.py
@@ -1,0 +1,164 @@
+"""JSONL-backed patch storage for Living Memory."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from .living_types import MemoryPatch, OccurrenceRecord, PatchStatus
+
+_log = logging.getLogger(__name__)
+
+
+class PatchStore:
+    """Append-only JSONL store for memory patches with query helpers.
+
+    Patches are persisted as one JSON object per line.  Updates to an
+    existing patch (e.g. status change) are appended as new lines;
+    queries always return the latest version for each ``patch_id``.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._patches: list[MemoryPatch] = []
+        if self._path.exists():
+            self._load()
+
+    def save(self, patch: MemoryPatch) -> MemoryPatch:
+        """Sign and append a new patch to the store."""
+        if not patch.signature:
+            patch.sign()
+        self._patches.append(patch)
+        self._append_line(patch.to_dict())
+        return patch
+
+    def update(self, patch: MemoryPatch) -> None:
+        """Re-sign and persist the updated patch by appending a new line."""
+        patch.sign()
+        self._append_line(patch.to_dict())
+
+    def get(self, patch_id: str) -> MemoryPatch | None:
+        """Retrieve the latest version of a patch by its ID."""
+        for patch in reversed(self._patches):
+            if patch.patch_id == patch_id:
+                return patch
+        return None
+
+    def list_by_status(
+        self,
+        status: PatchStatus | None = None,
+        *,
+        limit: int | None = None,
+    ) -> list[MemoryPatch]:
+        """Return patches filtered by status, newest first, deduplicated by ID."""
+        result = [
+            p for p in reversed(self._patches)
+            if status is None or p.status == status
+        ]
+        # Deduplicate by patch_id (keep latest)
+        seen: set[str] = set()
+        deduped: list[MemoryPatch] = []
+        for p in result:
+            if p.patch_id not in seen:
+                seen.add(p.patch_id)
+                deduped.append(p)
+        if limit is not None:
+            return deduped[:limit]
+        return deduped
+
+    def pending_patches(self) -> list[MemoryPatch]:
+        """Shorthand for listing all patches with status ``'pending'``."""
+        return self.list_by_status("pending")
+
+    def count(self, status: PatchStatus | None = None) -> int:
+        """Count patches, optionally filtered by status."""
+        return len(self.list_by_status(status))
+
+    def _append_line(self, data: dict[str, Any]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(data, sort_keys=True, default=str) + "\n")
+
+    def _load(self) -> None:
+        with self._path.open("r", encoding="utf-8") as f:
+            for line_num, line in enumerate(f, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    self._patches.append(MemoryPatch.from_dict(json.loads(line)))
+                except (json.JSONDecodeError, TypeError) as exc:
+                    _log.warning("Skipping corrupt patch at line %d: %s", line_num, exc)
+
+
+class OccurrenceTracker:
+    """Track fact occurrences across sessions to avoid single-observation noise.
+
+    Facts must be observed at least ``min_occurrences`` times (across
+    different sessions) before they are eligible for patch proposals.
+    State is persisted as a JSON file.
+    """
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self._path = Path(path) if path else None
+        self._records: dict[str, OccurrenceRecord] = {}
+        if self._path and self._path.exists():
+            self._load()
+
+    def record_occurrence(
+        self,
+        fact_key: str,
+        session_id: str,
+        evidence: str = "",
+    ) -> OccurrenceRecord:
+        """Record one observation of *fact_key* in the given session."""
+        if fact_key not in self._records:
+            self._records[fact_key] = OccurrenceRecord(fact_key=fact_key)
+        rec = self._records[fact_key]
+        rec.increment(session_id, evidence)
+        self._persist()
+        return rec
+
+    def get_mature_facts(self, min_occurrences: int = 3) -> list[OccurrenceRecord]:
+        """Return facts that have been observed at least *min_occurrences* times."""
+        return [
+            r for r in self._records.values()
+            if r.count >= min_occurrences
+        ]
+
+    def has_reached_threshold(self, fact_key: str, threshold: int = 3) -> bool:
+        """Check whether a fact has met the occurrence threshold."""
+        rec = self._records.get(fact_key)
+        return rec is not None and rec.count >= threshold
+
+    def get_count(self, fact_key: str) -> int:
+        """Return the current occurrence count for a fact, or 0 if unseen."""
+        rec = self._records.get(fact_key)
+        return rec.count if rec is not None else 0
+
+    def remove(self, fact_key: str) -> None:
+        """Delete tracking data for a fact."""
+        self._records.pop(fact_key, None)
+        self._persist()
+
+    def _persist(self) -> None:
+        if self._path is None:
+            return
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        data = {k: vars(v) for k, v in self._records.items()}
+        self._path.write_text(
+            json.dumps(data, sort_keys=True, default=str, indent=2),
+            encoding="utf-8",
+        )
+
+    def _load(self) -> None:
+        if self._path is None:
+            return
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+            for key, val in raw.items():
+                self._records[key] = OccurrenceRecord(**val)
+        except (json.JSONDecodeError, TypeError):
+            _log.warning("Could not parse occurrence tracker at %s", self._path)

--- a/src/synapsekit/memory/pii_filter.py
+++ b/src/synapsekit/memory/pii_filter.py
@@ -1,0 +1,130 @@
+"""PII filtering for Living Memory patches."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from ..agents.guardrails import GuardrailResult, PIIDetector
+
+
+@dataclass
+class PIIFilterResult:
+    """Result of PII filtering on a memory patch.
+
+    When ``is_clean`` is True the content contained no detectable PII.
+    Otherwise ``filtered_content`` holds the redacted version and
+    ``redaction_types`` lists which categories were found.
+    """
+
+    is_clean: bool
+    original_content: str
+    filtered_content: str
+    redacted_count: int = 0
+    redaction_types: list[str] = field(default_factory=list)
+
+
+class MemoryPIIFilter:
+    """Filter PII from proposed memory patches before they reach storage.
+
+    Leverages the existing :class:`PIIDetector` from the guardrails module
+    and adds active redaction — replacing detected PII with placeholder
+    tokens so that memory files never contain sensitive information.
+
+    Parameters
+    ----------
+    detect:
+        List of PII types to scan for.  Defaults to all known types.
+    redact:
+        When True (default), detected PII is replaced with placeholders.
+        When False, the filter only reports findings without modifying content.
+    """
+
+    _REDACTION_PATTERNS: dict[str, tuple[str, str]] = {
+        "email": (
+            r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
+            "[REDACTED_EMAIL]",
+        ),
+        "phone": (
+            r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b",
+            "[REDACTED_PHONE]",
+        ),
+        "ssn": (
+            r"\b\d{3}-\d{2}-\d{4}\b",
+            "[REDACTED_SSN]",
+        ),
+        "credit_card": (
+            r"\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b",
+            "[REDACTED_CC]",
+        ),
+        "ip_address": (
+            r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b",
+            "[REDACTED_IP]",
+        ),
+        "api_key": (
+            r"\b(?:sk|pk|api|key|token|secret)[-_]?[A-Za-z0-9]{20,}\b",
+            "[REDACTED_KEY]",
+        ),
+    }
+
+    def __init__(
+        self,
+        detect: list[str] | None = None,
+        *,
+        redact: bool = True,
+    ) -> None:
+        active_types = detect or list(self._REDACTION_PATTERNS.keys())
+        self._detector = PIIDetector(
+            detect=[t for t in active_types if t in PIIDetector._PATTERNS]
+        )
+        self._redact = redact
+        self._compiled: dict[str, tuple[re.Pattern[str], str]] = {}
+        for name, (pattern, replacement) in self._REDACTION_PATTERNS.items():
+            if name in active_types:
+                self._compiled[name] = (re.compile(pattern), replacement)
+
+    def check(self, text: str) -> GuardrailResult:
+        """Check for PII without redacting."""
+        return self._detector.check(text)
+
+    def filter_content(self, content: str) -> PIIFilterResult:
+        """Detect and optionally redact PII from content."""
+        check_result = self._detector.check(content)
+
+        if check_result.passed:
+            return PIIFilterResult(
+                is_clean=True,
+                original_content=content,
+                filtered_content=content,
+            )
+
+        if not self._redact:
+            return PIIFilterResult(
+                is_clean=False,
+                original_content=content,
+                filtered_content=content,
+                redaction_types=[
+                    v.split("(")[1].rstrip(")").split(":")[0]
+                    for v in check_result.violations
+                ],
+            )
+
+        # Apply redactions
+        filtered = content
+        total_redacted = 0
+        types_found: list[str] = []
+
+        for pii_type, (pattern, replacement) in self._compiled.items():
+            matches = pattern.findall(filtered)
+            if matches:
+                filtered = pattern.sub(replacement, filtered)
+                total_redacted += len(matches)
+                types_found.append(pii_type)
+
+        return PIIFilterResult(
+            is_clean=False,
+            original_content=content,
+            filtered_content=filtered,
+            redacted_count=total_redacted,
+            redaction_types=types_found,
+        )

--- a/tests/cli/test_memory_cli.py
+++ b/tests/cli/test_memory_cli.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import argparse
+
+from synapsekit.cli.memory import run_memory
+from synapsekit.memory import MemoryPatch, PatchStore
+
+
+def test_memory_cli_review_empty(tmp_path, capsys) -> None:
+    store_path = tmp_path / "patches.jsonl"
+    args = argparse.Namespace(
+        memory_command="review",
+        patch_id=None,
+        store_path=str(store_path),
+    )
+    run_memory(args)
+    captured = capsys.readouterr()
+    assert "No pending memory patches to review." in captured.out
+
+
+def test_memory_cli_review_list(tmp_path, capsys) -> None:
+    store_path = tmp_path / "patches.jsonl"
+    store = PatchStore(store_path)
+    patch = MemoryPatch(
+        file_path="CLAUDE.md",
+        before_content="A",
+        after_content="B",
+        unified_diff="diff",
+        rationale="Update test",
+    )
+    store.save(patch)
+
+    args = argparse.Namespace(
+        memory_command="review",
+        patch_id=None,
+        store_path=str(store_path),
+    )
+    run_memory(args)
+    captured = capsys.readouterr()
+    assert patch.patch_id in captured.out
+    assert "Update test" in captured.out
+
+
+def test_memory_cli_review_detail(tmp_path, capsys) -> None:
+    store_path = tmp_path / "patches.jsonl"
+    store = PatchStore(store_path)
+    patch = MemoryPatch(
+        file_path="CLAUDE.md",
+        before_content="A",
+        after_content="B",
+        unified_diff="diff content",
+        rationale="Specific patch description",
+    )
+    store.save(patch)
+
+    args = argparse.Namespace(
+        memory_command="review",
+        patch_id=patch.patch_id,
+        store_path=str(store_path),
+    )
+    run_memory(args)
+    captured = capsys.readouterr()
+    assert f"Patch ID:     {patch.patch_id}" in captured.out
+    assert "Specific patch description" in captured.out
+    assert "diff content" in captured.out
+
+
+def test_memory_cli_apply_success(tmp_path, capsys) -> None:
+    store_path = tmp_path / "patches.jsonl"
+    target_file = tmp_path / "CLAUDE.md"
+    target_file.write_text("Hello\n", encoding="utf-8")
+
+    store = PatchStore(store_path)
+    patch = MemoryPatch(
+        file_path=str(target_file),
+        before_content="Hello\n",
+        after_content="Hello World\n",
+        unified_diff="...",
+        rationale="test apply",
+    )
+    store.save(patch)
+
+    args = argparse.Namespace(
+        memory_command="apply",
+        patch_id=patch.patch_id,
+        store_path=str(store_path),
+    )
+    run_memory(args)
+    captured = capsys.readouterr()
+    assert f"Applied patch {patch.patch_id}" in captured.out
+    assert target_file.read_text(encoding="utf-8") == "Hello World\n"
+
+
+def test_memory_cli_revert_success(tmp_path, capsys) -> None:
+    store_path = tmp_path / "patches.jsonl"
+    target_file = tmp_path / "CLAUDE.md"
+    target_file.write_text("Hello World\n", encoding="utf-8")
+
+    store = PatchStore(store_path)
+    patch = MemoryPatch(
+        file_path=str(target_file),
+        before_content="Hello\n",
+        after_content="Hello World\n",
+        unified_diff="...",
+        rationale="test revert",
+        status="applied",
+    )
+    store.save(patch)
+
+    args = argparse.Namespace(
+        memory_command="revert",
+        patch_id=patch.patch_id,
+        store_path=str(store_path),
+    )
+    run_memory(args)
+    captured = capsys.readouterr()
+    assert f"Reverted patch {patch.patch_id}" in captured.out
+    assert target_file.read_text(encoding="utf-8") == "Hello\n"
+
+
+def test_memory_cli_log_table(tmp_path, capsys) -> None:
+    store_path = tmp_path / "patches.jsonl"
+    store = PatchStore(store_path)
+    patch = MemoryPatch(
+        file_path="CLAUDE.md",
+        before_content="A",
+        after_content="B",
+        unified_diff="diff",
+        rationale="History rationale",
+        status="reverted",
+    )
+    store.save(patch)
+
+    args = argparse.Namespace(
+        memory_command="log",
+        status=None,
+        limit=20,
+        output_format="table",
+        store_path=str(store_path),
+    )
+    run_memory(args)
+    captured = capsys.readouterr()
+    assert "History rationale" in captured.out
+    assert "reverted" in captured.out

--- a/tests/memory/test_living_memory.py
+++ b/tests/memory/test_living_memory.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from synapsekit.memory import (
+    FileDiffEngine,
+    LivingMemory,
+    MemoryFileRouter,
+    MemoryPatch,
+    MemoryPIIFilter,
+    OccurrenceTracker,
+    PatchStore,
+)
+
+
+class MockLLM:
+    """Mock LLM that returns a pre-configured response."""
+
+    def __init__(self, response_text: str) -> None:
+        self.response_text = response_text
+        self.calls: list[str] = []
+
+    async def agenerate(self, prompt: str) -> str:
+        self.calls.append(prompt)
+        return self.response_text
+
+    def generate(self, prompt: str) -> str:
+        self.calls.append(prompt)
+        return self.response_text
+
+
+def test_memory_patch_sign_verify() -> None:
+    patch = MemoryPatch(
+        file_path="CLAUDE.md",
+        before_content="Hello",
+        after_content="Hello World",
+        unified_diff="--- \n+++ \n@@ -1 +1 @@\n-Hello\n+Hello World\n",
+        rationale="Add World",
+    )
+    secret = "test-secret"
+    sig = patch.sign(secret)
+    assert sig != ""
+    assert patch.signature == sig
+    assert patch.verify(secret) is True
+    assert patch.verify("wrong-secret") is False
+
+    # Modify content and verify it fails
+    patch.after_content = "Hello Modified"
+    assert patch.verify(secret) is False
+
+
+def test_diff_engine_unified_diff() -> None:
+    before = "line1\nline2\n"
+    after = "line1\nline2 changed\n"
+    diff = FileDiffEngine.generate_unified_diff(before, after, "test.txt")
+    assert "line2" in diff
+    assert "line2 changed" in diff
+
+    stats = FileDiffEngine.count_changed_lines(diff)
+    assert stats["added"] == 1
+    assert stats["removed"] == 1
+
+
+def test_diff_engine_validation(tmp_path: Path) -> None:
+    file_path = tmp_path / "test.md"
+    content = "Hello World\n"
+    file_path.write_text(content, encoding="utf-8")
+
+    # Content matches exactly
+    ok, _ = FileDiffEngine.validate_patch_applicable(file_path, content)
+    assert ok is True
+
+    # Content matches with trailing whitespace diff
+    ok, _ = FileDiffEngine.validate_patch_applicable(file_path, "Hello World \n")
+    assert ok is True
+
+    # Content diverged
+    ok, _ = FileDiffEngine.validate_patch_applicable(file_path, "Diverged content")
+    assert ok is False
+
+
+def test_patch_store(tmp_path: Path) -> None:
+    store_file = tmp_path / "patches.jsonl"
+    store = PatchStore(store_file)
+
+    patch = MemoryPatch(
+        file_path="CLAUDE.md",
+        before_content="A",
+        after_content="B",
+        unified_diff="...",
+        rationale="Change A to B",
+    )
+    store.save(patch)
+
+    # Reload store
+    store2 = PatchStore(store_file)
+    retrieved = store2.get(patch.patch_id)
+    assert retrieved is not None
+    assert retrieved.rationale == "Change A to B"
+    assert retrieved.status == "pending"
+
+    # Update status
+    retrieved.status = "applied"
+    store2.update(retrieved)
+
+    # Check update persisted
+    store3 = PatchStore(store_file)
+    retrieved2 = store3.get(patch.patch_id)
+    assert retrieved2 is not None
+    assert retrieved2.status == "applied"
+
+
+def test_occurrence_tracker(tmp_path: Path) -> None:
+    tracker_file = tmp_path / "occurrences.json"
+    tracker = OccurrenceTracker(tracker_file)
+
+    fact = "user_prefers_concise_answers"
+    tracker.record_occurrence(fact, "session_1", "evidence 1")
+    assert tracker.has_reached_threshold(fact, 3) is False
+
+    tracker.record_occurrence(fact, "session_2", "evidence 2")
+    tracker.record_occurrence(fact, "session_3", "evidence 3")
+    assert tracker.has_reached_threshold(fact, 3) is True
+
+    # Reload tracker
+    tracker2 = OccurrenceTracker(tracker_file)
+    assert tracker2.has_reached_threshold(fact, 3) is True
+    assert tracker2.get_count(fact) == 3
+
+
+def test_pii_filter() -> None:
+    pii_filter = MemoryPIIFilter()
+
+    # Clean text
+    res = pii_filter.filter_content("Nothing sensitive here.")
+    assert res.is_clean is True
+
+    # Text containing email and credit card
+    res2 = pii_filter.filter_content("Email me at test@example.com or use card 1234-5678-1234-5678")
+    assert res2.is_clean is False
+    assert "[REDACTED_EMAIL]" in res2.filtered_content
+    assert "[REDACTED_CC]" in res2.filtered_content
+    assert "email" in res2.redaction_types
+    assert "credit_card" in res2.redaction_types
+
+
+def test_file_router() -> None:
+    router = MemoryFileRouter(
+        path_map={"user": "user_prefs.md", "feedback": "feedback.md"},
+        primary_path="CLAUDE.md",
+    )
+
+    # Categorization based on signals
+    assert router.categorize("The user prefers tabs over spaces.") == "user"
+    assert router.categorize("That was a mistake, let's fix it.") == "feedback"
+    assert router.categorize("The database architecture is PostgreSQL.") == "project"
+    assert router.categorize("Random fact about spaceships.") == "general"
+
+    managed = ["CLAUDE.md", "user_prefs.md", "project_info.md"]
+    # Path resolution
+    assert router.resolve_target_path("user", managed) == "user_prefs.md"
+    assert router.resolve_target_path("project", managed) == "project_info.md"
+    assert router.resolve_target_path("general", managed) == "CLAUDE.md"
+
+
+@pytest.mark.asyncio
+async def test_living_memory_orchestration(tmp_path: Path) -> None:
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text("# Core Memory\n", encoding="utf-8")
+
+    # Setup proposer response
+    proposals = [
+        {
+            "file_path": str(claude_md),
+            "section": "Core Memory",
+            "fact_key": "user_prefers_pytest",
+            "proposed_addition": "- The user prefers pytest for tests.",
+            "rationale": "Add pytest preference",
+            "evidence": "Use pytest always",
+        }
+    ]
+    proposer = MockLLM(json.dumps(proposals))
+
+    # LivingMemory instance
+    lm = LivingMemory(
+        paths=[str(claude_md)],
+        proposer=proposer,
+        require_approval=True,
+        store_path=str(tmp_path / "patches.jsonl"),
+        occurrence_path=str(tmp_path / "occurrences.json"),
+        occurrence_threshold=1,  # Lower threshold for testing
+    )
+
+    # 1. Propose patch from session
+    patches = await lm.propose_from_session("session_123", transcript="Use pytest always")
+    assert len(patches) == 1
+    patch = patches[0]
+    assert patch.status == "pending"
+    assert patch.file_path == str(claude_md)
+    assert "- The user prefers pytest for tests." in patch.after_content
+
+    # 2. Check pending list
+    pending = lm.pending_patches()
+    assert len(pending) == 1
+    assert pending[0].patch_id == patch.patch_id
+
+    # 3. Apply patch
+    applied = lm.apply(patch.patch_id)
+    assert applied.status == "applied"
+    assert claude_md.read_text(encoding="utf-8") == "# Core Memory\n- The user prefers pytest for tests.\n"
+
+    # 4. Revert patch
+    reverted = lm.revert(patch.patch_id)
+    assert reverted.status == "reverted"
+    assert claude_md.read_text(encoding="utf-8") == "# Core Memory\n"


### PR DESCRIPTION
Resolves #741

This PR implements the Living Memory Files feature (Issue #741), enabling the agent to observe user sessions, track fact occurrences, route them to appropriate categories/files, and propose signed markdown patches to memory files like CLAUDE.md and memory/*.md with built-in PII redaction and a CLI for reviewing, applying, reverting, and viewing patch logs.