### PR TITLE
feat: Added Verifiable Agents

### DIFF
--- a/examples/audit_verify.py
+++ b/examples/audit_verify.py
@@ -1,0 +1,59 @@
+"""Audit bundle verification example — run after ``examples/verifiable_agent.py``.
+
+Demonstrates the independent-verification story: :func:`verify` only
+depends on the stdlib plus ``cryptography`` (see the module docstring in
+``synapsekit/audit/verifier.py``), so a compliance auditor could run
+this same check on a machine with no SynapseKit installed. Also shows
+replay (confirming tool outputs/retrieval refs/policy hashes) and the
+equivalent CLI commands.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from synapsekit.audit import ReplayEngine
+from synapsekit.audit.verifier import verify
+
+
+def main(bundle_path: str = "support_run.audit.zip") -> int:
+    result = verify(bundle_path)
+
+    print(f"Bundle:          {bundle_path}")
+    print(f"Schema version:  {result.schema_version}")
+    print(f"Records:         {result.record_count}")
+    print(f"Signed batches:  {result.batch_count}")
+    print(f"Verdict:         {result.verdict.value}")
+
+    if not result.ok:
+        print(f"\n{result.verdict.value}:")
+        for error in result.errors:
+            print(f"  - {error}")
+        return 1
+
+    print("\nMATCH — hash chain, Merkle roots, and signatures all check out.")
+
+    # Replay checks provenance (inputs, tool outputs, retrieval refs,
+    # policy hashes) without requiring the LLM to have said the same
+    # thing twice — LLM determinism is explicitly optional.
+    report = ReplayEngine().replay(bundle_path)
+    print(f"\nReplay: {'OK' if report.ok else 'MISMATCHES FOUND'}")
+    print(f"  tool calls checked:  {report.checked_tool_calls}")
+    print(f"  retrievals checked:  {report.checked_retrievals}")
+    print(f"  decisions checked:   {report.checked_decisions}")
+    print(
+        f"  LLM calls skipped:   {report.skipped_llm_calls} (non-deterministic, not required to match)"
+    )
+    for mismatch in report.mismatches:
+        print(f"  - [{mismatch.kind}] {mismatch.event_id}: {mismatch.reason}")
+
+    return 0
+
+
+# Equivalent CLI:
+#   synapsekit audit verify support_run.audit.zip
+#   synapsekit audit replay support_run.audit.zip
+
+if __name__ == "__main__":
+    path = sys.argv[1] if len(sys.argv) > 1 else "support_run.audit.zip"
+    sys.exit(main(path))

--- a/examples/verifiable_agent.py
+++ b/examples/verifiable_agent.py
@@ -1,0 +1,68 @@
+"""Verifiable audit trail example — wrap an agent, sign, export, verify.
+
+Wraps a plain agent object with :class:`~synapsekit.audit.VerifiableAgent`
+so every call is captured into a hash-chained trace, batch-signs the
+trace with Ed25519, redacts PII before it's ever hashed, and exports a
+portable ``.zip`` bundle that can be verified independently — see
+``examples/audit_verify.py`` for the verification side.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from synapsekit.audit import (
+    AuditTracer,
+    EventKind,
+    PIIRedactor,
+    SigningPolicy,
+    VerifiableAgent,
+    export_audit_bundle,
+)
+
+
+class SupportAgent:
+    """A plain agent — no SynapseKit imports, no audit-specific code at all."""
+
+    async def retrieve(self, query: str) -> list[str]:
+        return [f"kb-article-about-{query.replace(' ', '-')}"]
+
+    async def generate(self, prompt: str) -> str:
+        return f"Here's what I found for: {prompt}"
+
+    async def call_tool(self, name: str, **kwargs: object) -> str:
+        if name == "send_email":
+            return f"sent to {kwargs.get('to')}"
+        raise ValueError(f"unknown tool: {name}")
+
+
+async def main() -> None:
+    tracer = AuditTracer()
+    # PII is redacted BEFORE anything is hashed — see redact.py's
+    # docstring for why the ordering matters and can't be reversed later.
+    redactor = PIIRedactor()
+
+    agent = VerifiableAgent(SupportAgent(), tracer=tracer, redactor=redactor)
+
+    docs = await agent.retrieve("refund policy")
+    answer = await agent.generate(f"Summarize: {docs}")
+    await agent.call_tool("send_email", to="alice@example.com", body=answer)
+
+    print(f"Captured {len(tracer)} audit records for this run.")
+
+    records = tracer.drain()
+    policy = SigningPolicy.ed25519()  # generates a fresh Ed25519 keypair
+    bundle_path = export_audit_bundle(records, policy, "support_run.audit.zip")
+    print(f"Exported signed bundle: {bundle_path}")
+
+    for record in records:
+        print(f"  [{record.kind}] {record.event_id[:8]} parent={str(record.parent_id or '-')[:8]}")
+
+    tool_calls = [r for r in records if r.kind == EventKind.TOOL_CALL.value]
+    print(
+        f"\n{len(tool_calls)} tool call(s) recorded; PII in their payloads has already been redacted."
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -434,7 +434,7 @@ snowflake-connector-python = "snowflake"
 "piper-tts" = "piper"
 
 [tool.deptry.per_rule_ignores]
-DEP001 = ["sqlalchemy", "pydantic", "aiohttp", "opentelemetry", "whisper", "botocore", "aiomcache", "nest_asyncio", "huggingface_hub", "serpapi", "weaviate", "uvicorn", "starlette", "tomli", "pyttsx3", "faster_whisper", "sounddevice", "soundfile", "aiokafka", "typesense", "prometheus_client", "sentence_transformers", "llama_cpp", "ragatouille", "torch"]
+DEP001 = ["sqlalchemy", "pydantic", "aiohttp", "opentelemetry", "whisper", "botocore", "aiomcache", "nest_asyncio", "huggingface_hub", "serpapi", "weaviate", "uvicorn", "starlette", "tomli", "pyttsx3", "faster_whisper", "sounddevice", "soundfile", "aiokafka", "kafka", "typesense", "prometheus_client", "sentence_transformers", "llama_cpp", "ragatouille", "torch"]
 DEP002 = ["numpy", "rank-bm25", "beautifulsoup4", "lxml", "pillow", "pyasn1", "faiss-cpu", "google-generativeai", "tavily-python", "youtube-search-python", "psycopg", "google-search-results", "discord.py", "google-auth", "weaviate-client", "pymilvus", "lancedb", "pgvector", "slack-sdk", "supabase", "pymongo", "azure-storage-blob", "elasticsearch", "tzdata", "torchaudio", "python-multipart", "z3-solver", "pyautogui"]
 DEP003 = ["sqlalchemy", "botocore", "nest_asyncio", "opentelemetry", "starlette", "uvicorn", "tomli", "torch"]
 DEP004 = ["pydantic"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,10 @@ dependencies = [
     # Pin to patched versions for high-severity advisories
     "pillow>=12.2.0",
     "pyasn1>=0.6.3",
+    # Ed25519 is the default (and only always-available) audit-bundle
+    # signing algorithm — it must work out of the box, not only via an
+    # opt-in extra.
+    "cryptography>=42",
 ]
 
 [project.urls]

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -151,6 +151,25 @@ from .agents import (
     requires_human_confirmation,
     tool,
 )
+from .audit import (
+    AuditMetrics,
+    AuditRecord,
+    AuditSink,
+    AuditTracer,
+    AuditVerificationError,
+    EventKind,
+    FileAuditSink,
+    MerkleHasher,
+    ReplayEngine,
+    Signature,
+    SigningPolicy,
+    Verdict,
+    VerifiableAgent,
+    VerificationResult,
+    export_audit_bundle,
+)
+from .audit import PIIRedactor as AuditPIIRedactor
+from .audit import verify as verify_audit_bundle
 from .embeddings.backend import SynapsekitEmbeddings
 from .evaluation import (
     EmailAlertSink,
@@ -915,6 +934,24 @@ __all__ = [
     "OPENAI_TRAINING_RATE_PER_M_TOKENS",
     "ANTHROPIC_TRAINING_RATE_PER_M_TOKENS",
     "ContinuousTrainer",
+    # Verifiable audit trail
+    "AuditTracer",
+    "AuditRecord",
+    "EventKind",
+    "Verdict",
+    "Signature",
+    "VerificationResult",
+    "AuditVerificationError",
+    "SigningPolicy",
+    "MerkleHasher",
+    "export_audit_bundle",
+    "verify_audit_bundle",
+    "ReplayEngine",
+    "AuditSink",
+    "FileAuditSink",
+    "AuditMetrics",
+    "VerifiableAgent",
+    "AuditPIIRedactor",
 ]
 
 # Lazy imports for optional backends

--- a/src/synapsekit/audit/__init__.py
+++ b/src/synapsekit/audit/__init__.py
@@ -1,0 +1,152 @@
+"""Verifiable, cryptographically signed audit trails for SynapseKit.
+
+Not a logger — a tamper-evident provenance system. Every LLM call, tool
+invocation, retrieval, memory access, and agent decision can be recorded
+into a hash-chained trace, batch-signed with Ed25519 (or a pluggable
+KMS/BYOK provider), exported as a portable bundle, and independently
+verified without SynapseKit installed.
+
+Typical flow::
+
+    from synapsekit.audit import AuditTracer, EventKind, SigningPolicy, export_audit_bundle
+
+    tracer = AuditTracer()
+    tracer.record(EventKind.LLM_CALL, {"model": "gpt-4o-mini", "prompt": "hi"})
+
+    policy = SigningPolicy.ed25519()
+    export_audit_bundle(tracer.drain(), policy, "run.audit.zip")
+
+    from synapsekit.audit import verify
+    result = verify("run.audit.zip")
+    assert result.verdict == "MATCH"
+"""
+
+from __future__ import annotations
+
+from .bundle import BUNDLE_SCHEMA_VERSION, export_audit_bundle, export_selective_bundle
+from .merkle import MerkleHasher, MerkleProof
+from .metrics import AuditMetrics
+from .otel import OTelAuditExporter, record_to_span_dict
+from .redact import (
+    DEFAULT_DETECTORS,
+    CreditCardDetector,
+    EmailDetector,
+    IPAddressDetector,
+    PhoneDetector,
+    PIIRedactor,
+    RegexDetector,
+    SSNDetector,
+)
+from .replay import ReplayEngine, ReplayMismatch, ReplayReport
+from .serializer import DeterministicSerializer, canonical_json, hash_value
+from .signer import (
+    AWSKMSSigningProvider,
+    AzureKeyVaultSigningProvider,
+    BYOKSigningProvider,
+    Ed25519SigningProvider,
+    GCPKMSSigningProvider,
+    KMSSigningProvider,
+    SigningPolicy,
+    SigningProvider,
+    verify_signature,
+)
+from .sink import (
+    AuditSink,
+    FileAuditSink,
+    KafkaAuditSink,
+    MultiSink,
+    OTelAuditSink,
+    S3AuditSink,
+    SignedBatch,
+)
+from .trace import AuditTracer, ChainIntegrityError, compute_payload_hash, compute_record_hash
+from .types import (
+    GENESIS_HASH,
+    SCHEMA_VERSION,
+    AuditRecord,
+    AuditVerificationError,
+    EventKind,
+    RedactionStatus,
+    Signature,
+    Verdict,
+    VerificationResult,
+    deep_freeze,
+    deep_unfreeze,
+)
+from .verifier import LoadedBundle, load_bundle, verify
+from .wrapper import VerifiableAgent, audited, infer_kind_pair
+
+__all__ = [
+    # types
+    "AuditRecord",
+    "EventKind",
+    "RedactionStatus",
+    "Signature",
+    "Verdict",
+    "VerificationResult",
+    "AuditVerificationError",
+    "SCHEMA_VERSION",
+    "GENESIS_HASH",
+    "deep_freeze",
+    "deep_unfreeze",
+    # serializer
+    "DeterministicSerializer",
+    "canonical_json",
+    "hash_value",
+    # trace
+    "AuditTracer",
+    "ChainIntegrityError",
+    "compute_record_hash",
+    "compute_payload_hash",
+    # merkle
+    "MerkleHasher",
+    "MerkleProof",
+    # signer
+    "SigningPolicy",
+    "SigningProvider",
+    "Ed25519SigningProvider",
+    "BYOKSigningProvider",
+    "KMSSigningProvider",
+    "AWSKMSSigningProvider",
+    "AzureKeyVaultSigningProvider",
+    "GCPKMSSigningProvider",
+    "verify_signature",
+    # redact
+    "PIIRedactor",
+    "RegexDetector",
+    "DEFAULT_DETECTORS",
+    "EmailDetector",
+    "PhoneDetector",
+    "SSNDetector",
+    "CreditCardDetector",
+    "IPAddressDetector",
+    # bundle
+    "export_audit_bundle",
+    "export_selective_bundle",
+    "BUNDLE_SCHEMA_VERSION",
+    # verifier
+    "verify",
+    "load_bundle",
+    "LoadedBundle",
+    # replay
+    "ReplayEngine",
+    "ReplayReport",
+    "ReplayMismatch",
+    # sinks
+    "AuditSink",
+    "FileAuditSink",
+    "S3AuditSink",
+    "KafkaAuditSink",
+    "OTelAuditSink",
+    "MultiSink",
+    "SignedBatch",
+    # otel
+    "OTelAuditExporter",
+    "record_to_span_dict",
+    # metrics
+    "AuditMetrics",
+    # wrapper
+    "VerifiableAgent",
+    "audited",
+    "infer_kind_pair",
+]

--- a/src/synapsekit/audit/bundle.py
+++ b/src/synapsekit/audit/bundle.py
@@ -35,7 +35,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from .merkle import MerkleHasher
+from .merkle import MerkleHasher, hash_leaf
 from .serializer import hash_value
 from .signer import SigningPolicy
 from .types import SCHEMA_VERSION, AuditRecord, Signature
@@ -64,7 +64,7 @@ class _Batch:
 
 
 def _sign_batch(records: list[AuditRecord], policy: SigningPolicy, *, start_index: int) -> _Batch:
-    leaves = [r.hash for r in records]
+    leaves = [hash_leaf(r.hash) for r in records]
     root = MerkleHasher.root(leaves)
     signature = policy.sign_batch(
         root, start_index=start_index, end_index=start_index + len(records) - 1

--- a/src/synapsekit/audit/bundle.py
+++ b/src/synapsekit/audit/bundle.py
@@ -1,0 +1,294 @@
+"""Audit bundle export — a portable, independently verifiable zip archive.
+
+Bundle format (open specification — see :mod:`synapsekit.audit.verifier`
+for a reader that only needs stdlib + ``cryptography``, not SynapseKit):
+
+    bundle.zip
+    ├── manifest.json     schema_version, run metadata, key registry, signed
+    ├── trace.jsonl       one canonical-JSON AuditRecord per line, in order
+    ├── hashes.merkle     JSON: per-batch leaf hash lists + computed roots
+    └── signatures.json   JSON list of Signature dicts (one per batch)
+
+A "batch" is a contiguous slice of ``trace.jsonl`` whose leaf hashes were
+combined into one Merkle root and signed once — see
+:mod:`synapsekit.audit.signer`. Multiple batches (each potentially signed
+by a different key) support key rotation within a single bundle.
+
+``manifest.json``'s own metadata (record_count, run_ids, created_at, the
+key registry) is itself hashed and signed by every key used in the
+export (``manifest_hash`` / ``manifest_signatures``) — a batch signature
+only covers its Merkle root, so without this, an attacker could alter
+manifest metadata freely without invalidating anything.
+
+Zip entries use a fixed timestamp so that exporting the same records
+twice produces byte-identical archives (aside from the inherently
+time-varying ``created_at``/``signed_at`` content fields).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .merkle import MerkleHasher
+from .serializer import hash_value
+from .signer import SigningPolicy
+from .types import SCHEMA_VERSION, AuditRecord, Signature
+
+if TYPE_CHECKING:
+    from .metrics import AuditMetrics
+
+BUNDLE_SCHEMA_VERSION = SCHEMA_VERSION
+
+#: Fixed so re-exporting identical content produces byte-identical zips —
+#: real value is irrelevant, only needs to be a valid DOS date/time.
+_FIXED_ZIP_DATE_TIME = (1980, 1, 1, 0, 0, 0)
+
+
+def _write_zip_entry(zf: zipfile.ZipFile, name: str, data: str) -> None:
+    info = zipfile.ZipInfo(name, date_time=_FIXED_ZIP_DATE_TIME)
+    info.compress_type = zipfile.ZIP_DEFLATED
+    zf.writestr(info, data)
+
+
+@dataclass
+class _Batch:
+    records: list[AuditRecord]
+    signature: Signature
+    leaves: list[str]
+
+
+def _sign_batch(records: list[AuditRecord], policy: SigningPolicy, *, start_index: int) -> _Batch:
+    leaves = [r.hash for r in records]
+    root = MerkleHasher.root(leaves)
+    signature = policy.sign_batch(
+        root, start_index=start_index, end_index=start_index + len(records) - 1
+    )
+    return _Batch(records=records, signature=signature, leaves=leaves)
+
+
+def _chunk(records: list[AuditRecord], batch_size: int | None) -> list[list[AuditRecord]]:
+    if not batch_size or batch_size >= len(records):
+        return [records] if records else []
+    return [records[i : i + batch_size] for i in range(0, len(records), batch_size)]
+
+
+def _sign_manifest(manifest: dict[str, Any], policies: list[SigningPolicy]) -> None:
+    """Hash ``manifest``'s current content and sign it with every distinct
+    policy used in this export, mutating ``manifest`` in place to add
+    ``manifest_hash``/``manifest_signatures``. Must be called *after* all
+    other manifest fields are set and *before* the manifest is written out.
+    """
+    manifest_hash = hash_value(manifest)
+    seen: dict[str, SigningPolicy] = {}
+    for policy in policies:
+        seen.setdefault(policy.provider.key_id, policy)
+    manifest["manifest_hash"] = manifest_hash
+    manifest["manifest_signatures"] = [p.sign_manifest_hash(manifest_hash) for p in seen.values()]
+
+
+def export_audit_bundle(
+    records: list[AuditRecord],
+    signing_policy: SigningPolicy | list[tuple[list[AuditRecord], SigningPolicy]],
+    output_path: str | Path,
+    *,
+    batch_size: int | None = None,
+    metrics: AuditMetrics | None = None,
+) -> Path:
+    """Export ``records`` as a signed, portable audit bundle.
+
+    Two calling conventions:
+
+    - ``export_audit_bundle(records, policy, path, batch_size=100)`` —
+      chunk ``records`` into batches of ``batch_size`` and sign each with
+      the same policy.
+    - ``export_audit_bundle([], [(batch1, policy_a), (batch2, policy_b)],
+      path)`` — pass pre-split ``(records, policy)`` batches explicitly,
+      e.g. to simulate/exercise key rotation across a single export.
+    """
+    from .metrics import default_metrics
+
+    m = metrics if metrics is not None else default_metrics
+
+    try:
+        if isinstance(signing_policy, SigningPolicy):
+            batches_in = [(chunk, signing_policy) for chunk in _chunk(records, batch_size)]
+        else:
+            batches_in = signing_policy
+
+        all_records: list[AuditRecord] = []
+        batches: list[_Batch] = []
+        index = 0
+        for chunk, policy in batches_in:
+            if not chunk:
+                continue
+            batch = _sign_batch(chunk, policy, start_index=index)
+            batches.append(batch)
+            all_records.extend(chunk)
+            index += len(chunk)
+
+        # Manifest metadata must be authenticated even for a zero-record
+        # export (no batches ever got signed) — fall back to the
+        # single-policy calling convention's key if that's what we have.
+        manifest_policies = [policy for _, policy in batches_in if policy is not None]
+        if not manifest_policies and isinstance(signing_policy, SigningPolicy):
+            manifest_policies = [signing_policy]
+
+        keys: dict[str, dict[str, str]] = {}
+        for batch in batches:
+            sig = batch.signature
+            keys[sig.key_id] = {"algorithm": sig.algorithm, "public_key_b64": sig.public_key_b64}
+        for policy in manifest_policies:
+            keys.setdefault(
+                policy.provider.key_id,
+                {
+                    "algorithm": policy.provider.algorithm,
+                    "public_key_b64": base64.b64encode(policy.provider.public_key_bytes()).decode(
+                        "ascii"
+                    ),
+                },
+            )
+
+        run_ids = sorted({r.run_id for r in all_records})
+        manifest: dict[str, Any] = {
+            "schema_version": BUNDLE_SCHEMA_VERSION,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "record_count": len(all_records),
+            "batch_count": len(batches),
+            "run_ids": run_ids,
+            "keys": keys,
+        }
+        _sign_manifest(manifest, manifest_policies)
+
+        hashes_doc = {
+            "batches": [
+                {
+                    "start_index": b.signature.start_index,
+                    "end_index": b.signature.end_index,
+                    "leaves": b.leaves,
+                    "merkle_root": b.signature.merkle_root,
+                }
+                for b in batches
+            ]
+        }
+
+        signatures_doc = [b.signature.to_dict() for b in batches]
+
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            _write_zip_entry(
+                zf,
+                "trace.jsonl",
+                "\n".join(json.dumps(r.to_dict(), sort_keys=True) for r in all_records)
+                + ("\n" if all_records else ""),
+            )
+            _write_zip_entry(zf, "hashes.merkle", json.dumps(hashes_doc, indent=2, sort_keys=True))
+            _write_zip_entry(
+                zf, "signatures.json", json.dumps(signatures_doc, indent=2, sort_keys=True)
+            )
+            _write_zip_entry(zf, "manifest.json", json.dumps(manifest, indent=2, sort_keys=True))
+    except Exception:
+        m.record_bundle_export(ok=False)
+        raise
+
+    m.record_bundle_export(ok=True)
+    return output_path
+
+
+def export_selective_bundle(
+    source_bundle: str | Path,
+    output_path: str | Path,
+    *,
+    kinds: list[str] | None = None,
+    run_ids: list[str] | None = None,
+    metrics: AuditMetrics | None = None,
+) -> Path:
+    """Re-export a subset of an existing bundle's records.
+
+    Dropping most of a run's records would normally break the per-batch
+    "recompute all leaves, recompute the root" check in
+    :mod:`synapsekit.audit.verifier`, since it assumes every record in
+    the signed range is present. Instead, each kept record carries its
+    own Merkle *inclusion proof* against the original signed root
+    (``signatures.json`` is copied through unchanged), so a verifier can
+    confirm each disclosed record really was part of a signed batch
+    without needing the omitted records at all — no re-signing required.
+
+    The original, still-validly-signed manifest is preserved verbatim
+    under ``original_manifest`` so its metadata (record_count, run_ids,
+    created_at, key registry) remains authenticated; we have no signing
+    key available at this point to re-sign a new manifest, so the
+    selective-disclosure wrapper fields (``kept_event_ids``, the reduced
+    ``record_count``) are themselves not separately signed — only which
+    subset was chosen is unauthenticated, not the disclosed content
+    itself (that's still fully covered by per-record Merkle proofs).
+    """
+    from .metrics import default_metrics
+    from .verifier import load_bundle
+
+    m = metrics if metrics is not None else default_metrics
+
+    try:
+        loaded = load_bundle(source_bundle)
+        index_by_event = {r.event_id: i for i, r in enumerate(loaded.records)}
+        batches = loaded.hashes_doc.get("batches", [])
+
+        kept = loaded.records
+        if kinds is not None:
+            kept = [r for r in kept if r.kind in kinds]
+        if run_ids is not None:
+            kept = [r for r in kept if r.run_id in run_ids]
+
+        proofs = []
+        for rec in kept:
+            gi = index_by_event[rec.event_id]
+            batch = next(b for b in batches if b["start_index"] <= gi <= b["end_index"])
+            local_index = gi - batch["start_index"]
+            proof = MerkleHasher.proof(batch["leaves"], local_index)
+            proofs.append(
+                {
+                    "event_id": rec.event_id,
+                    "batch_start": batch["start_index"],
+                    "batch_end": batch["end_index"],
+                    "leaf": proof.leaf,
+                    "siblings": proof.siblings,
+                    "sibling_is_right": proof.sibling_is_right,
+                }
+            )
+
+        hashes_doc = {"selective_disclosure": True, "proofs": proofs}
+        manifest = {
+            "schema_version": loaded.manifest.get("schema_version"),
+            "record_count": len(kept),
+            "selective_disclosure": True,
+            "kept_event_ids": sorted(r.event_id for r in kept),
+            "keys": loaded.manifest.get("keys", {}),
+            "original_manifest": loaded.manifest,
+        }
+
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            _write_zip_entry(
+                zf,
+                "trace.jsonl",
+                "\n".join(json.dumps(r.to_dict(), sort_keys=True) for r in kept)
+                + ("\n" if kept else ""),
+            )
+            _write_zip_entry(zf, "hashes.merkle", json.dumps(hashes_doc, indent=2, sort_keys=True))
+            _write_zip_entry(
+                zf, "signatures.json", json.dumps(loaded.signatures_doc, indent=2, sort_keys=True)
+            )
+            _write_zip_entry(zf, "manifest.json", json.dumps(manifest, indent=2, sort_keys=True))
+    except Exception:
+        m.record_bundle_export(ok=False)
+        raise
+
+    m.record_bundle_export(ok=True)
+    return output_path

--- a/src/synapsekit/audit/merkle.py
+++ b/src/synapsekit/audit/merkle.py
@@ -1,0 +1,101 @@
+"""Merkle tree over record hashes — batch signing signs a root, not every record.
+
+Records are hashed individually (their ``hash`` field). At flush time we
+build a Merkle tree over those leaf hashes and sign only the root,
+turning O(n) signature operations into O(1) per batch while still making
+every record independently provable via a Merkle proof.
+
+Uses the RFC 6962 (Certificate Transparency) tree construction: leaves
+are never duplicated to pad an odd count, and internal-node hashes are
+domain-separated from leaf hashes with a leading 0x01 byte. A naive
+"duplicate the last leaf" construction (as used by early Bitcoin) makes
+a tree with N leaves indistinguishable from a differently-shaped tree
+with N+1 leaves where the last is a copy of the previous one — the class
+of bug behind CVE-2012-2459. The recursive split here never produces
+that ambiguity.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+#: Domain-separates internal node hashes from leaf hashes so a node hash
+#: can never be replayed as if it were itself a valid leaf.
+_NODE_DOMAIN = b"\x01"
+
+
+def _hash_pair(left: str, right: str) -> str:
+    return hashlib.sha256(_NODE_DOMAIN + bytes.fromhex(left) + bytes.fromhex(right)).hexdigest()
+
+
+def _largest_power_of_two_less_than(n: int) -> int:
+    k = 1
+    while k * 2 < n:
+        k *= 2
+    return k
+
+
+@dataclass(frozen=True)
+class MerkleProof:
+    """Sibling hashes (bottom-up) plus left/right side markers for a leaf."""
+
+    leaf: str
+    siblings: list[str]
+    # True if the sibling at this level is on the right of our node.
+    sibling_is_right: list[bool]
+
+
+class MerkleHasher:
+    """Builds Merkle roots and inclusion proofs over hex leaf hashes.
+
+    Handles 0 (empty root) and 1 (root == leaf) leaf batches as special
+    cases; everything else uses the RFC 6962 recursive split so no leaf
+    is ever duplicated regardless of batch size.
+    """
+
+    EMPTY_ROOT = hashlib.sha256(b"").hexdigest()
+
+    @classmethod
+    def root(cls, leaves: list[str]) -> str:
+        return cls._mth(leaves)
+
+    @classmethod
+    def _mth(cls, leaves: list[str]) -> str:
+        n = len(leaves)
+        if n == 0:
+            return cls.EMPTY_ROOT
+        if n == 1:
+            return leaves[0]
+        k = _largest_power_of_two_less_than(n)
+        left = cls._mth(leaves[:k])
+        right = cls._mth(leaves[k:])
+        return _hash_pair(left, right)
+
+    @classmethod
+    def proof(cls, leaves: list[str], index: int) -> MerkleProof:
+        if not leaves:
+            raise ValueError("cannot build a proof for an empty tree")
+        if not (0 <= index < len(leaves)):
+            raise IndexError(f"index {index} out of range for {len(leaves)} leaves")
+        siblings, sides = cls._path(leaves, index)
+        return MerkleProof(leaf=leaves[index], siblings=siblings, sibling_is_right=sides)
+
+    @classmethod
+    def _path(cls, leaves: list[str], m: int) -> tuple[list[str], list[bool]]:
+        n = len(leaves)
+        if n == 1:
+            return [], []
+        k = _largest_power_of_two_less_than(n)
+        if m < k:
+            siblings, sides = cls._path(leaves[:k], m)
+            return [*siblings, cls._mth(leaves[k:])], [*sides, True]
+        siblings, sides = cls._path(leaves[k:], m - k)
+        return [*siblings, cls._mth(leaves[:k])], [*sides, False]
+
+    @classmethod
+    def verify(cls, proof: MerkleProof, root: str) -> bool:
+        node = proof.leaf
+        for sibling, is_right in zip(proof.siblings, proof.sibling_is_right, strict=True):
+            node = _hash_pair(node, sibling) if is_right else _hash_pair(sibling, node)
+        return node == root

--- a/src/synapsekit/audit/merkle.py
+++ b/src/synapsekit/audit/merkle.py
@@ -13,6 +13,14 @@ a tree with N leaves indistinguishable from a differently-shaped tree
 with N+1 leaves where the last is a copy of the previous one — the class
 of bug behind CVE-2012-2459. The recursive split here never produces
 that ambiguity.
+
+:class:`MerkleHasher` itself builds a tree over already-computed hex
+leaf hashes (it doesn't know or care what a "leaf" represents) — use
+:func:`hash_leaf` to turn a record's own ``hash`` field into the actual
+RFC 6962 leaf hash (with the 0x00 domain-separation prefix) before
+handing it to :meth:`MerkleHasher.root`/:meth:`MerkleHasher.proof`. That
+keeps a leaf hash from ever being replayable as an internal node hash
+(0x01-prefixed) or vice versa.
 """
 
 from __future__ import annotations
@@ -23,6 +31,22 @@ from dataclasses import dataclass
 #: Domain-separates internal node hashes from leaf hashes so a node hash
 #: can never be replayed as if it were itself a valid leaf.
 _NODE_DOMAIN = b"\x01"
+
+#: Domain-separates leaf hashes from internal node hashes (RFC 6962 §2.1
+#: uses 0x00 for leaves and 0x01 for internal nodes) so a raw record hash
+#: can never be replayed as if it were itself an internal node hash.
+_LEAF_DOMAIN = b"\x00"
+
+
+def hash_leaf(value: str) -> str:
+    """RFC 6962 leaf hash: ``SHA256(0x00 || value)`` over a hex-encoded input.
+
+    Call this on a record's ``hash`` field before passing it to
+    :meth:`MerkleHasher.root`/:meth:`MerkleHasher.proof` — those methods
+    treat their inputs as opaque, already-domain-separated leaf hashes
+    and do not apply this prefix themselves.
+    """
+    return hashlib.sha256(_LEAF_DOMAIN + bytes.fromhex(value)).hexdigest()
 
 
 def _hash_pair(left: str, right: str) -> str:

--- a/src/synapsekit/audit/metrics.py
+++ b/src/synapsekit/audit/metrics.py
@@ -1,0 +1,113 @@
+"""Prometheus metrics for the audit subsystem.
+
+Mirrors the lazy-optional pattern in
+:class:`synapsekit.observability.metrics.PrometheusMetrics` — a separate,
+small counter set rather than bolting more labels onto the general LLM
+cost/latency metrics, since audit events (signing, export, verification,
+redaction) aren't per-model.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    from prometheus_client import CollectorRegistry as PromCollectorRegistry
+    from prometheus_client import Counter as PromCounter
+
+    _PROMETHEUS_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    PromCollectorRegistry = None  # type: ignore[assignment,misc]
+    PromCounter = None  # type: ignore[assignment,misc]
+    _PROMETHEUS_AVAILABLE = False
+
+
+class AuditMetrics:
+    """Exposes:
+
+    - ``audit_records_signed_total``
+    - ``audit_bundle_exports_total``
+    - ``audit_verification_failures_total``
+    - ``audit_redactions_total``
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = True,
+        namespace: str = "synapsekit",
+        registry: Any | None = None,
+    ) -> None:
+        self.enabled = bool(enabled) and _PROMETHEUS_AVAILABLE
+        self._namespace = namespace
+        self._registry = registry
+        if self._registry is None and self.enabled and PromCollectorRegistry is not None:
+            self._registry = PromCollectorRegistry()
+
+        self._records_signed: Any | None = None
+        self._bundle_exports: Any | None = None
+        self._verification_failures: Any | None = None
+        self._redactions: Any | None = None
+
+        if self.enabled:
+            self._records_signed = PromCounter(
+                "audit_records_signed_total",
+                "Total audit records covered by a completed batch signature.",
+                ["algorithm"],
+                namespace=self._namespace,
+                registry=self._registry,
+            )
+            self._bundle_exports = PromCounter(
+                "audit_bundle_exports_total",
+                "Total audit bundles exported.",
+                ["result"],
+                namespace=self._namespace,
+                registry=self._registry,
+            )
+            self._verification_failures = PromCounter(
+                "audit_verification_failures_total",
+                "Total bundle verification failures, by reason category.",
+                ["reason"],
+                namespace=self._namespace,
+                registry=self._registry,
+            )
+            self._redactions = PromCounter(
+                "audit_redactions_total",
+                "Total PII redactions applied before hashing.",
+                ["label"],
+                namespace=self._namespace,
+                registry=self._registry,
+            )
+
+    def record_signed_batch(self, *, algorithm: str, count: int) -> None:
+        if not self.enabled or self._records_signed is None:
+            return
+        with suppress(Exception):
+            self._records_signed.labels(algorithm=str(algorithm)).inc(int(count))
+
+    def record_bundle_export(self, *, ok: bool = True) -> None:
+        if not self.enabled or self._bundle_exports is None:
+            return
+        with suppress(Exception):
+            self._bundle_exports.labels(result="success" if ok else "failure").inc()
+
+    def record_verification_failure(self, *, reason: str) -> None:
+        if not self.enabled or self._verification_failures is None:
+            return
+        with suppress(Exception):
+            self._verification_failures.labels(reason=str(reason)).inc()
+
+    def record_redaction(self, *, label: str, count: int = 1) -> None:
+        if not self.enabled or self._redactions is None:
+            return
+        with suppress(Exception):
+            self._redactions.labels(label=str(label)).inc(int(count))
+
+
+#: Shared instance used by :mod:`signer`, :mod:`bundle`, :mod:`verifier`,
+#: and :mod:`redact` whenever a caller doesn't supply their own —
+#: metrics fire automatically without every call site needing to wire
+#: one up explicitly. Pass an explicit ``metrics=`` argument anywhere
+#: this is used as a default to override it (e.g. a custom registry).
+default_metrics = AuditMetrics()

--- a/src/synapsekit/audit/otel.py
+++ b/src/synapsekit/audit/otel.py
@@ -1,0 +1,104 @@
+"""OpenTelemetry mapping — every AuditRecord maps cleanly to a span/event.
+
+Falls back to a no-op when the ``opentelemetry`` packages aren't
+installed, matching the lazy-optional-dependency pattern used by
+:mod:`synapsekit.observability.otel`. Works with any OTLP-compatible
+backend (Jaeger, Honeycomb, Tempo, ...).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .serializer import canonical_json
+from .types import AuditRecord
+
+try:  # pragma: no cover - optional dependency
+    from opentelemetry import trace as _otel_trace
+
+    _OTEL_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    _OTEL_AVAILABLE = False
+
+
+def _span_attribute_value(value: Any) -> Any:
+    """OTel span attributes must be a primitive or a homogeneous sequence
+    of primitives — anything else (nested dict/list/None) is JSON-encoded
+    to a string rather than silently dropped, so no payload data is lost
+    on export.
+    """
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    return canonical_json(value).decode("utf-8")
+
+
+def record_to_span_dict(record: AuditRecord) -> dict[str, Any]:
+    """Map one AuditRecord to an OTel-shaped span dict.
+
+    ``trace_id`` is the run id, ``span_id`` the event id, and
+    ``parent_span_id`` the parent event id — audit runs are already a
+    causal DAG, so this mapping is structure-preserving in both
+    directions (a span-shaped view can be traced back to the exact
+    record it came from via ``span_id``). The audit bundle remains
+    authoritative — OTel is an export layer only, never the source of
+    truth (a later verifier can confirm an exported span's
+    ``audit.hash``/``audit.payload_hash`` attributes still match the
+    signed record with that ``span_id``).
+    """
+    return {
+        "name": f"audit.{record.kind}",
+        "trace_id": record.run_id,
+        "span_id": record.event_id,
+        "parent_span_id": record.parent_id,
+        "start_time": record.timestamp.isoformat(),
+        "attributes": {
+            "audit.kind": record.kind,
+            "audit.actor": record.actor,
+            "audit.hash": record.hash,
+            "audit.payload_hash": record.payload_hash,
+            "audit.prev_hash": record.prev_hash,
+            "audit.schema_version": record.schema_version,
+            "audit.redaction_status": record.redaction_status,
+            **{
+                f"audit.payload.{k}": _span_attribute_value(v)
+                for k, v in record.payload.items()
+                if v is not None
+            },
+        },
+    }
+
+
+class OTelAuditExporter:
+    """Exports audit records as OTel spans when the SDK is available.
+
+    Usage::
+
+        exporter = OTelAuditExporter(service_name="my-agent")
+        exporter.export_records(records)
+    """
+
+    def __init__(self, service_name: str = "synapsekit-audit", tracer_provider: Any = None) -> None:
+        self.service_name = service_name
+        self._tracer = None
+        if _OTEL_AVAILABLE:
+            provider = tracer_provider or _otel_trace.get_tracer_provider()
+            self._tracer = _otel_trace.get_tracer(service_name, tracer_provider=provider)
+
+    @property
+    def available(self) -> bool:
+        return self._tracer is not None
+
+    def export_record(self, record: AuditRecord) -> dict[str, Any]:
+        span_dict = record_to_span_dict(record)
+        if self._tracer is not None:
+            with self._tracer.start_as_current_span(span_dict["name"]) as span:
+                for key, value in span_dict["attributes"].items():
+                    span.set_attribute(key, value)
+        return span_dict
+
+    def export_records(self, records: list[AuditRecord]) -> list[dict[str, Any]]:
+        return [self.export_record(r) for r in records]
+
+
+def export_records(exporter: OTelAuditExporter, records: list[AuditRecord]) -> list[dict[str, Any]]:
+    return exporter.export_records(records)

--- a/src/synapsekit/audit/redact.py
+++ b/src/synapsekit/audit/redact.py
@@ -135,7 +135,7 @@ class PIIRedactor:
 
     def redact_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Recursively redact all string values in a payload dict."""
-        return self._redact_value(payload)  # type: ignore[return-value]
+        return self._redact_value(payload)  # type: ignore[no-any-return]
 
     def _redact_value(self, value: Any) -> Any:
         if isinstance(value, str):

--- a/src/synapsekit/audit/redact.py
+++ b/src/synapsekit/audit/redact.py
@@ -1,0 +1,149 @@
+"""PII redaction — MUST run before hashing.
+
+Redaction is a lossy, irreversible rewrite of a record's payload. It has
+to happen *before* :func:`synapsekit.audit.trace.compute_record_hash`
+runs, not after: the hash chain commits to whatever payload it was given,
+so if you redact after hashing, the recorded hash no longer matches the
+(redacted) content anyone can actually inspect, and the chain becomes
+unverifiable. The tradeoff this creates is deliberate and permanent —
+once a record is hashed on the redacted payload, the pre-redaction
+content is gone forever and cannot be recovered even by SynapseKit
+itself. Decide your detectors before you start tracing, not after.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from typing import Any, Protocol
+
+from .metrics import AuditMetrics, default_metrics
+from .serializer import hash_value
+
+
+class Detector(Protocol):
+    """A PII detector: scans text and returns spans to redact."""
+
+    label: str
+
+    def find(self, text: str) -> list[tuple[int, int]]: ...
+
+
+class RegexDetector:
+    """Detects PII via a compiled regular expression."""
+
+    def __init__(self, label: str, pattern: str) -> None:
+        self.label = label
+        self._pattern = re.compile(pattern)
+
+    def find(self, text: str) -> list[tuple[int, int]]:
+        return [m.span() for m in self._pattern.finditer(text)]
+
+
+EmailDetector = RegexDetector("EMAIL", r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")
+PhoneDetector = RegexDetector(
+    "PHONE", r"(?<!\d)(?:\+?\d{1,3}[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}(?!\d)"
+)
+SSNDetector = RegexDetector("SSN", r"(?<!\d)\d{3}-\d{2}-\d{4}(?!\d)")
+CreditCardDetector = RegexDetector("CREDIT_CARD", r"(?<!\d)(?:\d[ -]?){13,16}(?!\d)")
+IPAddressDetector = RegexDetector(
+    "IP_ADDRESS",
+    r"(?<!\d)(?:(?:25[0-5]|2[0-4]\d|[01]?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d?\d)(?!\d)",
+)
+
+DEFAULT_DETECTORS: list[Detector] = [
+    EmailDetector,
+    PhoneDetector,
+    SSNDetector,
+    CreditCardDetector,
+    IPAddressDetector,
+]
+
+
+class PIIRedactor:
+    """Redacts PII from audit payloads before they enter the hash chain.
+
+    ``ml_detector``, if given, is any callable ``(text) -> list[(start,
+    end, label)]`` — a spot for a statistical/NER-based detector (e.g. a
+    spaCy or Presidio pipeline) to supplement the regex detectors. It's
+    optional and lazily used only when provided, so the base package
+    never requires an ML dependency.
+    """
+
+    def __init__(
+        self,
+        detectors: list[Detector] | None = None,
+        *,
+        ml_detector: Callable[[str], list[tuple[int, int, str]]] | None = None,
+        replacement: str = "[REDACTED:{label}]",
+        metrics: AuditMetrics | None = None,
+    ) -> None:
+        self.detectors = detectors if detectors is not None else list(DEFAULT_DETECTORS)
+        self.ml_detector = ml_detector
+        self.replacement = replacement
+        self.redaction_count = 0
+        self._metrics = metrics if metrics is not None else default_metrics
+
+    def policy_fingerprint(self) -> str:
+        """A stable hash identifying which detectors/config produced a redaction.
+
+        Recorded on each record as ``redaction_policy_hash`` (see
+        :class:`~synapsekit.audit.types.AuditRecord`) so a future
+        compliance verifier can confirm *which* policy was applied to a
+        given record without needing the original unredacted content —
+        v2.0 only stores this metadata, it doesn't enforce anything
+        based on it yet.
+        """
+        return hash_value(
+            {
+                "detectors": sorted(d.label for d in self.detectors),
+                "ml_detector": self.ml_detector is not None,
+                "replacement": self.replacement,
+            }
+        )
+
+    def redact_text(self, text: str) -> str:
+        spans: list[tuple[int, int, str]] = []
+        for detector in self.detectors:
+            for start, end in detector.find(text):
+                spans.append((start, end, detector.label))
+        if self.ml_detector is not None:
+            spans.extend(self.ml_detector(text))
+        if not spans:
+            return text
+
+        # Resolve overlaps by taking the earliest, longest span first.
+        spans.sort(key=lambda s: (s[0], -(s[1] - s[0])))
+        merged: list[tuple[int, int, str]] = []
+        cursor = -1
+        for start, end, label in spans:
+            if start < cursor:
+                continue
+            merged.append((start, end, label))
+            cursor = end
+
+        out: list[str] = []
+        pos = 0
+        for start, end, label in merged:
+            out.append(text[pos:start])
+            out.append(self.replacement.format(label=label))
+            pos = end
+            self.redaction_count += 1
+            self._metrics.record_redaction(label=label)
+        out.append(text[pos:])
+        return "".join(out)
+
+    def redact_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Recursively redact all string values in a payload dict."""
+        return self._redact_value(payload)  # type: ignore[return-value]
+
+    def _redact_value(self, value: Any) -> Any:
+        if isinstance(value, str):
+            return self.redact_text(value)
+        if isinstance(value, dict):
+            return {k: self._redact_value(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [self._redact_value(v) for v in value]
+        if isinstance(value, tuple):
+            return tuple(self._redact_value(v) for v in value)
+        return value

--- a/src/synapsekit/audit/redact.py
+++ b/src/synapsekit/audit/redact.py
@@ -40,12 +40,57 @@ class RegexDetector:
         return [m.span() for m in self._pattern.finditer(text)]
 
 
+def _luhn_checksum_valid(digits: str) -> bool:
+    """True if ``digits`` (a numeric string, no separators) passes the Luhn check.
+
+    Real card numbers are Luhn-valid by construction; an arbitrary 13-16
+    digit numeric ID (order number, tracking number, phone extension...)
+    passes the Luhn check only ~1 in 10 times by chance, so this is an
+    effective filter against over-redacting ordinary numeric IDs that
+    merely happen to be the right length.
+    """
+    total = 0
+    parity = len(digits) % 2
+    for i, ch in enumerate(digits):
+        d = int(ch)
+        if i % 2 == parity:
+            d *= 2
+            if d > 9:
+                d -= 9
+        total += d
+    return total % 10 == 0
+
+
+class LuhnValidatedDetector:
+    """Detects credit-card-shaped digit runs that also pass a Luhn checksum.
+
+    The regex alone (13-16 digits, optional space/dash separators) would
+    match any numeric ID of that length — order numbers, tracking
+    numbers, database IDs. Real card numbers are Luhn-valid by
+    construction, so requiring the checksum to pass before redacting
+    keeps the detector from over-redacting ordinary numeric IDs while
+    still catching real card numbers regardless of separator style.
+    """
+
+    def __init__(self, label: str, pattern: str) -> None:
+        self.label = label
+        self._pattern = re.compile(pattern)
+
+    def find(self, text: str) -> list[tuple[int, int]]:
+        spans = []
+        for m in self._pattern.finditer(text):
+            digits = re.sub(r"[ -]", "", m.group())
+            if _luhn_checksum_valid(digits):
+                spans.append(m.span())
+        return spans
+
+
 EmailDetector = RegexDetector("EMAIL", r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")
 PhoneDetector = RegexDetector(
     "PHONE", r"(?<!\d)(?:\+?\d{1,3}[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}(?!\d)"
 )
 SSNDetector = RegexDetector("SSN", r"(?<!\d)\d{3}-\d{2}-\d{4}(?!\d)")
-CreditCardDetector = RegexDetector("CREDIT_CARD", r"(?<!\d)(?:\d[ -]?){13,16}(?!\d)")
+CreditCardDetector = LuhnValidatedDetector("CREDIT_CARD", r"(?<!\d)(?:\d[ -]?){13,16}(?!\d)")
 IPAddressDetector = RegexDetector(
     "IP_ADDRESS",
     r"(?<!\d)(?:(?:25[0-5]|2[0-4]\d|[01]?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d?\d)(?!\d)",

--- a/src/synapsekit/audit/replay.py
+++ b/src/synapsekit/audit/replay.py
@@ -1,0 +1,194 @@
+"""Replay — verifies provenance, not "did the LLM say the same thing".
+
+Replay confirms that a recorded run is *reproducible in the parts that
+matter for audit*: the same inputs were fed to each step, tool outputs
+match (when a live executor is supplied), retrieval references still
+resolve, and any recorded policy hash matches the policy payload it
+claims to hash. Identical LLM output is explicitly OPTIONAL — LLMs are
+not required to be deterministic, so ``LLM_CALL``/``LLM_RESPONSE``
+records are checked for structural completeness only, never for output
+equality.
+
+Paired event kinds (``TOOL_CALL``/``TOOL_RESULT``, ``LLM_CALL``/
+``LLM_RESPONSE``) carry their input args/kwargs *and* output together on
+the response/result record (see :mod:`synapsekit.audit.wrapper`), so
+replay checks operate on that record directly rather than needing to
+correlate it back to its paired call event.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .serializer import hash_value
+from .trace import AuditTracer, ChainIntegrityError
+from .types import EventKind
+from .verifier import load_bundle
+
+
+@dataclass
+class ReplayMismatch:
+    event_id: str
+    kind: str
+    reason: str
+    expected: Any = None
+    actual: Any = None
+
+
+@dataclass
+class ReplayReport:
+    ok: bool
+    mismatches: list[ReplayMismatch] = field(default_factory=list)
+    record_count: int = 0
+    checked_tool_calls: int = 0
+    checked_retrievals: int = 0
+    checked_decisions: int = 0
+    skipped_llm_calls: int = 0
+
+
+class ReplayEngine:
+    """Replays a verified bundle's provenance without re-running any LLM.
+
+    ``tool_executors`` maps a tool name to a callable that re-executes it
+    given the recorded input; if omitted for a given tool, that tool's
+    calls are checked for structural completeness only (no live
+    comparison). ``retrieval_resolver`` maps a doc id to *something*
+    (raise/`None` means "not found") to confirm retrieval references
+    still resolve against the current corpus.
+    """
+
+    def __init__(
+        self,
+        *,
+        tool_executors: dict[str, Callable[[dict[str, Any]], Any]] | None = None,
+        retrieval_resolver: Callable[[str], Any] | None = None,
+    ) -> None:
+        self.tool_executors = tool_executors or {}
+        self.retrieval_resolver = retrieval_resolver
+
+    def replay(self, bundle_path: str | Path) -> ReplayReport:
+        loaded = load_bundle(bundle_path)
+        records = loaded.records
+        mismatches: list[ReplayMismatch] = []
+
+        by_run: dict[str, list] = {}
+        for rec in records:
+            by_run.setdefault(rec.run_id, []).append(rec)
+        for run_id, run_records in by_run.items():
+            try:
+                AuditTracer.verify_chain(run_records)
+            except ChainIntegrityError as exc:
+                mismatches.append(
+                    ReplayMismatch(event_id="*", kind="chain", reason=f"run {run_id}: {exc}")
+                )
+
+        counts = {"tool_call": 0, "retrieval": 0, "decision": 0, "llm_call": 0}
+        for rec in records:
+            # Two conventions both work: a manually-recorded single
+            # TOOL_CALL/LLM_CALL with input+output already merged in one
+            # payload, or VerifiableAgent's paired TOOL_CALL+TOOL_RESULT /
+            # LLM_CALL+LLM_RESPONSE (input+output merged onto the
+            # RESULT/RESPONSE record — see wrapper.py). A bare paired
+            # TOOL_CALL/LLM_CALL with no output yet is simply not checked.
+            if (
+                rec.kind in (EventKind.TOOL_CALL.value, EventKind.TOOL_RESULT.value)
+                and "output" in rec.payload
+            ):
+                counts["tool_call"] += 1
+                mismatches.extend(self._check_tool_call(rec))
+            elif rec.kind == EventKind.RETRIEVAL.value:
+                counts["retrieval"] += 1
+                mismatches.extend(self._check_retrieval(rec))
+            elif rec.kind == EventKind.DECISION.value:
+                counts["decision"] += 1
+                mismatches.extend(self._check_decision(rec))
+            elif rec.kind == EventKind.LLM_CALL.value:
+                counts["llm_call"] += 1
+                # Intentionally not checked for output equality: LLM
+                # determinism is not required for replay to succeed.
+
+        return ReplayReport(
+            ok=not mismatches,
+            mismatches=mismatches,
+            record_count=len(records),
+            checked_tool_calls=counts["tool_call"],
+            checked_retrievals=counts["retrieval"],
+            checked_decisions=counts["decision"],
+            skipped_llm_calls=counts["llm_call"],
+        )
+
+    def _check_tool_call(self, rec) -> list[ReplayMismatch]:
+        payload = rec.payload
+        # Accept both the explicit {"tool", "input", "output"} convention
+        # and the generic {"method", "args", "kwargs", "output"} shape
+        # that synapsekit.audit.wrapper.VerifiableAgent records.
+        tool_name = payload.get("tool", payload.get("method"))
+        tool_input = (
+            payload["input"]
+            if "input" in payload
+            else {"args": payload.get("args"), "kwargs": payload.get("kwargs")}
+        )
+        if tool_name is None or "output" not in payload:
+            return [
+                ReplayMismatch(
+                    rec.event_id,
+                    rec.kind,
+                    "tool_call payload missing a tool/method name or 'output'",
+                )
+            ]
+        executor = self.tool_executors.get(tool_name)
+        if executor is None:
+            return []
+        fresh_output = executor(tool_input)
+        if hash_value(fresh_output) != hash_value(payload["output"]):
+            return [
+                ReplayMismatch(
+                    rec.event_id,
+                    rec.kind,
+                    f"tool {tool_name!r} produced a different output on replay",
+                    expected=payload["output"],
+                    actual=fresh_output,
+                )
+            ]
+        return []
+
+    def _check_retrieval(self, rec) -> list[ReplayMismatch]:
+        payload = rec.payload
+        doc_ids = payload.get("doc_ids", [])
+        if self.retrieval_resolver is None:
+            return []
+        mismatches = []
+        for doc_id in doc_ids:
+            try:
+                found = self.retrieval_resolver(doc_id)
+            except Exception:
+                found = None
+            if found is None:
+                mismatches.append(
+                    ReplayMismatch(
+                        rec.event_id, rec.kind, f"retrieval reference {doc_id!r} no longer resolves"
+                    )
+                )
+        return mismatches
+
+    def _check_decision(self, rec) -> list[ReplayMismatch]:
+        payload = rec.payload
+        policy = payload.get("policy")
+        policy_hash = payload.get("policy_hash")
+        if policy is None or policy_hash is None:
+            return []
+        recomputed = hash_value(policy)
+        if recomputed != policy_hash:
+            return [
+                ReplayMismatch(
+                    rec.event_id,
+                    rec.kind,
+                    "recorded policy_hash does not match the recorded policy payload",
+                    expected=policy_hash,
+                    actual=recomputed,
+                )
+            ]
+        return []

--- a/src/synapsekit/audit/serializer.py
+++ b/src/synapsekit/audit/serializer.py
@@ -11,9 +11,34 @@ from __future__ import annotations
 
 import hashlib
 import json
+import unicodedata
 from datetime import date, datetime, timezone
 from types import MappingProxyType
 from typing import Any
+
+
+def _normalize_strings(value: Any) -> Any:
+    """Recursively apply Unicode NFC normalization to every string leaf.
+
+    Two payloads that render identically to a human can be byte-for-byte
+    different Python strings — e.g. an "e" followed by a combining acute
+    accent (``"e\\u0301"``) versus the single precomposed "é"
+    (``"\\u00e9"``). Without normalizing to one canonical form first,
+    those would hash differently even though they commit to the same
+    logical value, which is exactly what :func:`canonical_json` promises
+    not to happen. This must run *before* ``json.dumps`` — dict keys are
+    strings too and need the same treatment so two logically-identical
+    keys don't collide or fail to collide inconsistently.
+    """
+    if isinstance(value, str):
+        return unicodedata.normalize("NFC", value)
+    if isinstance(value, dict | MappingProxyType):
+        return {_normalize_strings(k): _normalize_strings(v) for k, v in value.items()}
+    if isinstance(value, list | tuple):
+        return [_normalize_strings(v) for v in value]
+    if isinstance(value, set | frozenset):
+        return {_normalize_strings(v) for v in value}
+    return value
 
 
 def _default(obj: Any) -> Any:
@@ -43,10 +68,14 @@ def canonical_json(value: Any) -> bytes:
 
     Uses sorted keys, minimal separators, and ASCII-only output so the
     same logical value always produces byte-identical output regardless
-    of dict insertion order, locale, or platform.
+    of dict insertion order, locale, or platform. String values (and
+    dict keys) are also normalized to Unicode NFC first, so visually
+    identical text using different Unicode encodings (combining vs
+    precomposed characters) hashes to the same value.
     """
+    normalized = _normalize_strings(value)
     text = json.dumps(
-        value,
+        normalized,
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=True,

--- a/src/synapsekit/audit/serializer.py
+++ b/src/synapsekit/audit/serializer.py
@@ -1,0 +1,82 @@
+"""Deterministic canonical serialization for hashing.
+
+Hashing must never depend on dict ordering, whitespace, float repr, the
+Python version, or the platform. We never hash ``repr()`` of a Python
+object — everything that gets hashed first passes through
+:func:`canonical_json`, which produces the same bytes for the same
+logical value on every machine.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date, datetime, timezone
+from types import MappingProxyType
+from typing import Any
+
+
+def _default(obj: Any) -> Any:
+    if isinstance(obj, datetime):
+        return obj.astimezone(timezone.utc).isoformat()
+    if isinstance(obj, date):
+        return obj.isoformat()
+    if isinstance(obj, bytes):
+        import base64
+
+        return base64.b64encode(obj).decode("ascii")
+    if isinstance(obj, MappingProxyType):
+        # Read-only view over an already-frozen record payload (see
+        # trace.py's deep-freeze) — unwrap one level; the encoder recurses
+        # into the result and will call back into `_default` for any
+        # nested MappingProxyType/frozenset values it still contains.
+        return dict(obj)
+    if isinstance(obj, set | frozenset):
+        return sorted(obj, key=repr)
+    if hasattr(obj, "to_dict"):
+        return obj.to_dict()
+    raise TypeError(f"Object of type {type(obj).__name__} is not canonically serializable")
+
+
+def canonical_json(value: Any) -> bytes:
+    """Serialize ``value`` to canonical (deterministic) JSON bytes.
+
+    Uses sorted keys, minimal separators, and ASCII-only output so the
+    same logical value always produces byte-identical output regardless
+    of dict insertion order, locale, or platform.
+    """
+    text = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+        default=_default,
+    )
+    return text.encode("utf-8")
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def hash_value(value: Any) -> str:
+    """Canonicalize ``value`` and return its hex SHA-256 digest."""
+    return sha256_hex(canonical_json(value))
+
+
+class DeterministicSerializer:
+    """Namespace wrapper around the canonical-serialization functions.
+
+    Kept as a class (rather than bare functions) so callers can swap in
+    an alternate serializer via dependency injection without changing
+    call sites — e.g. a stricter variant that rejects floats entirely.
+    """
+
+    @staticmethod
+    def canonicalize(value: Any) -> bytes:
+        return canonical_json(value)
+
+    @staticmethod
+    def hash(value: Any) -> str:
+        return hash_value(value)

--- a/src/synapsekit/audit/signer.py
+++ b/src/synapsekit/audit/signer.py
@@ -9,11 +9,15 @@ from __future__ import annotations
 
 import base64
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from datetime import datetime, timezone
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from .metrics import AuditMetrics, default_metrics
 from .types import Signature
+
+if TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 
 class SigningProvider(ABC):
@@ -68,7 +72,7 @@ class Ed25519SigningProvider(SigningProvider):
             private_key = Ed25519PrivateKey.generate()
         elif isinstance(private_key, bytes | bytearray):
             private_key = Ed25519PrivateKey.from_private_bytes(bytes(private_key))
-        self._private_key = private_key
+        self._private_key: Ed25519PrivateKey = private_key
         self.key_id = key_id or self.public_key_b64()[:16]
 
     def sign(self, data: bytes) -> bytes:
@@ -168,9 +172,10 @@ class KMSSigningProvider(SigningProvider):
     downstream never needs to know which cloud is in play.
     """
 
-    def __init__(self, *, key_id: str, algorithm: str) -> None:
+    def __init__(self, *, key_id: str, algorithm: str, client: Any = None) -> None:
         self.key_id = key_id
         self.algorithm = algorithm
+        self._client = client
 
 
 class AWSKMSSigningProvider(KMSSigningProvider):
@@ -309,7 +314,7 @@ class SigningPolicy:
         flush_interval_seconds: float = 5.0,
         metrics: AuditMetrics | None = None,
     ) -> SigningPolicy:
-        providers: dict[str, type[KMSSigningProvider]] = {
+        providers: dict[str, Callable[..., KMSSigningProvider]] = {
             "aws": AWSKMSSigningProvider,
             "azure": AzureKeyVaultSigningProvider,
             "gcp": GCPKMSSigningProvider,

--- a/src/synapsekit/audit/signer.py
+++ b/src/synapsekit/audit/signer.py
@@ -1,0 +1,359 @@
+"""Signing strategy — Ed25519 by default, pluggable BYOK/KMS providers.
+
+Nothing outside this module hardcodes Ed25519. Everything signs through
+the :class:`SigningProvider` interface so swapping in a KMS-backed
+provider later doesn't touch :mod:`trace`, :mod:`bundle`, or callers.
+"""
+
+from __future__ import annotations
+
+import base64
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+from .metrics import AuditMetrics, default_metrics
+from .types import Signature
+
+
+class SigningProvider(ABC):
+    """A signing key/backend that can sign bytes and expose its public key."""
+
+    #: e.g. "ed25519", "aws-kms-ecdsa-p256", "byok"
+    algorithm: str
+    #: Stable identifier for this key, recorded in the manifest so a
+    #: verifier can match a signature to the right public key across
+    #: key rotations.
+    key_id: str
+
+    @abstractmethod
+    def sign(self, data: bytes) -> bytes: ...
+
+    @abstractmethod
+    def public_key_bytes(self) -> bytes: ...
+
+
+def verify_signature(
+    *, algorithm: str, public_key_bytes: bytes, data: bytes, signature: bytes
+) -> bool:
+    """Verify ``signature`` over ``data`` for a given algorithm and public key.
+
+    This is the single verification entry point used by both the
+    in-process verifier and the standalone bundle verifier, so "how do
+    we check a signature" is defined in exactly one place.
+    """
+    if algorithm == "ed25519":
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+        try:
+            Ed25519PublicKey.from_public_bytes(public_key_bytes).verify(signature, data)
+            return True
+        except InvalidSignature:
+            return False
+    raise ValueError(f"unsupported signing algorithm: {algorithm!r}")
+
+
+class Ed25519SigningProvider(SigningProvider):
+    """Default signing provider — Ed25519 via the ``cryptography`` package."""
+
+    algorithm = "ed25519"
+
+    def __init__(self, private_key: Any = None, *, key_id: str | None = None) -> None:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PrivateKey,
+        )
+
+        if private_key is None:
+            private_key = Ed25519PrivateKey.generate()
+        elif isinstance(private_key, bytes | bytearray):
+            private_key = Ed25519PrivateKey.from_private_bytes(bytes(private_key))
+        self._private_key = private_key
+        self.key_id = key_id or self.public_key_b64()[:16]
+
+    def sign(self, data: bytes) -> bytes:
+        return self._private_key.sign(data)
+
+    def public_key_bytes(self) -> bytes:
+        from cryptography.hazmat.primitives import serialization
+
+        return self._private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+
+    def public_key_b64(self) -> str:
+        return base64.b64encode(self.public_key_bytes()).decode("ascii")
+
+    def private_key_bytes(self) -> bytes:
+        """Raw, UNENCRYPTED private key bytes.
+
+        Convenient for reusing the same key across processes in tests
+        or local development, but the caller is responsible for secure
+        storage — prefer :meth:`export_encrypted_private_key` for
+        anything persisted outside memory in a regulated deployment.
+        """
+        from cryptography.hazmat.primitives import serialization
+
+        return self._private_key.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+    def export_encrypted_private_key(self, passphrase: bytes) -> bytes:
+        """Export the private key as passphrase-encrypted PEM (PKCS#8).
+
+        Use this instead of :meth:`private_key_bytes` for anything
+        written to disk, a secrets manager, or backup storage — the
+        result is useless without ``passphrase``, unlike the raw bytes.
+        """
+        from cryptography.hazmat.primitives import serialization
+
+        return self._private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.BestAvailableEncryption(passphrase),
+        )
+
+    @classmethod
+    def from_encrypted_private_key(
+        cls, data: bytes, passphrase: bytes, *, key_id: str | None = None
+    ) -> Ed25519SigningProvider:
+        """Load a provider from PEM bytes produced by :meth:`export_encrypted_private_key`."""
+        from cryptography.hazmat.primitives import serialization
+
+        private_key = serialization.load_pem_private_key(data, password=passphrase)
+        return cls(private_key, key_id=key_id)
+
+
+class SignFn(Protocol):
+    def __call__(self, data: bytes) -> bytes: ...
+
+
+class BYOKSigningProvider(SigningProvider):
+    """Bring-your-own-key: wraps caller-supplied sign/public-key callables.
+
+    Lets an organization plug in a signing mechanism SynapseKit doesn't
+    know about (an HSM client, a custom enclave, etc.) without needing a
+    dedicated subclass, as long as it can produce raw signature bytes.
+    """
+
+    def __init__(
+        self,
+        *,
+        sign_fn: SignFn,
+        public_key: bytes,
+        key_id: str,
+        algorithm: str = "byok",
+    ) -> None:
+        self._sign_fn = sign_fn
+        self._public_key = public_key
+        self.key_id = key_id
+        self.algorithm = algorithm
+
+    def sign(self, data: bytes) -> bytes:
+        return self._sign_fn(data)
+
+    def public_key_bytes(self) -> bytes:
+        return self._public_key
+
+
+class KMSSigningProvider(SigningProvider):
+    """Base class for cloud KMS-backed signing providers.
+
+    Concrete clouds (AWS/Azure/GCP) subclass this; each is responsible
+    for translating ``sign``/``public_key_bytes`` into the relevant SDK
+    calls. The abstraction means :class:`SigningPolicy` and everything
+    downstream never needs to know which cloud is in play.
+    """
+
+    def __init__(self, *, key_id: str, algorithm: str) -> None:
+        self.key_id = key_id
+        self.algorithm = algorithm
+
+
+class AWSKMSSigningProvider(KMSSigningProvider):
+    """Signs via AWS KMS asymmetric keys (requires ``boto3`` and network access)."""
+
+    def __init__(
+        self, *, key_id: str, algorithm: str = "aws-kms-ecdsa-sha256", client: Any = None
+    ) -> None:
+        super().__init__(key_id=key_id, algorithm=algorithm)
+        if client is None:
+            import boto3
+
+            client = boto3.client("kms")
+        self._client = client
+
+    def sign(self, data: bytes) -> bytes:
+        response = self._client.sign(
+            KeyId=self.key_id,
+            Message=data,
+            MessageType="RAW",
+            SigningAlgorithm="ECDSA_SHA_256",
+        )
+        return bytes(response["Signature"])
+
+    def public_key_bytes(self) -> bytes:
+        response = self._client.get_public_key(KeyId=self.key_id)
+        return bytes(response["PublicKey"])
+
+
+class AzureKeyVaultSigningProvider(KMSSigningProvider):
+    """Placeholder for Azure Key Vault-backed signing (future-friendly interface)."""
+
+    def __init__(
+        self, *, key_id: str, algorithm: str = "azure-kv-es256", client: Any = None
+    ) -> None:
+        super().__init__(key_id=key_id, algorithm=algorithm)
+        self._client = client
+
+    def sign(self, data: bytes) -> bytes:
+        raise NotImplementedError(
+            "Azure Key Vault signing requires 'azure-keyvault-keys'; "
+            "pass a configured CryptographyClient via `client=`."
+        )
+
+    def public_key_bytes(self) -> bytes:
+        raise NotImplementedError("Azure Key Vault signing is not yet wired up.")
+
+
+class GCPKMSSigningProvider(KMSSigningProvider):
+    """Placeholder for GCP Cloud KMS-backed signing (future-friendly interface)."""
+
+    def __init__(
+        self, *, key_id: str, algorithm: str = "gcp-kms-ec-sign-p256-sha256", client: Any = None
+    ) -> None:
+        super().__init__(key_id=key_id, algorithm=algorithm)
+        self._client = client
+
+    def sign(self, data: bytes) -> bytes:
+        raise NotImplementedError(
+            "GCP Cloud KMS signing requires 'google-cloud-kms'; "
+            "pass a configured KeyManagementServiceClient via `client=`."
+        )
+
+    def public_key_bytes(self) -> bytes:
+        raise NotImplementedError("GCP Cloud KMS signing is not yet wired up.")
+
+
+class SigningPolicy:
+    """Batch-signing policy: wraps a :class:`SigningProvider` plus batching knobs.
+
+    Records are never signed individually — call :meth:`sign_batch` once
+    per Merkle root at flush time. ``flush_interval_seconds`` and
+    ``max_batch_size`` are read by :mod:`synapsekit.audit.bundle` /
+    higher-level flush loops to decide when a batch closes.
+    """
+
+    def __init__(
+        self,
+        provider: SigningProvider,
+        *,
+        max_batch_size: int = 500,
+        flush_interval_seconds: float = 5.0,
+        metrics: AuditMetrics | None = None,
+    ) -> None:
+        self.provider = provider
+        self.max_batch_size = max_batch_size
+        self.flush_interval_seconds = flush_interval_seconds
+        self._metrics = metrics if metrics is not None else default_metrics
+
+    @classmethod
+    def ed25519(
+        cls,
+        private_key: bytes | None = None,
+        *,
+        key_id: str | None = None,
+        max_batch_size: int = 500,
+        flush_interval_seconds: float = 5.0,
+        metrics: AuditMetrics | None = None,
+    ) -> SigningPolicy:
+        return cls(
+            Ed25519SigningProvider(private_key, key_id=key_id),
+            max_batch_size=max_batch_size,
+            flush_interval_seconds=flush_interval_seconds,
+            metrics=metrics,
+        )
+
+    @classmethod
+    def byok(
+        cls,
+        *,
+        sign_fn: SignFn,
+        public_key: bytes,
+        key_id: str,
+        algorithm: str = "byok",
+        max_batch_size: int = 500,
+        flush_interval_seconds: float = 5.0,
+        metrics: AuditMetrics | None = None,
+    ) -> SigningPolicy:
+        return cls(
+            BYOKSigningProvider(
+                sign_fn=sign_fn, public_key=public_key, key_id=key_id, algorithm=algorithm
+            ),
+            max_batch_size=max_batch_size,
+            flush_interval_seconds=flush_interval_seconds,
+            metrics=metrics,
+        )
+
+    @classmethod
+    def kms(
+        cls,
+        provider: str,
+        *,
+        key_id: str,
+        client: Any = None,
+        max_batch_size: int = 500,
+        flush_interval_seconds: float = 5.0,
+        metrics: AuditMetrics | None = None,
+    ) -> SigningPolicy:
+        providers: dict[str, type[KMSSigningProvider]] = {
+            "aws": AWSKMSSigningProvider,
+            "azure": AzureKeyVaultSigningProvider,
+            "gcp": GCPKMSSigningProvider,
+        }
+        cls_ = providers.get(provider)
+        if cls_ is None:
+            raise ValueError(
+                f"unknown KMS provider {provider!r}; expected one of {sorted(providers)}"
+            )
+        return cls(
+            cls_(key_id=key_id, client=client),
+            max_batch_size=max_batch_size,
+            flush_interval_seconds=flush_interval_seconds,
+            metrics=metrics,
+        )
+
+    def sign_batch(self, merkle_root: str, *, start_index: int, end_index: int) -> Signature:
+        """Sign a Merkle root, producing the :class:`Signature` for one batch."""
+        signature_bytes = self.provider.sign(bytes.fromhex(merkle_root))
+        self._metrics.record_signed_batch(
+            algorithm=self.provider.algorithm, count=end_index - start_index + 1
+        )
+        return Signature(
+            algorithm=self.provider.algorithm,
+            key_id=self.provider.key_id,
+            public_key_b64=base64.b64encode(self.provider.public_key_bytes()).decode("ascii"),
+            signature_b64=base64.b64encode(signature_bytes).decode("ascii"),
+            merkle_root=merkle_root,
+            signed_at=datetime.now(timezone.utc),
+            start_index=start_index,
+            end_index=end_index,
+        )
+
+    def sign_manifest_hash(self, manifest_hash: str) -> dict[str, str]:
+        """Sign a bundle manifest's content hash (see :mod:`synapsekit.audit.bundle`).
+
+        Distinct from :meth:`sign_batch`: a manifest signature isn't
+        tied to a record range, so it's returned as a plain dict rather
+        than the batch-shaped :class:`Signature` dataclass.
+        """
+        signature_bytes = self.provider.sign(bytes.fromhex(manifest_hash))
+        return {
+            "key_id": self.provider.key_id,
+            "algorithm": self.provider.algorithm,
+            "public_key_b64": base64.b64encode(self.provider.public_key_bytes()).decode("ascii"),
+            "signature_b64": base64.b64encode(signature_bytes).decode("ascii"),
+        }

--- a/src/synapsekit/audit/sink.py
+++ b/src/synapsekit/audit/sink.py
@@ -1,0 +1,181 @@
+"""Audit sinks — persistence backends that receive already-signed batches.
+
+Sinks never see a signing key and never decide when something is signed;
+:mod:`synapsekit.audit.signer` produces a :class:`Signature` over a batch
+*before* any sink is invoked. A sink's only job is durable storage of
+bytes it's handed.
+
+Every sink exposes both a blocking :meth:`~AuditSink.write` and an
+:meth:`~AuditSink.awrite` coroutine. The base class implements
+``awrite`` by running ``write`` in a worker thread
+(``asyncio.to_thread``) so none of the blocking disk/network I/O below
+(file ``fsync``, S3/Kafka network calls) ever stalls the event loop when
+called from SynapseKit's async-native code paths — override ``awrite``
+directly in a subclass if a truly async client (e.g. ``aioboto3``) is
+available.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .types import AuditRecord, Signature
+
+
+@dataclass
+class SignedBatch:
+    """A batch of records plus the signature already computed over its Merkle root."""
+
+    records: list[AuditRecord]
+    signature: Signature
+    leaves: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "records": [r.to_dict() for r in self.records],
+            "signature": self.signature.to_dict(),
+            "leaves": self.leaves,
+        }
+
+
+class AuditSink(ABC):
+    """A durable store for signed audit batches."""
+
+    @abstractmethod
+    def write(self, batch: SignedBatch) -> None: ...
+
+    async def awrite(self, batch: SignedBatch) -> None:
+        """Async-safe write — off-loads the (potentially blocking) :meth:`write` to a thread."""
+        await asyncio.to_thread(self.write, batch)
+
+
+class FileAuditSink(AuditSink):
+    """Append-only newline-delimited JSON file. Never truncates or rewrites."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+
+    def write(self, batch: SignedBatch) -> None:
+        import os
+
+        line = json.dumps(batch.to_dict(), sort_keys=True)
+        with self._lock, open(self._path, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+
+
+class S3AuditSink(AuditSink):
+    """Writes one object per batch to S3 (or an S3-compatible store).
+
+    The ``boto3`` client is constructed lazily on first use (not in
+    ``__init__``), so simply instantiating this sink — e.g. while
+    validating configuration — never attempts a network/credential
+    round-trip.
+    """
+
+    def __init__(
+        self, bucket: str, *, prefix: str = "synapsekit-audit", client: Any = None
+    ) -> None:
+        self._bucket = bucket
+        self._prefix = prefix.rstrip("/")
+        self._client = client
+
+    def _ensure_client(self) -> Any:
+        if self._client is None:
+            import boto3
+
+            self._client = boto3.client("s3")
+        return self._client
+
+    def write(self, batch: SignedBatch) -> None:
+        client = self._ensure_client()
+        key = f"{self._prefix}/{batch.signature.start_index:012d}-{batch.signature.end_index:012d}.json"
+        body = json.dumps(batch.to_dict(), sort_keys=True).encode("utf-8")
+        client.put_object(Bucket=self._bucket, Key=key, Body=body, ContentType="application/json")
+
+
+class KafkaAuditSink(AuditSink):
+    """Publishes one message per batch to a Kafka topic.
+
+    The ``kafka-python`` producer is constructed lazily on first use
+    (not in ``__init__``), so simply instantiating this sink never
+    attempts a broker connection.
+    """
+
+    def __init__(
+        self, topic: str, *, producer: Any = None, bootstrap_servers: str | None = None
+    ) -> None:
+        self._topic = topic
+        self._producer = producer
+        self._bootstrap_servers = bootstrap_servers
+
+    def _ensure_producer(self) -> Any:
+        if self._producer is None:
+            from kafka import KafkaProducer
+
+            self._producer = KafkaProducer(
+                bootstrap_servers=self._bootstrap_servers or "localhost:9092",
+                value_serializer=lambda v: json.dumps(v, sort_keys=True).encode("utf-8"),
+            )
+        return self._producer
+
+    def write(self, batch: SignedBatch) -> None:
+        producer = self._ensure_producer()
+        future = producer.send(self._topic, batch.to_dict())
+        # Surface send-time errors immediately rather than dropping them —
+        # a swallowed publish failure would silently break the audit trail.
+        if hasattr(future, "get"):
+            future.get(timeout=30)
+
+
+class OTelAuditSink(AuditSink):
+    """Forwards each record in a batch to an OTel exporter as a span/event."""
+
+    def __init__(self, exporter: Any) -> None:
+        self._exporter = exporter
+
+    def write(self, batch: SignedBatch) -> None:
+        from .otel import export_records
+
+        export_records(self._exporter, batch.records)
+
+
+class MultiSink(AuditSink):
+    """Fans a batch out to several sinks; raises if any of them fails."""
+
+    def __init__(self, sinks: list[AuditSink]) -> None:
+        self._sinks = sinks
+
+    def write(self, batch: SignedBatch) -> None:
+        errors = []
+        for sink in self._sinks:
+            try:
+                sink.write(batch)
+            except Exception as exc:
+                errors.append(f"{type(sink).__name__}: {exc}")
+        if errors:
+            raise RuntimeError(f"{len(errors)} sink(s) failed to write batch: {'; '.join(errors)}")
+
+    async def awrite(self, batch: SignedBatch) -> None:
+        # Concurrent fan-out rather than the base class's single
+        # to_thread(write) — each sink's own I/O overlaps instead of
+        # being serialized behind one one worker thread.
+        results = await asyncio.gather(
+            *(sink.awrite(batch) for sink in self._sinks), return_exceptions=True
+        )
+        errors = [
+            f"{type(sink).__name__}: {result}"
+            for sink, result in zip(self._sinks, results, strict=True)
+            if isinstance(result, Exception)
+        ]
+        if errors:
+            raise RuntimeError(f"{len(errors)} sink(s) failed to write batch: {'; '.join(errors)}")

--- a/src/synapsekit/audit/trace.py
+++ b/src/synapsekit/audit/trace.py
@@ -1,0 +1,220 @@
+"""Hash-chained trace recorder — the append-only spine of the audit system."""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from .serializer import hash_value
+from .types import (
+    GENESIS_HASH,
+    SCHEMA_VERSION,
+    AuditRecord,
+    EventKind,
+    RedactionStatus,
+    deep_freeze,
+)
+
+if TYPE_CHECKING:
+    from .redact import PIIRedactor
+
+
+def _new_id() -> str:
+    return uuid.uuid4().hex
+
+
+def compute_payload_hash(payload: Any) -> str:
+    """Hash a record's (already redacted, already frozen) payload on its own.
+
+    Keeping this separate from :func:`compute_record_hash` — which
+    commits to ``payload_hash`` rather than the raw payload directly —
+    means a future selective-disclosure mode can drop a record's payload
+    entirely while keeping ``payload_hash`` as evidence of what it
+    originally committed to, without changing the hash-chain format.
+    """
+    return hash_value(payload)
+
+
+def compute_record_hash(
+    *,
+    event_id: str,
+    parent_id: str | None,
+    run_id: str,
+    kind: str,
+    actor: str,
+    payload_hash: str,
+    timestamp: datetime,
+    prev_hash: str,
+    schema_version: str = SCHEMA_VERSION,
+    redaction_policy_hash: str | None = None,
+    redaction_status: RedactionStatus = "none",
+) -> str:
+    """Hash everything about a record except its own ``hash`` field.
+
+    Commits to ``payload_hash`` rather than the raw ``payload`` — see
+    :func:`compute_payload_hash`. This is the single source of truth for
+    "what a record hash means" — :mod:`trace`, :mod:`bundle`, and
+    :mod:`verifier` all call equivalent logic so a record produced by
+    SynapseKit and one recomputed by an external verifier are
+    byte-for-byte comparable.
+    """
+    return hash_value(
+        {
+            "event_id": event_id,
+            "parent_id": parent_id,
+            "run_id": run_id,
+            "kind": kind,
+            "actor": actor,
+            "payload_hash": payload_hash,
+            "timestamp": timestamp,
+            "prev_hash": prev_hash,
+            "schema_version": schema_version,
+            "redaction_policy_hash": redaction_policy_hash,
+            "redaction_status": redaction_status,
+        }
+    )
+
+
+class ChainIntegrityError(Exception):
+    """Raised when a record sequence fails hash-chain verification."""
+
+
+class AuditTracer:
+    """Append-only, hash-chained recorder for one run.
+
+    Every :meth:`record` call links to the previous record's hash, so the
+    chain behaves like a blockchain: retroactively editing any record
+    changes its hash and invalidates every record after it. Thread-safe;
+    an :class:`AuditTracer` is meant to be flushed periodically (see
+    :mod:`synapsekit.audit.sink`) rather than kept forever in memory.
+    """
+
+    def __init__(self, run_id: str | None = None, *, redactor: PIIRedactor | None = None) -> None:
+        self.run_id = run_id or _new_id()
+        self._lock = threading.Lock()
+        self._records: list[AuditRecord] = []
+        self._last_hash = GENESIS_HASH
+        self._redactor = redactor
+
+    def record(
+        self,
+        kind: EventKind | str,
+        payload: dict[str, Any],
+        *,
+        actor: str = "system",
+        parent_id: str | None = None,
+        event_id: str | None = None,
+        timestamp: datetime | None = None,
+    ) -> AuditRecord:
+        """Append a new record to the chain and return it.
+
+        If this tracer was constructed with a ``redactor``, PII is
+        redacted here — before hashing — regardless of whether the
+        caller already redacted it, and ``redaction_status``/
+        ``redaction_policy_hash`` are stamped onto the record (metadata
+        only in v2.0 — no enforcement yet). The stored payload is then
+        deep-frozen (see :func:`deep_freeze`) so it can never drift out
+        of sync with the hash already computed over it.
+        """
+        kind_value = kind.value if isinstance(kind, EventKind) else str(kind)
+        eid = event_id or _new_id()
+        ts = timestamp or datetime.now(timezone.utc)
+
+        redaction_status: RedactionStatus = "none"
+        redaction_policy_hash: str | None = None
+        if self._redactor is not None:
+            redacted = self._redactor.redact_payload(payload)
+            redaction_policy_hash = self._redactor.policy_fingerprint()
+            redaction_status = "redacted" if redacted != payload else "none"
+            payload = redacted
+        frozen_payload = deep_freeze(payload)
+        payload_hash = compute_payload_hash(frozen_payload)
+
+        with self._lock:
+            prev_hash = self._last_hash
+            record_hash = compute_record_hash(
+                event_id=eid,
+                parent_id=parent_id,
+                run_id=self.run_id,
+                kind=kind_value,
+                actor=actor,
+                payload_hash=payload_hash,
+                timestamp=ts,
+                prev_hash=prev_hash,
+                redaction_policy_hash=redaction_policy_hash,
+                redaction_status=redaction_status,
+            )
+            record = AuditRecord(
+                event_id=eid,
+                parent_id=parent_id,
+                run_id=self.run_id,
+                kind=kind_value,
+                actor=actor,
+                payload=frozen_payload,
+                payload_hash=payload_hash,
+                timestamp=ts,
+                schema_version=SCHEMA_VERSION,
+                prev_hash=prev_hash,
+                hash=record_hash,
+                redaction_policy_hash=redaction_policy_hash,
+                redaction_status=redaction_status,
+            )
+            self._records.append(record)
+            self._last_hash = record_hash
+        return record
+
+    @property
+    def records(self) -> tuple[AuditRecord, ...]:
+        """A read-only snapshot of the chain so far."""
+        with self._lock:
+            return tuple(self._records)
+
+    def drain(self) -> list[AuditRecord]:
+        """Atomically pop all buffered records (for flushing to a sink)."""
+        with self._lock:
+            records, self._records = self._records, []
+            return records
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._records)
+
+    @staticmethod
+    def verify_chain(records: list[AuditRecord], *, expect_genesis: bool = True) -> None:
+        """Recompute every hash and linkage; raise :class:`ChainIntegrityError` on any break."""
+        prev_hash = GENESIS_HASH
+        for i, rec in enumerate(records):
+            if i == 0 and expect_genesis and rec.prev_hash != GENESIS_HASH:
+                raise ChainIntegrityError(
+                    f"record 0 ({rec.event_id}) does not start from the genesis hash"
+                )
+            if rec.prev_hash != prev_hash:
+                raise ChainIntegrityError(
+                    f"record {i} ({rec.event_id}) prev_hash does not match "
+                    f"the hash of the preceding record — chain broken or reordered"
+                )
+            recomputed_payload_hash = compute_payload_hash(rec.payload)
+            if recomputed_payload_hash != rec.payload_hash:
+                raise ChainIntegrityError(
+                    f"record {i} ({rec.event_id}) payload_hash does not match its payload — tampered payload"
+                )
+            recomputed = compute_record_hash(
+                event_id=rec.event_id,
+                parent_id=rec.parent_id,
+                run_id=rec.run_id,
+                kind=rec.kind,
+                actor=rec.actor,
+                payload_hash=rec.payload_hash,
+                timestamp=rec.timestamp,
+                prev_hash=rec.prev_hash,
+                schema_version=rec.schema_version,
+                redaction_policy_hash=rec.redaction_policy_hash,
+                redaction_status=rec.redaction_status,
+            )
+            if recomputed != rec.hash:
+                raise ChainIntegrityError(
+                    f"record {i} ({rec.event_id}) hash does not match its content — tampered record"
+                )
+            prev_hash = rec.hash

--- a/src/synapsekit/audit/trace.py
+++ b/src/synapsekit/audit/trace.py
@@ -183,7 +183,25 @@ class AuditTracer:
 
     @staticmethod
     def verify_chain(records: list[AuditRecord], *, expect_genesis: bool = True) -> None:
-        """Recompute every hash and linkage; raise :class:`ChainIntegrityError` on any break."""
+        """Recompute every hash and linkage; raise :class:`ChainIntegrityError` on any break.
+
+        ``records`` must all share one ``run_id`` — a chain link only
+        means something within a single run. If a caller passes an
+        unfiltered, multi-run record list, ``prev_hash``/``hash``
+        matches happening to line up *across* runs would otherwise be
+        accepted as a legitimate link, which is not a real guarantee
+        (nothing ties ``run_id`` to the hash chain itself). Callers that
+        need to verify a mixed batch should group by ``run_id`` first
+        and call this once per run — see :mod:`synapsekit.audit.replay`
+        for the pattern.
+        """
+        if records:
+            run_ids = {rec.run_id for rec in records}
+            if len(run_ids) > 1:
+                raise ChainIntegrityError(
+                    f"verify_chain received records from multiple runs ({sorted(run_ids)}) — "
+                    "group records by run_id and verify each run's chain independently"
+                )
         prev_hash = GENESIS_HASH
         for i, rec in enumerate(records):
             if i == 0 and expect_genesis and rec.prev_hash != GENESIS_HASH:

--- a/src/synapsekit/audit/types.py
+++ b/src/synapsekit/audit/types.py
@@ -50,10 +50,14 @@ def deep_unfreeze(value: Any) -> Any:
 #: - 1.2 renamed ``step_id`` to ``event_id``, added ``actor`` and a
 #:   two-level ``payload_hash``/``hash`` commitment (see
 #:   :mod:`synapsekit.audit.trace`), replaced the ad hoc ``kind`` set with
-#:   the stable :class:`EventKind` taxonomy, and reserved
+#:   the stable :class:`EventKind` taxonomy, reserved
 #:   ``redaction_policy_hash``/``redaction_status`` fields for future
-#:   compliance enforcement. Bundles from 1.1 and earlier are not
-#:   compatible with 1.2 verifiers.
+#:   compliance enforcement, and added the RFC 6962 0x00 leaf-hash domain
+#:   prefix (see :func:`synapsekit.audit.merkle.hash_leaf`) so leaf hashes
+#:   can never be replayed as internal node hashes. Bundles from 1.1 and
+#:   earlier are not compatible with 1.2 verifiers. 1.2 has not shipped
+#:   yet, so this leaf-hashing change lands within the same version
+#:   rather than bumping to 1.3.
 SCHEMA_VERSION = "1.2"
 
 #: prev_hash of the first record in a run — there is nothing before it.
@@ -149,7 +153,7 @@ class AuditRecord:
             run_id=data["run_id"],
             kind=data["kind"],
             actor=data.get("actor", "unknown"),
-            payload=data["payload"],
+            payload=deep_freeze(data["payload"]),
             payload_hash=data["payload_hash"],
             timestamp=ts,
             schema_version=data.get("schema_version", SCHEMA_VERSION),

--- a/src/synapsekit/audit/types.py
+++ b/src/synapsekit/audit/types.py
@@ -1,0 +1,260 @@
+"""Immutable audit record model — the unit of the verifiable trace chain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Literal
+
+
+def deep_freeze(value: Any) -> Any:
+    """Recursively convert dict/list/tuple/set into read-only equivalents.
+
+    ``@dataclass(frozen=True)`` on :class:`AuditRecord` only stops
+    *rebinding* ``record.payload`` — it does nothing to stop
+    ``record.payload["x"] = "y"`` in place, which would silently desync
+    the live object from the hash already computed over its original
+    content. Freezing the payload's containers (not just the outer
+    field) closes that gap: mutation attempts now raise instead of
+    silently succeeding. Primitive leaves and any other object type are
+    returned unchanged.
+    """
+    if isinstance(value, dict):
+        return MappingProxyType({k: deep_freeze(v) for k, v in value.items()})
+    if isinstance(value, list | tuple):
+        return tuple(deep_freeze(v) for v in value)
+    if isinstance(value, set | frozenset):
+        return frozenset(deep_freeze(v) for v in value)
+    return value
+
+
+def deep_unfreeze(value: Any) -> Any:
+    """Inverse of :func:`deep_freeze` — plain, JSON-friendly dict/list output."""
+    if isinstance(value, MappingProxyType):
+        return {k: deep_unfreeze(v) for k, v in value.items()}
+    if isinstance(value, tuple | frozenset):
+        return [deep_unfreeze(v) for v in value]
+    return value
+
+
+#: Bundle/record schema version. Bump on any breaking change to the
+#: canonical hash inputs, the bundle layout, or the manifest fields —
+#: verifiers must refuse to process a version they don't recognize.
+#:
+#: - 1.1 switched the Merkle construction from naive last-leaf duplication
+#:   (the CVE-2012-2459 class of ambiguity) to the RFC 6962 recursive-split
+#:   algorithm with domain-separated leaf/node hashing, and added signed
+#:   manifest metadata.
+#: - 1.2 renamed ``step_id`` to ``event_id``, added ``actor`` and a
+#:   two-level ``payload_hash``/``hash`` commitment (see
+#:   :mod:`synapsekit.audit.trace`), replaced the ad hoc ``kind`` set with
+#:   the stable :class:`EventKind` taxonomy, and reserved
+#:   ``redaction_policy_hash``/``redaction_status`` fields for future
+#:   compliance enforcement. Bundles from 1.1 and earlier are not
+#:   compatible with 1.2 verifiers.
+SCHEMA_VERSION = "1.2"
+
+#: prev_hash of the first record in a run — there is nothing before it.
+GENESIS_HASH = "0" * 64
+
+#: Redaction lifecycle for a record's payload — reserved for future
+#: compliance enforcement (HIPAA/GDPR/EU AI Act redaction policies). v2.0
+#: only stores this metadata; it does not yet enforce anything based on it.
+RedactionStatus = Literal["none", "redacted", "withheld"]
+
+
+class EventKind(str, Enum):
+    """The stable, public event taxonomy — arbitrary strings are not allowed.
+
+    Renaming or removing a value is a breaking change to the bundle
+    format; adding a new value is not (old verifiers simply don't
+    recognize the new kind string, they don't reject the record for it).
+    """
+
+    USER_INPUT = "USER_INPUT"
+    LLM_CALL = "LLM_CALL"
+    LLM_RESPONSE = "LLM_RESPONSE"
+    TOOL_CALL = "TOOL_CALL"
+    TOOL_RESULT = "TOOL_RESULT"
+    RETRIEVAL = "RETRIEVAL"
+    MEMORY_READ = "MEMORY_READ"
+    MEMORY_WRITE = "MEMORY_WRITE"
+    STATE_CHANGE = "STATE_CHANGE"
+    DECISION = "DECISION"
+    SYSTEM_EVENT = "SYSTEM_EVENT"
+    ERROR = "ERROR"
+
+
+@dataclass(frozen=True)
+class AuditRecord:
+    """A single, immutable, hash-chained audit event.
+
+    ``hash`` commits to every other field (including ``prev_hash`` and
+    ``payload_hash``, but not the raw ``payload`` directly — see
+    :mod:`synapsekit.audit.trace`), so mutating any prior record changes
+    its hash and breaks the chain for every record that follows it —
+    this is what makes the trace tamper-evident rather than merely
+    append-only.
+
+    ``redaction_policy_hash``/``redaction_status`` are reserved for
+    future compliance enforcement (HIPAA/GDPR/EU AI Act) — they exist in
+    the schema now specifically so that turning on real enforcement
+    later never requires a breaking bundle-format change. v2.0 only
+    records this metadata; it does not enforce anything based on it.
+    """
+
+    event_id: str
+    parent_id: str | None
+    run_id: str
+    kind: str
+    actor: str
+    payload: dict[str, Any]
+    payload_hash: str
+    timestamp: datetime
+    schema_version: str
+    prev_hash: str
+    hash: str
+
+    # Reserved for future compliance support — do not remove.
+    redaction_policy_hash: str | None = None
+    redaction_status: RedactionStatus = "none"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "parent_id": self.parent_id,
+            "run_id": self.run_id,
+            "kind": self.kind,
+            "actor": self.actor,
+            "payload": deep_unfreeze(self.payload),
+            "payload_hash": self.payload_hash,
+            "timestamp": self.timestamp.astimezone(timezone.utc).isoformat(),
+            "schema_version": self.schema_version,
+            "prev_hash": self.prev_hash,
+            "hash": self.hash,
+            "redaction_policy_hash": self.redaction_policy_hash,
+            "redaction_status": self.redaction_status,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AuditRecord:
+        ts = data["timestamp"]
+        if isinstance(ts, str):
+            ts = datetime.fromisoformat(ts)
+        return cls(
+            event_id=data["event_id"],
+            parent_id=data.get("parent_id"),
+            run_id=data["run_id"],
+            kind=data["kind"],
+            actor=data.get("actor", "unknown"),
+            payload=data["payload"],
+            payload_hash=data["payload_hash"],
+            timestamp=ts,
+            schema_version=data.get("schema_version", SCHEMA_VERSION),
+            prev_hash=data["prev_hash"],
+            hash=data["hash"],
+            redaction_policy_hash=data.get("redaction_policy_hash"),
+            redaction_status=data.get("redaction_status", "none"),
+        )
+
+
+@dataclass(frozen=True)
+class Signature:
+    """A single Ed25519/KMS signature over a Merkle root (a signed batch)."""
+
+    algorithm: str
+    key_id: str
+    public_key_b64: str
+    signature_b64: str
+    merkle_root: str
+    signed_at: datetime
+    start_index: int
+    end_index: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "algorithm": self.algorithm,
+            "key_id": self.key_id,
+            "public_key_b64": self.public_key_b64,
+            "signature_b64": self.signature_b64,
+            "merkle_root": self.merkle_root,
+            "signed_at": self.signed_at.astimezone(timezone.utc).isoformat(),
+            "start_index": self.start_index,
+            "end_index": self.end_index,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Signature:
+        signed_at = data["signed_at"]
+        if isinstance(signed_at, str):
+            signed_at = datetime.fromisoformat(signed_at)
+        return cls(
+            algorithm=data["algorithm"],
+            key_id=data["key_id"],
+            public_key_b64=data["public_key_b64"],
+            signature_b64=data["signature_b64"],
+            merkle_root=data["merkle_root"],
+            signed_at=signed_at,
+            start_index=data["start_index"],
+            end_index=data["end_index"],
+        )
+
+
+class Verdict(str, Enum):
+    """The three possible outcomes of :func:`synapsekit.audit.verifier.verify`.
+
+    This is deliberately not a bool: a verifier can fail to reach a
+    conclusion (``UNVERIFIABLE`` — e.g. a corrupted bundle, an
+    unsupported schema version, or a key it has no way to check against)
+    without that meaning the evidence actively *contradicts* what's
+    claimed (``DRIFT`` — a broken hash chain, an invalid signature, a
+    tampered Merkle root). Collapsing that distinction into a single
+    boolean would make "we couldn't check" indistinguishable from "we
+    checked and it's wrong".
+    """
+
+    MATCH = "MATCH"
+    DRIFT = "DRIFT"
+    UNVERIFIABLE = "UNVERIFIABLE"
+
+
+@dataclass
+class VerificationResult:
+    """Outcome of verifying a bundle.
+
+    ``trust_anchor`` distinguishes two very different claims:
+
+    - ``"none"`` — only internal self-consistency was checked (hash
+      chain, Merkle tree, and signatures all verify against public keys
+      *sourced from the bundle itself*). This proves the bundle wasn't
+      tampered with after it was produced, but NOT that it was produced
+      by any particular party — anyone can generate a self-consistent
+      bundle from scratch with their own keypair.
+    - ``"pinned"`` — every signature (batch and manifest) was checked
+      against a caller-supplied ``trusted_keys`` map obtained
+      independently of the bundle, giving real non-repudiation.
+    """
+
+    verdict: Verdict
+    errors: list[str] = field(default_factory=list)
+    record_count: int = 0
+    batch_count: int = 0
+    schema_version: str | None = None
+    trust_anchor: str = "none"
+
+    @property
+    def ok(self) -> bool:
+        """Convenience alias for ``verdict == Verdict.MATCH``."""
+        return self.verdict == Verdict.MATCH
+
+    def raise_if_invalid(self) -> None:
+        if self.verdict != Verdict.MATCH:
+            raise AuditVerificationError(
+                f"{self.verdict.value}: " + ("; ".join(self.errors) or "verification failed")
+            )
+
+
+class AuditVerificationError(Exception):
+    """Raised when a bundle fails cryptographic or structural verification."""

--- a/src/synapsekit/audit/verifier.py
+++ b/src/synapsekit/audit/verifier.py
@@ -1,0 +1,676 @@
+"""Standalone bundle verifier — the other half of the open bundle spec.
+
+This module intentionally only depends on the Python standard library
+plus ``cryptography`` (for Ed25519 verification) — not on
+:mod:`synapsekit.audit.trace` or :mod:`synapsekit.audit.signer`. That is
+the whole point: a compliance auditor with no SynapseKit installation
+can copy this one file plus ``pip install cryptography`` and independently
+verify a bundle produced months or years ago, using only the bundle
+format documented in :mod:`synapsekit.audit.bundle`.
+
+Verification never "silently succeeds" — any structural problem,
+cryptographic failure, or unexpected exception is captured as a
+:class:`~synapsekit.audit.types.Verdict` other than ``MATCH`` rather than
+swallowed. The verdict is deliberately three-valued rather than a bool:
+``DRIFT`` means the evidence actively contradicts what's claimed (a
+broken hash chain, an invalid signature, a tampered Merkle root);
+``UNVERIFIABLE`` means there isn't enough evidence to reach a conclusion
+either way (a corrupted bundle, an unsupported schema version, a key
+this verifier has no way to check against). Collapsing that distinction
+into a single boolean would make "we couldn't check" indistinguishable
+from "we checked and it's wrong".
+
+IMPORTANT — trust anchor: by default, :func:`verify` checks every
+signature against the public key *embedded in the bundle's own
+manifest*. That proves internal self-consistency (nothing was edited
+after export) but NOT authenticity — anyone can generate a fully
+self-consistent bundle from scratch with a freshly generated keypair.
+For real non-repudiation, pass ``trusted_keys`` with the signer's public
+key(s) obtained independently of the bundle (e.g. published out-of-band,
+pinned in your own config) — signatures from any other key are then
+rejected outright, regardless of what the manifest itself claims.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .types import GENESIS_HASH, AuditRecord, Verdict, VerificationResult
+
+if TYPE_CHECKING:
+    from .metrics import AuditMetrics
+
+SUPPORTED_SCHEMA_VERSIONS = {"1.2"}
+
+REQUIRED_ENTRIES = ("manifest.json", "trace.jsonl", "hashes.merkle", "signatures.json")
+
+#: Must match synapsekit.audit.merkle's domain separation exactly, or a
+#: bundle produced by this package would fail its own verifier.
+_NODE_DOMAIN = b"\x01"
+
+#: (verdict, message) — the atomic unit of evidence a check contributes.
+Finding = tuple[Verdict, str]
+
+
+def _hash_pair(left: str, right: str) -> str:
+    return hashlib.sha256(_NODE_DOMAIN + bytes.fromhex(left) + bytes.fromhex(right)).hexdigest()
+
+
+def _largest_power_of_two_less_than(n: int) -> int:
+    k = 1
+    while k * 2 < n:
+        k *= 2
+    return k
+
+
+def _merkle_root(leaves: list[str]) -> str:
+    """RFC 6962 recursive-split root — never duplicates a leaf to pad odd counts."""
+    n = len(leaves)
+    if n == 0:
+        return hashlib.sha256(b"").hexdigest()
+    if n == 1:
+        return leaves[0]
+    k = _largest_power_of_two_less_than(n)
+    return _hash_pair(_merkle_root(leaves[:k]), _merkle_root(leaves[k:]))
+
+
+def _verify_ed25519(public_key: bytes, data: bytes, signature: bytes) -> bool:
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+    try:
+        Ed25519PublicKey.from_public_bytes(public_key).verify(signature, data)
+        return True
+    except InvalidSignature:
+        return False
+
+
+def _verify_signature(*, algorithm: str, public_key: bytes, data: bytes, signature: bytes) -> bool:
+    if algorithm == "ed25519":
+        return _verify_ed25519(public_key, data, signature)
+    raise ValueError(f"unsupported signing algorithm: {algorithm!r}")
+
+
+def _canonical_json(value: Any) -> bytes:
+    """Canonical serialization for values already made of plain JSON types
+    (str/int/float/bool/None/dict/list) — used for record and manifest
+    hashing. A record's ``timestamp`` is the one exception (a live
+    ``datetime``), handled via ``default=``.
+    """
+
+    def default(obj: Any) -> Any:
+        from datetime import date, datetime, timezone
+
+        if isinstance(obj, datetime):
+            return obj.astimezone(timezone.utc).isoformat()
+        if isinstance(obj, date):
+            return obj.isoformat()
+        raise TypeError(f"Object of type {type(obj).__name__} is not canonically serializable")
+
+    text = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+        default=default,
+    )
+    return text.encode("utf-8")
+
+
+def _payload_hash(payload: Any) -> str:
+    return hashlib.sha256(_canonical_json(payload)).hexdigest()
+
+
+def _record_hash(rec: AuditRecord) -> str:
+    metadata = {
+        "event_id": rec.event_id,
+        "parent_id": rec.parent_id,
+        "run_id": rec.run_id,
+        "kind": rec.kind,
+        "actor": rec.actor,
+        "payload_hash": rec.payload_hash,
+        "timestamp": rec.timestamp,
+        "prev_hash": rec.prev_hash,
+        "schema_version": rec.schema_version,
+        "redaction_policy_hash": rec.redaction_policy_hash,
+        "redaction_status": rec.redaction_status,
+    }
+    return hashlib.sha256(_canonical_json(metadata)).hexdigest()
+
+
+@dataclass
+class LoadedBundle:
+    manifest: dict[str, Any]
+    records: list[AuditRecord]
+    hashes_doc: dict[str, Any]
+    signatures_doc: list[dict[str, Any]]
+
+
+def load_bundle(path: str | Path) -> LoadedBundle:
+    """Parse a bundle's four entries with no cryptographic checks (raw read)."""
+    with zipfile.ZipFile(path) as zf:
+        names = set(zf.namelist())
+        missing = [n for n in REQUIRED_ENTRIES if n not in names]
+        if missing:
+            raise ValueError(f"bundle is missing required entries: {missing}")
+
+        manifest = json.loads(zf.read("manifest.json"))
+        hashes_doc = json.loads(zf.read("hashes.merkle"))
+        signatures_doc = json.loads(zf.read("signatures.json"))
+
+        trace_text = zf.read("trace.jsonl").decode("utf-8")
+        records: list[AuditRecord] = []
+        for line in trace_text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            records.append(AuditRecord.from_dict(json.loads(line)))
+
+    return LoadedBundle(
+        manifest=manifest, records=records, hashes_doc=hashes_doc, signatures_doc=signatures_doc
+    )
+
+
+def _verify_merkle_proof(
+    leaf: str, siblings: list[str], sibling_is_right: list[bool], root: str
+) -> bool:
+    node = leaf
+    for sibling, is_right in zip(siblings, sibling_is_right, strict=True):
+        node = _hash_pair(node, sibling) if is_right else _hash_pair(sibling, node)
+    return node == root
+
+
+def _resolve_public_key(
+    key_id: str, manifest_keys: dict[str, Any], trusted_keys: dict[str, bytes] | None
+) -> tuple[bytes | None, Finding | None]:
+    """Return ``(public_key_bytes, finding)`` for a key_id — ``finding`` is set on failure.
+
+    When ``trusted_keys`` is supplied, it is authoritative and
+    exclusive: a key_id not present there is rejected even if the
+    bundle's own manifest claims a public key for it — the whole point
+    of pinning is to never trust key material sourced from the artifact
+    being verified. A missing key is UNVERIFIABLE (we lack evidence),
+    not DRIFT (evidence contradicting a claim) — see the module docstring.
+    """
+    if trusted_keys is not None:
+        key_bytes = trusted_keys.get(key_id)
+        if key_bytes is None:
+            return None, (
+                Verdict.UNVERIFIABLE,
+                f"key_id {key_id!r} is not in the caller-supplied trusted key set",
+            )
+        return key_bytes, None
+    info = manifest_keys.get(key_id)
+    if info is None:
+        return None, (Verdict.UNVERIFIABLE, f"no public key registered for key_id {key_id!r}")
+    return base64.b64decode(info["public_key_b64"]), None
+
+
+def _verify_manifest_signature(
+    manifest: dict[str, Any], *, trusted_keys: dict[str, bytes] | None
+) -> list[Finding]:
+    """Authenticate manifest metadata (record_count, run_ids, created_at, keys, ...).
+
+    Without this, an attacker could alter those fields freely — they
+    aren't part of any hashed record or covered by a batch signature
+    (which only signs the Merkle root of the trace) — without failing
+    verification.
+    """
+    manifest_hash = manifest.get("manifest_hash")
+    signatures = manifest.get("manifest_signatures")
+    if not manifest_hash or not signatures:
+        return [
+            (
+                Verdict.UNVERIFIABLE,
+                "manifest is not signed (missing manifest_hash/manifest_signatures) — its metadata is unauthenticated",
+            )
+        ]
+
+    core = {k: v for k, v in manifest.items() if k not in ("manifest_hash", "manifest_signatures")}
+    recomputed = hashlib.sha256(_canonical_json(core)).hexdigest()
+    if recomputed != manifest_hash:
+        return [
+            (
+                Verdict.DRIFT,
+                "manifest_hash does not match the manifest's own content — manifest metadata was tampered with",
+            )
+        ]
+
+    manifest_keys = manifest.get("keys", {})
+    last_finding: Finding | None = None
+    for sig in signatures:
+        public_key, finding = _resolve_public_key(sig["key_id"], manifest_keys, trusted_keys)
+        if public_key is None:
+            last_finding = finding
+            continue
+        try:
+            ok = _verify_signature(
+                algorithm=sig["algorithm"],
+                public_key=public_key,
+                data=bytes.fromhex(manifest_hash),
+                signature=base64.b64decode(sig["signature_b64"]),
+            )
+        except Exception as exc:
+            last_finding = (
+                Verdict.UNVERIFIABLE,
+                f"manifest signature verification raised an error: {exc}",
+            )
+            continue
+        if ok:
+            return []
+        last_finding = (
+            Verdict.DRIFT,
+            f"manifest signature from key_id {sig['key_id']!r} is invalid",
+        )
+
+    return [
+        last_finding
+        or (Verdict.UNVERIFIABLE, "no valid manifest signature found from a recognized key")
+    ]
+
+
+def _verify_record_self_consistency(rec: AuditRecord, i: int) -> list[Finding]:
+    """payload_hash matches the payload, and the overall hash matches the metadata + payload_hash."""
+    try:
+        recomputed_payload_hash = _payload_hash(rec.payload)
+    except Exception as exc:
+        return [
+            (
+                Verdict.UNVERIFIABLE,
+                f"record {i} ({rec.event_id}) payload could not be hashed: {exc}",
+            )
+        ]
+    if recomputed_payload_hash != rec.payload_hash:
+        return [
+            (
+                Verdict.DRIFT,
+                f"record {i} ({rec.event_id}) payload_hash does not match its payload — tampered payload",
+            )
+        ]
+    try:
+        recomputed_hash = _record_hash(rec)
+    except Exception as exc:
+        return [(Verdict.UNVERIFIABLE, f"record {i} ({rec.event_id}) could not be hashed: {exc}")]
+    if recomputed_hash != rec.hash:
+        return [
+            (
+                Verdict.DRIFT,
+                f"record {i} ({rec.event_id}) hash does not match its content — tampered record",
+            )
+        ]
+    return []
+
+
+def _verify_selective(
+    loaded: LoadedBundle, *, trusted_keys: dict[str, bytes] | None
+) -> list[Finding]:
+    """Verify a selective-disclosure bundle via per-record Merkle proofs.
+
+    A subset export can't satisfy the "recompute every leaf in the
+    batch" check (most leaves are intentionally absent), so each kept
+    record instead carries an inclusion proof against the *original*
+    signed Merkle root. Chain contiguity (prev_hash linkage) is not
+    checked here — by design, disclosure legitimately omits ancestors.
+    """
+    findings: list[Finding] = []
+    proofs_by_event = {p["event_id"]: p for p in loaded.hashes_doc.get("proofs", [])}
+    sig_by_range = {(s["start_index"], s["end_index"]): s for s in loaded.signatures_doc}
+    manifest_keys = loaded.manifest.get("keys", {})
+
+    for i, rec in enumerate(loaded.records):
+        self_findings = _verify_record_self_consistency(rec, i)
+        if self_findings:
+            findings.extend(self_findings)
+            continue
+
+        proof = proofs_by_event.get(rec.event_id)
+        if proof is None:
+            findings.append(
+                (
+                    Verdict.UNVERIFIABLE,
+                    f"record {i} ({rec.event_id}) has no Merkle proof in this selective bundle",
+                )
+            )
+            continue
+        if proof["leaf"] != rec.hash:
+            findings.append(
+                (
+                    Verdict.DRIFT,
+                    f"record {i} ({rec.event_id}) hash does not match the leaf its Merkle proof was issued for",
+                )
+            )
+            continue
+
+        signature = sig_by_range.get((proof["batch_start"], proof["batch_end"]))
+        if signature is None:
+            findings.append(
+                (
+                    Verdict.UNVERIFIABLE,
+                    f"record {i} ({rec.event_id}) references a batch with no matching signature",
+                )
+            )
+            continue
+        if not _verify_merkle_proof(
+            proof["leaf"], proof["siblings"], proof["sibling_is_right"], signature["merkle_root"]
+        ):
+            findings.append(
+                (
+                    Verdict.DRIFT,
+                    f"record {i} ({rec.event_id}) Merkle proof does not resolve to the signed root",
+                )
+            )
+            continue
+
+        public_key, finding = _resolve_public_key(signature["key_id"], manifest_keys, trusted_keys)
+        if public_key is None:
+            findings.append((finding[0], f"record {i} ({rec.event_id}): {finding[1]}"))
+            continue
+        try:
+            ok = _verify_signature(
+                algorithm=signature["algorithm"],
+                public_key=public_key,
+                data=bytes.fromhex(signature["merkle_root"]),
+                signature=base64.b64decode(signature["signature_b64"]),
+            )
+        except Exception as exc:
+            findings.append(
+                (
+                    Verdict.UNVERIFIABLE,
+                    f"record {i} ({rec.event_id}) signature verification raised an error: {exc}",
+                )
+            )
+            continue
+        if not ok:
+            findings.append(
+                (
+                    Verdict.DRIFT,
+                    f"record {i} ({rec.event_id}) signature is invalid for key_id {signature['key_id']!r}",
+                )
+            )
+
+    return findings
+
+
+def _resolve_verdict(findings: list[Finding]) -> Verdict:
+    verdicts = {f[0] for f in findings}
+    if Verdict.DRIFT in verdicts:
+        return Verdict.DRIFT
+    if Verdict.UNVERIFIABLE in verdicts:
+        return Verdict.UNVERIFIABLE
+    return Verdict.MATCH
+
+
+def _record_metrics(m: AuditMetrics, findings: list[Finding]) -> None:
+    for _verdict, message in {(f[0], f[1]) for f in findings}:
+        m.record_verification_failure(reason=_categorize(message))
+
+
+_FAILURE_CATEGORIES: tuple[tuple[str, str], ...] = (
+    ("schema version", "schema_version"),
+    ("prev_hash", "hash_chain"),
+    ("hash does not match", "hash_chain"),
+    ("parent_id", "parent_id"),
+    ("merkle", "merkle"),
+    ("signature", "signature"),
+    ("manifest", "manifest"),
+    ("record_count", "manifest"),
+    ("trusted key set", "untrusted_key"),
+)
+
+
+def _categorize(error: str) -> str:
+    for needle, category in _FAILURE_CATEGORIES:
+        if needle.lower() in error.lower():
+            return category
+    return "other"
+
+
+def verify(
+    bundle_path: str | Path,
+    *,
+    trusted_keys: dict[str, bytes] | None = None,
+    metrics: AuditMetrics | None = None,
+) -> VerificationResult:
+    """Verify a bundle end to end: schema, hash chain, Merkle roots, signatures, manifest.
+
+    Checks (in order, all run even after early failures where possible so
+    a single ``verify()`` call surfaces every problem at once):
+
+    1. bundle is a well-formed zip with all four required entries
+    2. manifest schema_version is one this verifier understands
+    3. every record's payload_hash matches its payload, and its overall
+       hash matches its metadata + payload_hash
+    4. every record's prev_hash links to the previous record in its run
+       (catches tampering, reordering, and deletion)
+    5. parent_id references point to an earlier record in the same run
+    6. per-batch leaf hashes + Merkle root match what's recorded
+    7. per-batch signature verifies against a public key — pinned via
+       ``trusted_keys`` if supplied, otherwise the manifest's own key
+       registry (see the module docstring on why that's a weaker claim)
+    8. the manifest itself is signed and its metadata (record_count,
+       run_ids, created_at, key registry, ...) matches that signature
+
+    Returns a :class:`~synapsekit.audit.types.VerificationResult` whose
+    ``verdict`` is ``MATCH``, ``DRIFT`` (evidence contradicts a claim —
+    tampering), or ``UNVERIFIABLE`` (not enough evidence to decide —
+    e.g. a corrupted bundle or a key this call wasn't given).
+
+    Pass ``trusted_keys={key_id: public_key_bytes, ...}`` (sourced
+    independently of the bundle) for real non-repudiation; without it,
+    verification only proves internal self-consistency.
+    """
+    from .metrics import default_metrics
+
+    m = metrics if metrics is not None else default_metrics
+    trust_anchor = "pinned" if trusted_keys is not None else "none"
+
+    try:
+        loaded = load_bundle(bundle_path)
+    except Exception as exc:
+        m.record_verification_failure(reason="corrupted_bundle")
+        return VerificationResult(
+            verdict=Verdict.UNVERIFIABLE,
+            errors=[f"failed to open bundle: {exc}"],
+            trust_anchor=trust_anchor,
+        )
+
+    manifest = loaded.manifest
+    records = loaded.records
+    findings: list[Finding] = []
+
+    schema_version = manifest.get("schema_version")
+    if schema_version not in SUPPORTED_SCHEMA_VERSIONS:
+        findings.append(
+            (
+                Verdict.UNVERIFIABLE,
+                f"unsupported schema version {schema_version!r}; this verifier supports {sorted(SUPPORTED_SCHEMA_VERSIONS)}",
+            )
+        )
+        # A schema we don't understand may have an incompatible record
+        # layout — stop here rather than guess at further checks.
+        _record_metrics(m, findings)
+        return VerificationResult(
+            verdict=_resolve_verdict(findings),
+            errors=[f for _, f in findings],
+            record_count=len(records),
+            schema_version=schema_version,
+            trust_anchor=trust_anchor,
+        )
+
+    expected_count = manifest.get("record_count")
+    if expected_count is None:
+        findings.append((Verdict.UNVERIFIABLE, "manifest is missing 'record_count'"))
+    elif expected_count != len(records):
+        findings.append(
+            (
+                Verdict.DRIFT,
+                f"manifest declares {expected_count} records but trace.jsonl contains {len(records)} "
+                "— records were added or removed after signing",
+            )
+        )
+
+    if manifest.get("selective_disclosure"):
+        # A selective-disclosure manifest has no manifest_hash/
+        # manifest_signatures of its own (there's no signing key
+        # available when a subset is re-exported) — instead it embeds
+        # the original, still-validly-signed manifest verbatim.
+        original_manifest = manifest.get("original_manifest")
+        if original_manifest is None:
+            findings.append(
+                (
+                    Verdict.UNVERIFIABLE,
+                    "selective-disclosure manifest is missing 'original_manifest' — its metadata cannot be authenticated",
+                )
+            )
+        else:
+            findings.extend(
+                _verify_manifest_signature(original_manifest, trusted_keys=trusted_keys)
+            )
+        findings.extend(_verify_selective(loaded, trusted_keys=trusted_keys))
+        _record_metrics(m, findings)
+        return VerificationResult(
+            verdict=_resolve_verdict(findings),
+            errors=[f for _, f in findings],
+            record_count=len(records),
+            batch_count=len(
+                {(p["batch_start"], p["batch_end"]) for p in loaded.hashes_doc.get("proofs", [])}
+            ),
+            schema_version=schema_version,
+            trust_anchor=trust_anchor,
+        )
+
+    findings.extend(_verify_manifest_signature(manifest, trusted_keys=trusted_keys))
+
+    actual_run_ids = sorted({r.run_id for r in records})
+    if manifest.get("run_ids") is not None and manifest.get("run_ids") != actual_run_ids:
+        findings.append(
+            (
+                Verdict.DRIFT,
+                "manifest 'run_ids' does not match the run_ids actually present in trace.jsonl",
+            )
+        )
+
+    # --- hash chain, per run_id ---------------------------------------
+    seen_event_ids: dict[str, set[str]] = {}
+    last_hash_by_run: dict[str, str] = {}
+    for i, rec in enumerate(records):
+        run_seen = seen_event_ids.setdefault(rec.run_id, set())
+        expected_prev = last_hash_by_run.get(rec.run_id, GENESIS_HASH)
+        if rec.prev_hash != expected_prev:
+            findings.append(
+                (
+                    Verdict.DRIFT,
+                    f"record {i} ({rec.event_id}) prev_hash does not match the preceding record "
+                    f"in run {rec.run_id} — chain broken, reordered, or a record was deleted",
+                )
+            )
+        findings.extend(_verify_record_self_consistency(rec, i))
+
+        if rec.parent_id is not None and rec.parent_id not in run_seen:
+            findings.append(
+                (
+                    Verdict.DRIFT,
+                    f"record {i} ({rec.event_id}) has parent_id {rec.parent_id!r} "
+                    f"which does not reference an earlier record in run {rec.run_id}",
+                )
+            )
+
+        run_seen.add(rec.event_id)
+        last_hash_by_run[rec.run_id] = rec.hash
+
+    # --- Merkle roots + signatures, per batch ---------------------------
+    batches = loaded.hashes_doc.get("batches", [])
+    manifest_keys = manifest.get("keys", {})
+    sig_by_range = {(s["start_index"], s["end_index"]): s for s in loaded.signatures_doc}
+
+    for batch in batches:
+        start, end = batch["start_index"], batch["end_index"]
+        slice_records = records[start : end + 1]
+        actual_leaves = [r.hash for r in slice_records]
+        if actual_leaves != batch["leaves"]:
+            findings.append(
+                (
+                    Verdict.DRIFT,
+                    f"batch [{start}:{end}] leaf hashes do not match the recorded records (reordered or edited)",
+                )
+            )
+            continue
+
+        recomputed_root = _merkle_root(actual_leaves)
+        if recomputed_root != batch["merkle_root"]:
+            findings.append(
+                (
+                    Verdict.DRIFT,
+                    f"batch [{start}:{end}] Merkle root does not match its leaves — invalid Merkle tree",
+                )
+            )
+
+        signature = sig_by_range.get((start, end))
+        if signature is None:
+            findings.append(
+                (Verdict.UNVERIFIABLE, f"batch [{start}:{end}] has no matching signature")
+            )
+            continue
+        if signature["merkle_root"] != batch["merkle_root"]:
+            findings.append(
+                (
+                    Verdict.DRIFT,
+                    f"batch [{start}:{end}] signature covers a different Merkle root than hashes.merkle records",
+                )
+            )
+            continue
+
+        public_key, finding = _resolve_public_key(signature["key_id"], manifest_keys, trusted_keys)
+        if public_key is None:
+            findings.append((finding[0], f"batch [{start}:{end}]: {finding[1]}"))
+            continue
+
+        try:
+            ok = _verify_signature(
+                algorithm=signature["algorithm"],
+                public_key=public_key,
+                data=bytes.fromhex(signature["merkle_root"]),
+                signature=base64.b64decode(signature["signature_b64"]),
+            )
+        except Exception as exc:
+            findings.append(
+                (
+                    Verdict.UNVERIFIABLE,
+                    f"batch [{start}:{end}] signature verification raised an error: {exc}",
+                )
+            )
+            continue
+        if not ok:
+            findings.append(
+                (
+                    Verdict.DRIFT,
+                    f"batch [{start}:{end}] signature is invalid for key_id {signature['key_id']!r}",
+                )
+            )
+
+    covered = sum(b["end_index"] - b["start_index"] + 1 for b in batches)
+    if covered != len(records):
+        findings.append(
+            (
+                Verdict.DRIFT,
+                f"batches cover {covered} records but the trace contains {len(records)} — unsigned records exist",
+            )
+        )
+
+    _record_metrics(m, findings)
+
+    return VerificationResult(
+        verdict=_resolve_verdict(findings),
+        errors=[f for _, f in findings],
+        record_count=len(records),
+        batch_count=len(batches),
+        schema_version=schema_version,
+        trust_anchor=trust_anchor,
+    )

--- a/src/synapsekit/audit/verifier.py
+++ b/src/synapsekit/audit/verifier.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import unicodedata
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -54,8 +55,17 @@ REQUIRED_ENTRIES = ("manifest.json", "trace.jsonl", "hashes.merkle", "signatures
 #: bundle produced by this package would fail its own verifier.
 _NODE_DOMAIN = b"\x01"
 
+#: Must match synapsekit.audit.merkle's leaf domain separation (RFC 6962
+#: §2.1: 0x00 for leaves, 0x01 for internal nodes) exactly, or a bundle
+#: produced by this package would fail its own verifier.
+_LEAF_DOMAIN = b"\x00"
+
 #: (verdict, message) — the atomic unit of evidence a check contributes.
 Finding = tuple[Verdict, str]
+
+
+def _hash_leaf(value: str) -> str:
+    return hashlib.sha256(_LEAF_DOMAIN + bytes.fromhex(value)).hexdigest()
 
 
 def _hash_pair(left: str, right: str) -> str:
@@ -97,24 +107,55 @@ def _verify_signature(*, algorithm: str, public_key: bytes, data: bytes, signatu
     raise ValueError(f"unsupported signing algorithm: {algorithm!r}")
 
 
+def _normalize_strings(value: Any) -> Any:
+    """Recursively apply Unicode NFC normalization to every string leaf.
+
+    Must mirror :func:`synapsekit.audit.serializer._normalize_strings`
+    exactly, or a record hashed by the producing package (which
+    normalizes) would not reproduce here (which wouldn't), and every
+    bundle containing non-NFC text would spuriously fail verification.
+    Also unwraps ``MappingProxyType``/frozenset — ``AuditRecord.from_dict``
+    deep-freezes the payload it reconstructs (see types.py), so a record
+    loaded from a bundle carries frozen containers just like a live one.
+    """
+    from types import MappingProxyType
+
+    if isinstance(value, str):
+        return unicodedata.normalize("NFC", value)
+    if isinstance(value, dict | MappingProxyType):
+        return {_normalize_strings(k): _normalize_strings(v) for k, v in value.items()}
+    if isinstance(value, list | tuple):
+        return [_normalize_strings(v) for v in value]
+    if isinstance(value, set | frozenset):
+        return sorted((_normalize_strings(v) for v in value), key=repr)
+    return value
+
+
 def _canonical_json(value: Any) -> bytes:
     """Canonical serialization for values already made of plain JSON types
     (str/int/float/bool/None/dict/list) — used for record and manifest
     hashing. A record's ``timestamp`` is the one exception (a live
-    ``datetime``), handled via ``default=``.
+    ``datetime``), handled via ``default=``. Must match
+    :func:`synapsekit.audit.serializer.canonical_json` byte-for-byte for
+    any value both can serialize, or this standalone verifier would
+    disagree with the hashes SynapseKit itself produces.
     """
 
     def default(obj: Any) -> Any:
         from datetime import date, datetime, timezone
+        from types import MappingProxyType
 
         if isinstance(obj, datetime):
             return obj.astimezone(timezone.utc).isoformat()
         if isinstance(obj, date):
             return obj.isoformat()
+        if isinstance(obj, MappingProxyType):
+            return dict(obj)
         raise TypeError(f"Object of type {type(obj).__name__} is not canonically serializable")
 
+    normalized = _normalize_strings(value)
     text = json.dumps(
-        value,
+        normalized,
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=True,
@@ -339,7 +380,7 @@ def _verify_selective(
                 )
             )
             continue
-        if proof["leaf"] != rec.hash:
+        if proof["leaf"] != _hash_leaf(rec.hash):
             findings.append(
                 (
                     Verdict.DRIFT,
@@ -596,7 +637,7 @@ def verify(
     for batch in batches:
         start, end = batch["start_index"], batch["end_index"]
         slice_records = records[start : end + 1]
-        actual_leaves = [r.hash for r in slice_records]
+        actual_leaves = [_hash_leaf(r.hash) for r in slice_records]
         if actual_leaves != batch["leaves"]:
             findings.append(
                 (

--- a/src/synapsekit/audit/verifier.py
+++ b/src/synapsekit/audit/verifier.py
@@ -370,6 +370,9 @@ def _verify_selective(
 
         public_key, finding = _resolve_public_key(signature["key_id"], manifest_keys, trusted_keys)
         if public_key is None:
+            assert (
+                finding is not None
+            )  # _resolve_public_key always sets one when public_key is None
             findings.append((finding[0], f"record {i} ({rec.event_id}): {finding[1]}"))
             continue
         try:
@@ -629,6 +632,9 @@ def verify(
 
         public_key, finding = _resolve_public_key(signature["key_id"], manifest_keys, trusted_keys)
         if public_key is None:
+            assert (
+                finding is not None
+            )  # _resolve_public_key always sets one when public_key is None
             findings.append((finding[0], f"batch [{start}:{end}]: {finding[1]}"))
             continue
 

--- a/src/synapsekit/audit/wrapper.py
+++ b/src/synapsekit/audit/wrapper.py
@@ -1,0 +1,448 @@
+"""VerifiableAgent — wraps any existing agent without changing its code.
+
+A transparent proxy: attribute access is forwarded to the wrapped agent,
+and callables are instrumented on the fly to emit hash-chained
+:class:`~synapsekit.audit.types.AuditRecord`\\ s around every call made
+*through the proxy*. Method names are mapped onto the stable
+:class:`~synapsekit.audit.types.EventKind` taxonomy — for kinds that
+come in call/response pairs (``LLM_CALL``/``LLM_RESPONSE``,
+``TOOL_CALL``/``TOOL_RESULT``), two linked records are emitted: one
+immediately before invocation, one after completion (or ``ERROR`` on an
+exception), with the response/result as a child of the call. Kinds with
+no natural pair (``RETRIEVAL``, ``MEMORY_READ``/``WRITE``, ``DECISION``,
+``STATE_CHANGE``) get a single record after completion, switching to
+``ERROR`` on an exception.
+
+Calls made through the proxy while another proxied call is in flight
+automatically get the right ``parent_id`` via a :mod:`contextvars`
+stack — e.g. calling ``verifiable.retrieve(...)`` from inside a handler
+that's running because of ``verifiable.run(...)`` records the retrieval
+as a child of that run's call event, with no manual wiring.
+
+Because this is an external proxy, calls the *agent's own methods* make
+directly on ``self`` are, by default, invisible to it — there is no
+source to change, but also nothing to intercept there. Pass
+``instrument_attrs=["llm", "retriever", ...]`` to close that gap for
+agents composed of named sub-components: each listed attribute's public
+methods are monkey-patched *in place* on the live object (not just on
+the outer proxy), so the agent's own internal ``self.llm.generate(...)``
+calls are captured too, without touching the agent's source. This still
+can't help fully inlined logic with no delegated sub-object — for that,
+construct with already-:func:`audited` tools/LLM calls instead.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import functools
+import inspect
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+from .redact import PIIRedactor
+from .trace import AuditTracer
+from .types import EventKind
+
+_current_event_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "synapsekit_audit_current_event_id", default=None
+)
+
+#: Kinds with a natural call/response pair — two records are emitted.
+_PAIRED_KIND_KEYWORDS: list[tuple[EventKind, EventKind, tuple[str, ...]]] = [
+    (
+        EventKind.LLM_CALL,
+        EventKind.LLM_RESPONSE,
+        ("generate", "chat", "complete", "predict", "llm"),
+    ),
+    (
+        EventKind.TOOL_CALL,
+        EventKind.TOOL_RESULT,
+        ("run", "step", "tool", "call", "execute", "act", "invoke"),
+    ),
+]
+
+#: Kinds with no natural pair — a single record is emitted after completion.
+_SINGLE_KIND_KEYWORDS: list[tuple[EventKind, tuple[str, ...]]] = [
+    (EventKind.RETRIEVAL, ("retrieve", "search", "query", "lookup")),
+    (EventKind.MEMORY_WRITE, ("remember", "save_memory", "write_memory", "store_memory")),
+    (EventKind.MEMORY_READ, ("recall", "load_memory", "read_memory", "get_memory")),
+    (EventKind.DECISION, ("decide", "choose", "route", "plan")),
+    (EventKind.STATE_CHANGE, ("transition", "set_state", "advance")),
+    (EventKind.USER_INPUT, ("user_input", "on_message", "receive_input")),
+]
+
+
+def infer_kind_pair(method_name: str) -> tuple[EventKind, EventKind | None]:
+    """Map a method name onto ``(call_kind, result_kind)``.
+
+    ``result_kind`` is ``None`` for kinds with no natural call/response
+    pair — the caller should emit a single record for those, not two.
+    Falls back to ``(EventKind.SYSTEM_EVENT, None)`` for anything
+    unrecognized rather than allowing an arbitrary string, per the
+    taxonomy being a closed, public specification.
+    """
+    # Single-kind keywords are checked first: they tend to be more
+    # specific ("recall", "decide") than the paired-kind keywords, which
+    # include short, generic substrings ("call", "step", "run") prone to
+    # false positives inside longer method names (e.g. "call" inside
+    # "recall_memory", "step" inside "decide_next_step").
+    name = method_name.lower()
+    for kind, keywords in _SINGLE_KIND_KEYWORDS:
+        if any(kw in name for kw in keywords):
+            return kind, None
+    for call_kind, result_kind, keywords in _PAIRED_KIND_KEYWORDS:
+        if any(kw in name for kw in keywords):
+            return call_kind, result_kind
+    return EventKind.SYSTEM_EVENT, None
+
+
+def _safe_value(value: Any, *, _depth: int = 0) -> Any:
+    """Best-effort coercion to something canonical-JSON-serializable.
+
+    Audit payloads must hash deterministically, so anything that isn't a
+    primitive/dict/list gets rendered to its ``repr()``-free string form
+    rather than being hashed by object identity (which would make the
+    same logical call hash differently every run).
+    """
+    if _depth > 6:
+        return "<max-depth-exceeded>"
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _safe_value(v, _depth=_depth + 1) for k, v in value.items()}
+    if isinstance(value, list | tuple | set | frozenset):
+        return [_safe_value(v, _depth=_depth + 1) for v in value]
+    if hasattr(value, "to_dict") and callable(value.to_dict):
+        try:
+            return _safe_value(value.to_dict(), _depth=_depth + 1)
+        except Exception:
+            pass
+    return str(value)
+
+
+class VerifiableAgent:
+    """Wraps ``agent`` so every method call is captured in a hash-chained trace.
+
+    Usage::
+
+        tracer = AuditTracer()
+        verifiable = VerifiableAgent(my_agent, tracer=tracer)
+        result = await verifiable.run("do the thing")  # traced automatically
+        records = tracer.drain()
+    """
+
+    def __init__(
+        self,
+        agent: Any,
+        *,
+        tracer: AuditTracer | None = None,
+        redactor: PIIRedactor | None = None,
+        actor: str | None = None,
+        kind_overrides: dict[str, EventKind] | None = None,
+        instrument_attrs: list[str] | None = None,
+    ) -> None:
+        object.__setattr__(self, "_agent", agent)
+        object.__setattr__(self, "tracer", tracer if tracer is not None else AuditTracer())
+        object.__setattr__(self, "_redactor", redactor)
+        object.__setattr__(self, "_actor", actor or f"agent:{type(agent).__name__}")
+        object.__setattr__(self, "_kind_overrides", kind_overrides or {})
+        for attr_name in instrument_attrs or []:
+            self._instrument_attr_in_place(attr_name)
+
+    def _kinds_for(self, name: str) -> tuple[EventKind, EventKind | None]:
+        override = self._kind_overrides.get(name)
+        if override is not None:
+            return override, None
+        return infer_kind_pair(name)
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._agent, name)
+        if not callable(attr):
+            return attr
+        call_kind, result_kind = self._kinds_for(name)
+        return self._instrument(name, attr, call_kind, result_kind)
+
+    def _instrument_attr_in_place(self, attr_name: str) -> None:
+        """Monkey-patch a named sub-attribute's methods on the *live* agent object.
+
+        Unlike the outer proxy (which only sees calls made through it),
+        this rewrites ``self._agent.<attr_name>``'s own methods so the
+        agent's *internal* code — e.g. ``self.llm.generate(...)`` called
+        from within its own ``run()`` — routes through the tracer too.
+        Best-effort: attributes that don't support instance-level
+        attribute assignment (slots, builtins, immutable types) are left
+        alone rather than raising.
+        """
+        target = getattr(self._agent, attr_name, None)
+        if target is None:
+            return
+        for method_name in dir(target):
+            if method_name.startswith("_"):
+                continue
+            method = getattr(target, method_name, None)
+            if not callable(method):
+                continue
+            call_kind, result_kind = self._kinds_for(method_name)
+            instrumented = self._instrument(method_name, method, call_kind, result_kind)
+            try:
+                object.__setattr__(target, method_name, instrumented)
+            except (AttributeError, TypeError):
+                continue
+
+    def _base_payload(self, name: str, args: tuple, kwargs: dict) -> dict[str, Any]:
+        return {
+            "method": name,
+            "args": _safe_value(list(args)),
+            "kwargs": _safe_value(kwargs),
+        }
+
+    def _finalize(self, payload: dict[str, Any]) -> dict[str, Any]:
+        # Redaction must cover the full payload — including output/error,
+        # not just the pre-call args/kwargs — since those can echo back
+        # PII from the call's inputs (see redact.py's module docstring).
+        if self._redactor is not None:
+            payload = self._redactor.redact_payload(payload)
+        return payload
+
+    def _record_call(
+        self, call_kind: EventKind, payload: dict[str, Any], parent_id: str | None, event_id: str
+    ) -> None:
+        self.tracer.record(
+            call_kind,
+            self._finalize(payload),
+            actor=self._actor,
+            parent_id=parent_id,
+            event_id=event_id,
+        )
+
+    def _record_outcome(
+        self,
+        *,
+        paired: bool,
+        result_kind: EventKind | None,
+        call_kind: EventKind,
+        payload: dict[str, Any],
+        parent_id: str | None,
+        call_event_id: str,
+        is_error: bool,
+    ) -> None:
+        if is_error:
+            kind = EventKind.ERROR
+        else:
+            kind = result_kind if paired else call_kind
+        if paired:
+            # The response/result is a child of its own call event.
+            self.tracer.record(
+                kind, self._finalize(payload), actor=self._actor, parent_id=call_event_id
+            )
+        else:
+            # No pairing — this IS the call event (reuses its event_id).
+            self.tracer.record(
+                kind,
+                self._finalize(payload),
+                actor=self._actor,
+                parent_id=parent_id,
+                event_id=call_event_id,
+            )
+
+    def _instrument(
+        self, name: str, fn: Callable[..., Any], call_kind: EventKind, result_kind: EventKind | None
+    ) -> Callable[..., Any]:
+        paired = result_kind is not None
+
+        if inspect.iscoroutinefunction(fn):
+
+            @functools.wraps(fn)
+            async def async_wrapped(*args: Any, **kwargs: Any) -> Any:
+                parent_id = _current_event_id.get()
+                call_event_id = uuid.uuid4().hex
+                base_payload = self._base_payload(name, args, kwargs)
+                if paired:
+                    self._record_call(call_kind, dict(base_payload), parent_id, call_event_id)
+                token = _current_event_id.set(call_event_id)
+                try:
+                    result = await fn(*args, **kwargs)
+                    payload = {**base_payload, "output": _safe_value(result), "status": "ok"}
+                    self._record_outcome(
+                        paired=paired,
+                        result_kind=result_kind,
+                        call_kind=call_kind,
+                        payload=payload,
+                        parent_id=parent_id,
+                        call_event_id=call_event_id,
+                        is_error=False,
+                    )
+                    return result
+                except Exception as exc:
+                    payload = {
+                        **base_payload,
+                        "error": str(exc),
+                        "error_type": type(exc).__name__,
+                        "status": "error",
+                    }
+                    self._record_outcome(
+                        paired=paired,
+                        result_kind=result_kind,
+                        call_kind=call_kind,
+                        payload=payload,
+                        parent_id=parent_id,
+                        call_event_id=call_event_id,
+                        is_error=True,
+                    )
+                    raise
+                finally:
+                    _current_event_id.reset(token)
+
+            return async_wrapped
+
+        @functools.wraps(fn)
+        def sync_wrapped(*args: Any, **kwargs: Any) -> Any:
+            parent_id = _current_event_id.get()
+            call_event_id = uuid.uuid4().hex
+            base_payload = self._base_payload(name, args, kwargs)
+            if paired:
+                self._record_call(call_kind, dict(base_payload), parent_id, call_event_id)
+            token = _current_event_id.set(call_event_id)
+            try:
+                result = fn(*args, **kwargs)
+                payload = {**base_payload, "output": _safe_value(result), "status": "ok"}
+                self._record_outcome(
+                    paired=paired,
+                    result_kind=result_kind,
+                    call_kind=call_kind,
+                    payload=payload,
+                    parent_id=parent_id,
+                    call_event_id=call_event_id,
+                    is_error=False,
+                )
+                return result
+            except Exception as exc:
+                payload = {
+                    **base_payload,
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                    "status": "error",
+                }
+                self._record_outcome(
+                    paired=paired,
+                    result_kind=result_kind,
+                    call_kind=call_kind,
+                    payload=payload,
+                    parent_id=parent_id,
+                    call_event_id=call_event_id,
+                    is_error=True,
+                )
+                raise
+            finally:
+                _current_event_id.reset(token)
+
+        return sync_wrapped
+
+    @property
+    def wrapped(self) -> Any:
+        """Escape hatch to the underlying, un-instrumented agent."""
+        return self._agent
+
+
+def audited(
+    kind: EventKind | str = EventKind.SYSTEM_EVENT,
+    *,
+    tracer: AuditTracer,
+    redactor: PIIRedactor | None = None,
+    actor: str = "system",
+    name: str | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator form of :class:`VerifiableAgent` for standalone functions/tools.
+
+    Emits a single record per call (kind ``kind`` on success, always
+    ``EventKind.ERROR`` on an exception regardless of ``kind``). Useful
+    when you want to audit one specific tool or LLM-call helper rather
+    than wrapping an entire agent object::
+
+        tracer = AuditTracer()
+
+        @audited(EventKind.TOOL_CALL, tracer=tracer)
+        async def search_web(query: str) -> str: ...
+    """
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        call_name = name or fn.__name__
+
+        def build_payload(args: tuple, kwargs: dict) -> dict[str, Any]:
+            return {
+                "method": call_name,
+                "args": _safe_value(list(args)),
+                "kwargs": _safe_value(kwargs),
+            }
+
+        def finalize(payload: dict[str, Any]) -> dict[str, Any]:
+            # Redact the full payload (including output/error), not just
+            # the pre-call args/kwargs — see redact.py's module docstring.
+            if redactor is not None:
+                payload = redactor.redact_payload(payload)
+            return payload
+
+        if inspect.iscoroutinefunction(fn):
+
+            @functools.wraps(fn)
+            async def async_wrapped(*args: Any, **kwargs: Any) -> Any:
+                parent_id = _current_event_id.get()
+                event_id = uuid.uuid4().hex
+                payload = build_payload(args, kwargs)
+                token = _current_event_id.set(event_id)
+                try:
+                    result = await fn(*args, **kwargs)
+                    payload["output"] = _safe_value(result)
+                    payload["status"] = "ok"
+                    emitted_kind = kind
+                    return result
+                except Exception as exc:
+                    payload["error"] = str(exc)
+                    payload["error_type"] = type(exc).__name__
+                    payload["status"] = "error"
+                    emitted_kind = EventKind.ERROR
+                    raise
+                finally:
+                    _current_event_id.reset(token)
+                    tracer.record(
+                        emitted_kind,
+                        finalize(payload),
+                        actor=actor,
+                        parent_id=parent_id,
+                        event_id=event_id,
+                    )
+
+            return async_wrapped
+
+        @functools.wraps(fn)
+        def sync_wrapped(*args: Any, **kwargs: Any) -> Any:
+            parent_id = _current_event_id.get()
+            event_id = uuid.uuid4().hex
+            payload = build_payload(args, kwargs)
+            token = _current_event_id.set(event_id)
+            try:
+                result = fn(*args, **kwargs)
+                payload["output"] = _safe_value(result)
+                payload["status"] = "ok"
+                emitted_kind = kind
+                return result
+            except Exception as exc:
+                payload["error"] = str(exc)
+                payload["error_type"] = type(exc).__name__
+                payload["status"] = "error"
+                emitted_kind = EventKind.ERROR
+                raise
+            finally:
+                _current_event_id.reset(token)
+                tracer.record(
+                    emitted_kind,
+                    finalize(payload),
+                    actor=actor,
+                    parent_id=parent_id,
+                    event_id=event_id,
+                )
+
+        return sync_wrapped
+
+    return decorator

--- a/src/synapsekit/audit/wrapper.py
+++ b/src/synapsekit/audit/wrapper.py
@@ -229,8 +229,11 @@ class VerifiableAgent:
     ) -> None:
         if is_error:
             kind = EventKind.ERROR
+        elif paired:
+            assert result_kind is not None  # paired implies a result_kind was supplied
+            kind = result_kind
         else:
-            kind = result_kind if paired else call_kind
+            kind = call_kind
         if paired:
             # The response/result is a child of its own call event.
             self.tracer.record(

--- a/src/synapsekit/cli/audit.py
+++ b/src/synapsekit/cli/audit.py
@@ -1,0 +1,184 @@
+"""``synapsekit audit`` commands: verify and replay signed audit bundles."""
+
+from __future__ import annotations
+
+import base64
+import sys
+from typing import Any
+
+
+def _add_trusted_key_arg(parser: Any) -> None:
+    parser.add_argument(
+        "--trusted-key",
+        dest="trusted_keys",
+        action="append",
+        metavar="KEY_ID:BASE64_PUBLIC_KEY",
+        default=None,
+        help=(
+            "Pin a public key obtained independently of the bundle (repeatable). "
+            "Without this, verification only proves the bundle wasn't edited after "
+            "export — NOT who produced it, since public keys are otherwise read "
+            "from the bundle's own manifest."
+        ),
+    )
+
+
+def _parse_trusted_keys(raw: list[str] | None) -> dict[str, bytes] | None:
+    if not raw:
+        return None
+    trusted: dict[str, bytes] = {}
+    for entry in raw:
+        key_id, sep, b64 = entry.partition(":")
+        if not sep:
+            raise SystemExit(f"invalid --trusted-key {entry!r}; expected KEY_ID:BASE64_PUBLIC_KEY")
+        trusted[key_id] = base64.b64decode(b64)
+    return trusted
+
+
+def build_audit_parser(subparsers: Any) -> None:
+    p = subparsers.add_parser(
+        "audit", help="Verify and replay cryptographically signed audit bundles"
+    )
+    audit_sub = p.add_subparsers(dest="audit_command")
+
+    verify_cmd = audit_sub.add_parser(
+        "verify", help="Verify a bundle's chain, Merkle tree, signatures, and manifest"
+    )
+    verify_cmd.add_argument("bundle", help="Path to the .zip audit bundle")
+    verify_cmd.add_argument(
+        "--format",
+        dest="output_format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format",
+    )
+    _add_trusted_key_arg(verify_cmd)
+
+    replay_cmd = audit_sub.add_parser(
+        "replay", help="Reconstruct and verify provenance from a bundle"
+    )
+    replay_cmd.add_argument("bundle", help="Path to the .zip audit bundle")
+    replay_cmd.add_argument(
+        "--format",
+        dest="output_format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format",
+    )
+    _add_trusted_key_arg(replay_cmd)
+
+
+def run_audit(args: Any) -> None:
+    if args.audit_command == "verify":
+        _run_verify(args)
+        return
+    if args.audit_command == "replay":
+        _run_replay(args)
+        return
+    raise SystemExit("Missing audit subcommand. Use: verify or replay")
+
+
+def _run_verify(args: Any) -> None:
+    from ..audit.verifier import verify
+
+    trusted_keys = _parse_trusted_keys(getattr(args, "trusted_keys", None))
+    result = verify(args.bundle, trusted_keys=trusted_keys)
+
+    if args.output_format == "json":
+        import json
+
+        print(
+            json.dumps(
+                {
+                    "verdict": result.verdict.value,
+                    "record_count": result.record_count,
+                    "batch_count": result.batch_count,
+                    "schema_version": result.schema_version,
+                    "trust_anchor": result.trust_anchor,
+                    "errors": result.errors,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(f"Bundle: {args.bundle}")
+        print(f"Schema version: {result.schema_version}")
+        print(f"Records: {result.record_count}  Batches: {result.batch_count}")
+        print(f"Verdict: {result.verdict.value}")
+        if result.ok:
+            print("Chain:      OK")
+            print("Merkle:     OK")
+            print("Signatures: OK")
+            print("Manifest:   OK")
+            if result.trust_anchor == "pinned":
+                print("Trust:      PINNED — signatures verified against caller-supplied keys")
+                print("\nMATCH — bundle is intact and was signed by a key you independently trust.")
+            else:
+                print(
+                    "Trust:      NONE — signatures verified only against keys embedded in the bundle"
+                )
+                print(
+                    "\nMATCH (self-consistent only) — bundle wasn't edited after export, but "
+                    "its signer's identity is UNAUTHENTICATED. Pass --trusted-key to establish that."
+                )
+        elif result.verdict.value == "DRIFT":
+            print("\nDRIFT — evidence contradicts recorded claims (tampering detected):")
+            for err in result.errors:
+                print(f"  - {err}")
+        else:
+            print("\nUNVERIFIABLE — not enough evidence to reach a conclusion:")
+            for err in result.errors:
+                print(f"  - {err}")
+
+    sys.exit(0 if result.ok else 1)
+
+
+def _run_replay(args: Any) -> None:
+    from ..audit.replay import ReplayEngine
+    from ..audit.verifier import verify
+
+    trusted_keys = _parse_trusted_keys(getattr(args, "trusted_keys", None))
+    verification = verify(args.bundle, trusted_keys=trusted_keys)
+    if not verification.ok:
+        print("Cannot replay: bundle failed verification.")
+        for err in verification.errors:
+            print(f"  - {err}")
+        sys.exit(1)
+
+    report = ReplayEngine().replay(args.bundle)
+
+    if args.output_format == "json":
+        import json
+
+        print(
+            json.dumps(
+                {
+                    "ok": report.ok,
+                    "record_count": report.record_count,
+                    "checked_tool_calls": report.checked_tool_calls,
+                    "checked_retrievals": report.checked_retrievals,
+                    "checked_decisions": report.checked_decisions,
+                    "skipped_llm_calls": report.skipped_llm_calls,
+                    "mismatches": [m.__dict__ for m in report.mismatches],
+                },
+                indent=2,
+                default=str,
+            )
+        )
+    else:
+        print(f"Bundle: {args.bundle}")
+        print(f"Records: {report.record_count}")
+        print(f"Tool calls checked: {report.checked_tool_calls}")
+        print(f"Retrievals checked: {report.checked_retrievals}")
+        print(f"Decisions checked: {report.checked_decisions}")
+        print(
+            f"LLM calls skipped (non-deterministic, not required to match): {report.skipped_llm_calls}"
+        )
+        if report.ok:
+            print("\nREPLAY OK — provenance reconstructed with no mismatches.")
+        else:
+            print("\nREPLAY MISMATCHES:")
+            for m in report.mismatches:
+                print(f"  - [{m.kind}] {m.event_id}: {m.reason}")
+
+    sys.exit(0 if report.ok else 1)

--- a/src/synapsekit/cli/main.py
+++ b/src/synapsekit/cli/main.py
@@ -155,6 +155,12 @@ def _add_edge_parser(subparsers: argparse._SubParsersAction) -> None:  # type: i
     build_edge_parser(subparsers)
 
 
+def _add_audit_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    from .audit import build_audit_parser
+
+    build_audit_parser(subparsers)
+
+
 def _add_agent_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = subparsers.add_parser("agent", help="Inspect and manage SynapseKit agents")
     agent_sub = p.add_subparsers(dest="agent_command")
@@ -203,6 +209,7 @@ def main(argv: list[str] | None = None) -> None:
     _add_agent_parser(subparsers)
     _add_ui_parser(subparsers)
     _add_plugin_parser(subparsers)
+    _add_audit_parser(subparsers)
 
     args = parser.parse_args(argv)
 
@@ -256,6 +263,10 @@ def main(argv: list[str] | None = None) -> None:
         from .plugins import run_plugin
 
         run_plugin(args)
+    elif args.command == "audit":
+        from .audit import run_audit
+
+        run_audit(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/tests/audit/conftest.py
+++ b/tests/audit/conftest.py
@@ -1,0 +1,67 @@
+"""Shared fixtures for the audit test suite."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from synapsekit.audit import AuditTracer, EventKind, SigningPolicy, export_audit_bundle
+from synapsekit.audit.serializer import hash_value
+
+
+def build_sample_records():
+    tracer = AuditTracer(run_id="run-1")
+    tracer.record(
+        EventKind.LLM_CALL, {"model": "gpt-4o-mini", "prompt": "What is 2+2?", "response": "4"}
+    )
+    tracer.record(
+        EventKind.TOOL_CALL,
+        {"tool": "calculator", "input": {"expr": "2+2"}, "output": 4},
+    )
+    tracer.record(
+        EventKind.RETRIEVAL,
+        {"query": "capital of france", "doc_ids": ["doc-1", "doc-2"]},
+    )
+    policy = {"rule": "always_confirm"}
+    tracer.record(
+        EventKind.DECISION,
+        {"policy": policy, "policy_hash": hash_value(policy), "decision": "proceed"},
+    )
+    return tracer.drain()
+
+
+@pytest.fixture
+def sample_records():
+    return build_sample_records()
+
+
+@pytest.fixture
+def bundle_path(tmp_path: Path, sample_records) -> Path:
+    policy = SigningPolicy.ed25519()
+    return export_audit_bundle(sample_records, policy, tmp_path / "sample.audit.zip")
+
+
+def read_zip_entries(path: Path) -> dict[str, bytes]:
+    with zipfile.ZipFile(path) as zf:
+        return {name: zf.read(name) for name in zf.namelist()}
+
+
+def write_zip_entries(path: Path, entries: dict[str, bytes]) -> None:
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+
+
+def load_trace_lines(entries: dict[str, bytes]) -> list[dict]:
+    return [
+        json.loads(line)
+        for line in entries["trace.jsonl"].decode("utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def dump_trace_lines(entries: dict[str, bytes], records: list[dict]) -> None:
+    entries["trace.jsonl"] = ("\n".join(json.dumps(r) for r in records) + "\n").encode("utf-8")

--- a/tests/audit/test_bundle_and_verifier.py
+++ b/tests/audit/test_bundle_and_verifier.py
@@ -1,0 +1,201 @@
+"""Bundle export + standalone verification — positive and negative (tamper) cases."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+from synapsekit.audit import SigningPolicy, export_audit_bundle
+from synapsekit.audit.verifier import verify
+
+from .conftest import dump_trace_lines, load_trace_lines, read_zip_entries, write_zip_entries
+
+
+class TestValidBundle:
+    def test_valid_bundle_verifies_ok(self, bundle_path: Path):
+        result = verify(bundle_path)
+        assert result.ok
+        assert result.errors == []
+        assert result.record_count == 4
+
+    def test_batch_count_matches_number_of_signed_batches(self, tmp_path, sample_records):
+        policy = SigningPolicy.ed25519()
+        path = export_audit_bundle(sample_records, policy, tmp_path / "b.zip", batch_size=2)
+        result = verify(path)
+        assert result.ok
+        assert result.batch_count == 2
+
+    def test_empty_record_set_produces_a_verifiable_empty_bundle(self, tmp_path):
+        policy = SigningPolicy.ed25519()
+        path = export_audit_bundle([], policy, tmp_path / "empty.zip")
+        result = verify(path)
+        assert result.ok
+        assert result.record_count == 0
+
+
+class TestNegativeVerification:
+    """Every listed tamper scenario MUST fail verification — never silently pass."""
+
+    def _mutate(self, tmp_path: Path, bundle_path: Path, mutate_records) -> Path:
+        entries = read_zip_entries(bundle_path)
+        records = load_trace_lines(entries)
+        records = mutate_records(records)
+        dump_trace_lines(entries, records)
+        out = tmp_path / "mutated.zip"
+        write_zip_entries(out, entries)
+        return out
+
+    def test_remove_a_record(self, tmp_path, bundle_path):
+        mutated = self._mutate(tmp_path, bundle_path, lambda recs: recs[:-1])
+        result = verify(mutated)
+        assert not result.ok
+
+    def test_reorder_records(self, tmp_path, bundle_path):
+        def swap(recs):
+            recs = list(recs)
+            recs[0], recs[1] = recs[1], recs[0]
+            return recs
+
+        mutated = self._mutate(tmp_path, bundle_path, swap)
+        result = verify(mutated)
+        assert not result.ok
+
+    def test_modify_payload(self, tmp_path, bundle_path):
+        def tamper(recs):
+            recs[0]["payload"] = {**recs[0]["payload"], "prompt": "INJECTED"}
+            return recs
+
+        mutated = self._mutate(tmp_path, bundle_path, tamper)
+        result = verify(mutated)
+        assert not result.ok
+
+    def test_modify_timestamp(self, tmp_path, bundle_path):
+        def tamper(recs):
+            recs[0]["timestamp"] = "2099-01-01T00:00:00+00:00"
+            return recs
+
+        mutated = self._mutate(tmp_path, bundle_path, tamper)
+        result = verify(mutated)
+        assert not result.ok
+
+    def test_modify_hash(self, tmp_path, bundle_path):
+        def tamper(recs):
+            recs[0]["hash"] = "0" * 64
+            return recs
+
+        mutated = self._mutate(tmp_path, bundle_path, tamper)
+        result = verify(mutated)
+        assert not result.ok
+
+    def test_invalid_parent_id(self, tmp_path, bundle_path):
+        def tamper(recs):
+            recs[1]["parent_id"] = "does-not-exist"
+            return recs
+
+        mutated = self._mutate(tmp_path, bundle_path, tamper)
+        result = verify(mutated)
+        assert not result.ok
+        assert any("parent_id" in e for e in result.errors)
+
+    def test_invalid_merkle_root(self, tmp_path, bundle_path):
+        entries = read_zip_entries(bundle_path)
+        hashes_doc = json.loads(entries["hashes.merkle"])
+        hashes_doc["batches"][0]["merkle_root"] = "f" * 64
+        entries["hashes.merkle"] = json.dumps(hashes_doc).encode("utf-8")
+        out = tmp_path / "bad_merkle.zip"
+        write_zip_entries(out, entries)
+        result = verify(out)
+        assert not result.ok
+
+    def test_invalid_manifest_missing_record_count(self, tmp_path, bundle_path):
+        entries = read_zip_entries(bundle_path)
+        manifest = json.loads(entries["manifest.json"])
+        del manifest["record_count"]
+        entries["manifest.json"] = json.dumps(manifest).encode("utf-8")
+        out = tmp_path / "bad_manifest.zip"
+        write_zip_entries(out, entries)
+        result = verify(out)
+        assert not result.ok
+
+    def test_schema_version_mismatch(self, tmp_path, bundle_path):
+        entries = read_zip_entries(bundle_path)
+        manifest = json.loads(entries["manifest.json"])
+        manifest["schema_version"] = "99.0"
+        entries["manifest.json"] = json.dumps(manifest).encode("utf-8")
+        out = tmp_path / "bad_schema.zip"
+        write_zip_entries(out, entries)
+        result = verify(out)
+        assert not result.ok
+        assert "unsupported schema version" in result.errors[0]
+
+    def test_wrong_public_key(self, tmp_path, bundle_path):
+        entries = read_zip_entries(bundle_path)
+        manifest = json.loads(entries["manifest.json"])
+        other = SigningPolicy.ed25519()
+        for key_id in manifest["keys"]:
+            manifest["keys"][key_id]["public_key_b64"] = base64.b64encode(
+                other.provider.public_key_bytes()
+            ).decode("ascii")
+        entries["manifest.json"] = json.dumps(manifest).encode("utf-8")
+        out = tmp_path / "wrong_key.zip"
+        write_zip_entries(out, entries)
+        result = verify(out)
+        assert not result.ok
+
+    def test_missing_zip_entry_is_reported_not_crashed(self, tmp_path, bundle_path):
+        entries = read_zip_entries(bundle_path)
+        del entries["signatures.json"]
+        out = tmp_path / "missing_entry.zip"
+        write_zip_entries(out, entries)
+        result = verify(out)
+        assert not result.ok
+        assert result.errors  # never silently succeeds
+
+    def test_corrupted_zip_is_reported_not_crashed(self, tmp_path):
+        bad = tmp_path / "corrupt.zip"
+        bad.write_bytes(b"not a zip file at all")
+        result = verify(bad)
+        assert not result.ok
+
+    def test_missing_bundle_file_is_reported_not_crashed(self, tmp_path):
+        result = verify(tmp_path / "does_not_exist.zip")
+        assert not result.ok
+
+
+class TestKeyRotation:
+    def test_verification_succeeds_across_rotated_keys_in_one_bundle(
+        self, tmp_path, sample_records
+    ):
+        key_a = SigningPolicy.ed25519(key_id="key-a")
+        key_b = SigningPolicy.ed25519(key_id="key-b")
+        batch_a = sample_records[:2]
+        batch_b = sample_records[2:]
+
+        path = export_audit_bundle(
+            [],
+            [(batch_a, key_a), (batch_b, key_b)],
+            tmp_path / "rotated.zip",
+        )
+        result = verify(path)
+        assert result.ok
+        assert result.batch_count == 2
+
+    def test_tampering_after_rotation_still_caught(self, tmp_path, sample_records):
+        key_a = SigningPolicy.ed25519(key_id="key-a")
+        key_b = SigningPolicy.ed25519(key_id="key-b")
+        batch_a = sample_records[:2]
+        batch_b = sample_records[2:]
+        path = export_audit_bundle(
+            [], [(batch_a, key_a), (batch_b, key_b)], tmp_path / "rotated2.zip"
+        )
+
+        entries = read_zip_entries(path)
+        records = load_trace_lines(entries)
+        records[3]["payload"] = {**records[3]["payload"], "decision": "TAMPERED"}
+        dump_trace_lines(entries, records)
+        out = tmp_path / "rotated2_tampered.zip"
+        write_zip_entries(out, entries)
+
+        result = verify(out)
+        assert not result.ok

--- a/tests/audit/test_bundle_and_verifier.py
+++ b/tests/audit/test_bundle_and_verifier.py
@@ -118,6 +118,49 @@ class TestNegativeVerification:
         result = verify(out)
         assert not result.ok
 
+
+class TestMerkleLeafDomainSeparation:
+    """Regression test: the exported bundle's hashes.merkle leaves must be
+    the RFC 6962 domain-separated leaf hashes (hash_leaf(record.hash)),
+    not the raw record.hash values. On the buggy code, leaves ==
+    [r.hash for r in records] -- indistinguishable from an internal node
+    input. A valid bundle must still verify end to end with the fix.
+    """
+
+    def test_recorded_leaves_are_not_raw_record_hashes(self, bundle_path, sample_records):
+        entries = read_zip_entries(bundle_path)
+        hashes_doc = json.loads(entries["hashes.merkle"])
+        recorded_leaves = hashes_doc["batches"][0]["leaves"]
+        raw_hashes = [r.hash for r in sample_records]
+        assert recorded_leaves != raw_hashes
+
+    def test_recorded_leaves_match_hash_leaf_of_record_hash(self, bundle_path, sample_records):
+        from synapsekit.audit.merkle import hash_leaf
+
+        entries = read_zip_entries(bundle_path)
+        hashes_doc = json.loads(entries["hashes.merkle"])
+        recorded_leaves = hashes_doc["batches"][0]["leaves"]
+        expected = [hash_leaf(r.hash) for r in sample_records]
+        assert recorded_leaves == expected
+
+    def test_valid_bundle_with_domain_separated_leaves_still_verifies(self, bundle_path):
+        result = verify(bundle_path)
+        assert result.ok
+        assert result.errors == []
+
+    def test_replaying_raw_record_hash_as_a_leaf_is_rejected(self, tmp_path, bundle_path):
+        # Simulate an attacker who tries to pass a raw record.hash off as
+        # a pre-domain-separated leaf -- must fail Merkle verification.
+        entries = read_zip_entries(bundle_path)
+        records = load_trace_lines(entries)
+        hashes_doc = json.loads(entries["hashes.merkle"])
+        hashes_doc["batches"][0]["leaves"][0] = records[0]["hash"]
+        entries["hashes.merkle"] = json.dumps(hashes_doc).encode("utf-8")
+        out = tmp_path / "raw_hash_as_leaf.zip"
+        write_zip_entries(out, entries)
+        result = verify(out)
+        assert not result.ok
+
     def test_schema_version_mismatch(self, tmp_path, bundle_path):
         entries = read_zip_entries(bundle_path)
         manifest = json.loads(entries["manifest.json"])

--- a/tests/audit/test_cli.py
+++ b/tests/audit/test_cli.py
@@ -1,0 +1,116 @@
+"""``synapsekit audit verify`` / ``synapsekit audit replay`` CLI entry points."""
+
+from __future__ import annotations
+
+import pytest
+
+from synapsekit.cli.main import main
+
+
+class TestAuditCLI:
+    def test_verify_exits_zero_for_a_valid_bundle(self, bundle_path, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["audit", "verify", str(bundle_path)])
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "Verdict: MATCH" in out
+
+    def test_verify_exits_nonzero_for_a_tampered_bundle(self, tmp_path, bundle_path, capsys):
+        from .conftest import (
+            dump_trace_lines,
+            load_trace_lines,
+            read_zip_entries,
+            write_zip_entries,
+        )
+
+        entries = read_zip_entries(bundle_path)
+        records = load_trace_lines(entries)
+        records[0]["hash"] = "0" * 64
+        dump_trace_lines(entries, records)
+        tampered = tmp_path / "tampered.zip"
+        write_zip_entries(tampered, entries)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(["audit", "verify", str(tampered)])
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "DRIFT" in out
+
+    def test_verify_json_output_format(self, bundle_path, capsys):
+        with pytest.raises(SystemExit):
+            main(["audit", "verify", str(bundle_path), "--format", "json"])
+        out = capsys.readouterr().out
+        assert '"verdict": "MATCH"' in out
+
+    def test_replay_exits_zero_for_a_valid_bundle(self, bundle_path, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["audit", "replay", str(bundle_path)])
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "REPLAY OK" in out
+
+    def test_replay_refuses_to_run_on_a_bundle_that_fails_verification(
+        self, tmp_path, bundle_path, capsys
+    ):
+        from .conftest import (
+            dump_trace_lines,
+            load_trace_lines,
+            read_zip_entries,
+            write_zip_entries,
+        )
+
+        entries = read_zip_entries(bundle_path)
+        records = load_trace_lines(entries)
+        records[0]["hash"] = "0" * 64
+        dump_trace_lines(entries, records)
+        tampered = tmp_path / "tampered.zip"
+        write_zip_entries(tampered, entries)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(["audit", "replay", str(tampered)])
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "Cannot replay" in out
+
+    def test_verify_without_trusted_key_reports_self_consistent_only(self, bundle_path, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["audit", "verify", str(bundle_path)])
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "Trust:      NONE" in out
+
+    def test_verify_with_correct_trusted_key_passes(self, tmp_path, sample_records, capsys):
+        import base64
+
+        from synapsekit.audit import SigningPolicy, export_audit_bundle
+
+        policy = SigningPolicy.ed25519(key_id="release-key")
+        path = export_audit_bundle(sample_records, policy, tmp_path / "b.zip")
+        pubkey_b64 = base64.b64encode(policy.provider.public_key_bytes()).decode("ascii")
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(["audit", "verify", str(path), "--trusted-key", f"release-key:{pubkey_b64}"])
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "Trust:      PINNED" in out
+
+    def test_verify_with_wrong_trusted_key_fails(self, tmp_path, sample_records, capsys):
+        import base64
+
+        from synapsekit.audit import SigningPolicy, export_audit_bundle
+
+        policy = SigningPolicy.ed25519(key_id="release-key")
+        path = export_audit_bundle(sample_records, policy, tmp_path / "b.zip")
+        other_pubkey_b64 = base64.b64encode(
+            SigningPolicy.ed25519().provider.public_key_bytes()
+        ).decode("ascii")
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(["audit", "verify", str(path), "--trusted-key", f"release-key:{other_pubkey_b64}"])
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "DRIFT" in out
+
+    def test_malformed_trusted_key_argument_raises_system_exit(self, bundle_path):
+        with pytest.raises(SystemExit):
+            main(["audit", "verify", str(bundle_path), "--trusted-key", "not-a-valid-entry"])

--- a/tests/audit/test_metrics.py
+++ b/tests/audit/test_metrics.py
@@ -1,0 +1,119 @@
+"""AuditMetrics must actually fire as a side effect of real operations —
+not just exist as an importable, disconnected class.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from synapsekit.audit import (
+    AuditMetrics,
+    AuditTracer,
+    EventKind,
+    SigningPolicy,
+    export_audit_bundle,
+)
+from synapsekit.audit.redact import PIIRedactor
+from synapsekit.audit.verifier import verify
+
+prometheus_client = pytest.importorskip("prometheus_client")
+
+
+def _counter_total(metrics: AuditMetrics, attr: str) -> float:
+    metric = getattr(metrics, attr)
+    assert metric is not None, f"{attr} metric was never initialized"
+    total = 0.0
+    for sample_family in metric.collect():
+        for sample in sample_family.samples:
+            if sample.name.endswith("_total"):
+                total += sample.value
+    return total
+
+
+class TestSigningMetrics:
+    def test_export_audit_bundle_increments_records_signed(self, tmp_path, sample_records):
+        registry = prometheus_client.CollectorRegistry()
+        metrics = AuditMetrics(registry=registry)
+        policy = SigningPolicy.ed25519(metrics=metrics)
+
+        export_audit_bundle(sample_records, policy, tmp_path / "b.zip", metrics=metrics)
+
+        assert _counter_total(metrics, "_records_signed") == len(sample_records)
+
+    def test_sign_batch_directly_increments_the_counter_regardless_of_caller(self):
+        registry = prometheus_client.CollectorRegistry()
+        metrics = AuditMetrics(registry=registry)
+        policy = SigningPolicy.ed25519(metrics=metrics)
+
+        policy.sign_batch("ab" * 32, start_index=0, end_index=4)
+
+        assert _counter_total(metrics, "_records_signed") == 5
+
+
+class TestBundleExportMetrics:
+    def test_successful_export_increments_bundle_exports_total(self, tmp_path, sample_records):
+        registry = prometheus_client.CollectorRegistry()
+        metrics = AuditMetrics(registry=registry)
+
+        export_audit_bundle(
+            sample_records, SigningPolicy.ed25519(), tmp_path / "b.zip", metrics=metrics
+        )
+
+        assert _counter_total(metrics, "_bundle_exports") == 1
+
+
+class TestVerificationMetrics:
+    def test_failed_verification_increments_verification_failures_total(
+        self, tmp_path, bundle_path
+    ):
+        from .conftest import (
+            dump_trace_lines,
+            load_trace_lines,
+            read_zip_entries,
+            write_zip_entries,
+        )
+
+        entries = read_zip_entries(bundle_path)
+        records = load_trace_lines(entries)
+        records[0]["hash"] = "0" * 64
+        dump_trace_lines(entries, records)
+        tampered = tmp_path / "tampered.zip"
+        write_zip_entries(tampered, entries)
+
+        registry = prometheus_client.CollectorRegistry()
+        metrics = AuditMetrics(registry=registry)
+
+        result = verify(tampered, metrics=metrics)
+
+        assert not result.ok
+        assert _counter_total(metrics, "_verification_failures") >= 1
+
+    def test_successful_verification_does_not_increment_failures(self, bundle_path):
+        registry = prometheus_client.CollectorRegistry()
+        metrics = AuditMetrics(registry=registry)
+
+        result = verify(bundle_path, metrics=metrics)
+
+        assert result.ok
+        assert _counter_total(metrics, "_verification_failures") == 0
+
+
+class TestRedactionMetrics:
+    def test_redaction_increments_redactions_total(self):
+        registry = prometheus_client.CollectorRegistry()
+        metrics = AuditMetrics(registry=registry)
+        redactor = PIIRedactor(metrics=metrics)
+
+        redactor.redact_text("email me at a@b.com or c@d.com")
+
+        assert _counter_total(metrics, "_redactions") == 2
+
+    def test_tracer_level_redaction_also_feeds_the_metric(self):
+        registry = prometheus_client.CollectorRegistry()
+        metrics = AuditMetrics(registry=registry)
+        redactor = PIIRedactor(metrics=metrics)
+        tracer = AuditTracer(redactor=redactor)
+
+        tracer.record(EventKind.TOOL_CALL, {"note": "contact a@b.com"})
+
+        assert _counter_total(metrics, "_redactions") == 1

--- a/tests/audit/test_otel.py
+++ b/tests/audit/test_otel.py
@@ -1,0 +1,60 @@
+"""OTel mapping: every AuditRecord maps to a span/event; a record dropped
+before export means its span is simply missing — callers must reconcile
+record counts against exported spans themselves.
+"""
+
+from __future__ import annotations
+
+from synapsekit.audit import AuditTracer, EventKind
+from synapsekit.audit.otel import _OTEL_AVAILABLE, OTelAuditExporter, record_to_span_dict
+
+
+class TestRecordToSpanDict:
+    def test_maps_run_id_and_event_id_to_trace_and_span_id(self):
+        tracer = AuditTracer(run_id="run-42")
+        rec = tracer.record(EventKind.TOOL_CALL, {"tool": "calc"})
+        span = record_to_span_dict(rec)
+        assert span["trace_id"] == "run-42"
+        assert span["span_id"] == rec.event_id
+        assert span["name"] == "audit.TOOL_CALL"
+
+    def test_parent_child_relationship_is_preserved(self):
+        tracer = AuditTracer()
+        parent = tracer.record(EventKind.DECISION, {"x": 1})
+        child = tracer.record(EventKind.TOOL_CALL, {"x": 2}, parent_id=parent.event_id)
+        span = record_to_span_dict(child)
+        assert span["parent_span_id"] == parent.event_id
+
+
+class TestOTelAuditExporter:
+    def test_exporter_reflects_whether_the_opentelemetry_sdk_is_installed(self):
+        # Degrades gracefully either way: `available` mirrors whether the
+        # optional `opentelemetry` package is importable in this env,
+        # and construction never raises regardless of which it is.
+        exporter = OTelAuditExporter(service_name="test-service")
+        assert exporter.available is _OTEL_AVAILABLE
+
+    def test_export_records_returns_span_dicts_for_every_record(self):
+        tracer = AuditTracer()
+        tracer.record(EventKind.LLM_CALL, {"a": 1})
+        tracer.record(EventKind.TOOL_CALL, {"b": 2})
+        records = tracer.drain()
+        exporter = OTelAuditExporter()
+        spans = exporter.export_records(records)
+        assert len(spans) == len(records) == 2
+
+    def test_a_record_missing_from_the_export_set_has_no_span(self):
+        """ "Missing OTEL span" case: if a record never reaches export_records
+        (e.g. dropped by a filter upstream), no span is produced for it —
+        exporting is not implicitly complete just because *some* spans exist.
+        """
+        tracer = AuditTracer()
+        kept = tracer.record(EventKind.LLM_CALL, {"a": 1})
+        dropped = tracer.record(EventKind.TOOL_CALL, {"b": 2})
+        exporter = OTelAuditExporter()
+
+        spans = exporter.export_records([kept])  # simulate `dropped` never being forwarded
+
+        span_ids = {s["span_id"] for s in spans}
+        assert kept.event_id in span_ids
+        assert dropped.event_id not in span_ids

--- a/tests/audit/test_redact.py
+++ b/tests/audit/test_redact.py
@@ -1,0 +1,92 @@
+"""PII redaction: PII removed, hashes deterministic, and signatures remain valid post-redaction."""
+
+from __future__ import annotations
+
+from synapsekit.audit import AuditTracer, EventKind, SigningPolicy, export_audit_bundle
+from synapsekit.audit.redact import PIIRedactor
+from synapsekit.audit.serializer import hash_value
+from synapsekit.audit.verifier import verify
+
+
+class TestPIIRedactor:
+    def test_email_is_redacted(self):
+        redactor = PIIRedactor()
+        out = redactor.redact_text("contact me at alice@example.com please")
+        assert "alice@example.com" not in out
+        assert "[REDACTED:EMAIL]" in out
+
+    def test_phone_is_redacted(self):
+        redactor = PIIRedactor()
+        out = redactor.redact_text("call 555-123-4567 now")
+        assert "555-123-4567" not in out
+
+    def test_ssn_is_redacted(self):
+        redactor = PIIRedactor()
+        out = redactor.redact_text("ssn: 123-45-6789")
+        assert "123-45-6789" not in out
+        assert "[REDACTED:SSN]" in out
+
+    def test_credit_card_is_redacted(self):
+        redactor = PIIRedactor()
+        out = redactor.redact_text("card 4111111111111111 expires soon")
+        assert "4111111111111111" not in out
+
+    def test_ip_address_is_redacted(self):
+        redactor = PIIRedactor()
+        out = redactor.redact_text("connect to 192.168.1.100 now")
+        assert "192.168.1.100" not in out
+
+    def test_text_without_pii_is_unchanged(self):
+        redactor = PIIRedactor()
+        text = "just a normal sentence with no secrets"
+        assert redactor.redact_text(text) == text
+
+    def test_redact_payload_recurses_through_nested_structures(self):
+        redactor = PIIRedactor()
+        payload = {"user": {"email": "bob@example.com", "notes": ["call 555-987-6543"]}}
+        redacted = redactor.redact_payload(payload)
+        assert "bob@example.com" not in redacted["user"]["email"]
+        assert "555-987-6543" not in redacted["user"]["notes"][0]
+
+    def test_redaction_count_increments(self):
+        redactor = PIIRedactor()
+        redactor.redact_text("a@b.com and c@d.com")
+        assert redactor.redaction_count == 2
+
+    def test_pluggable_ml_detector_supplements_regex_detectors(self):
+        def fake_ner(text: str):
+            idx = text.find("Bob Smith")
+            return [(idx, idx + len("Bob Smith"), "PERSON")] if idx >= 0 else []
+
+        redactor = PIIRedactor(ml_detector=fake_ner)
+        out = redactor.redact_text("My name is Bob Smith and my email is x@y.com")
+        assert "Bob Smith" not in out
+        assert "x@y.com" not in out
+
+
+class TestRedactionBeforeHashing:
+    """Redaction must run BEFORE hashing — this is a documented, deliberate tradeoff."""
+
+    def test_hashing_the_redacted_payload_is_deterministic(self):
+        redactor = PIIRedactor()
+        payload = {"note": "email me at test@example.com"}
+        redacted_once = redactor.redact_payload(payload)
+        redacted_twice = PIIRedactor().redact_payload(payload)
+        assert hash_value(redacted_once) == hash_value(redacted_twice)
+
+    def test_bundle_built_from_redacted_payloads_verifies_normally(self, tmp_path):
+        redactor = PIIRedactor()
+        tracer = AuditTracer()
+        raw_payload = {"tool": "email_tool", "input": {"to": "alice@example.com"}, "output": "sent"}
+        tracer.record(EventKind.TOOL_CALL, redactor.redact_payload(raw_payload))
+
+        path = export_audit_bundle(
+            tracer.drain(), SigningPolicy.ed25519(), tmp_path / "redacted.zip"
+        )
+        result = verify(path)
+        assert result.ok
+
+        from .conftest import read_zip_entries
+
+        entries = read_zip_entries(path)
+        assert b"alice@example.com" not in entries["trace.jsonl"]

--- a/tests/audit/test_redact.py
+++ b/tests/audit/test_redact.py
@@ -64,6 +64,51 @@ class TestPIIRedactor:
         assert "x@y.com" not in out
 
 
+class TestCreditCardDetectorLuhnValidation:
+    """Regression test: the raw regex (13-16 digits, optional separators)
+    used to redact ANY numeric ID of that length — no Luhn check. That
+    over-redacts ordinary IDs (order numbers, tracking numbers) that
+    merely happen to be the right length. On the buggy code, a
+    Luhn-invalid 16-digit run was still redacted; on the fixed code it
+    is left alone.
+    """
+
+    def test_luhn_invalid_16_digit_id_is_not_redacted(self):
+        # A 16-digit run that is NOT Luhn-valid (fails the checksum) —
+        # e.g. a database/order ID that merely looks like a card number.
+        redactor = PIIRedactor()
+        non_card_id = "1234567890123456"  # fails Luhn
+        out = redactor.redact_text(f"order id {non_card_id} confirmed")
+        assert non_card_id in out
+        assert "[REDACTED:CREDIT_CARD]" not in out
+
+    def test_luhn_valid_card_number_is_still_redacted(self):
+        redactor = PIIRedactor()
+        # Standard Visa test number — Luhn-valid.
+        card = "4111111111111111"
+        out = redactor.redact_text(f"card {card} on file")
+        assert card not in out
+        assert "[REDACTED:CREDIT_CARD]" in out
+
+    def test_luhn_valid_card_with_dashes_is_redacted(self):
+        redactor = PIIRedactor()
+        card_with_dashes = "4111-1111-1111-1111"
+        out = redactor.redact_text(f"card {card_with_dashes} on file")
+        assert "1111-1111-1111-1111" not in out
+        assert "[REDACTED:CREDIT_CARD]" in out
+
+    def test_luhn_invalid_13_digit_run_is_not_redacted(self):
+        # Isolate the CreditCardDetector so PhoneDetector can't also
+        # match a 10-digit substring of this run and mask the assertion.
+        from synapsekit.audit.redact import CreditCardDetector
+
+        redactor = PIIRedactor(detectors=[CreditCardDetector])
+        non_card = "1234567890123"  # 13 digits, fails Luhn
+        out = redactor.redact_text(f"tracking {non_card} shipped")
+        assert non_card in out
+        assert "[REDACTED:CREDIT_CARD]" not in out
+
+
 class TestRedactionBeforeHashing:
     """Redaction must run BEFORE hashing — this is a documented, deliberate tradeoff."""
 

--- a/tests/audit/test_replay.py
+++ b/tests/audit/test_replay.py
@@ -1,0 +1,88 @@
+"""Replay: verifies provenance (inputs/tool outputs/retrieval refs/policy hashes),
+never requires deterministic LLM output.
+"""
+
+from __future__ import annotations
+
+from synapsekit.audit import AuditTracer, EventKind, SigningPolicy, export_audit_bundle
+from synapsekit.audit.replay import ReplayEngine
+from synapsekit.audit.serializer import hash_value
+
+
+class TestReplaySucceeds:
+    def test_replay_succeeds_on_a_clean_bundle(self, tmp_path, sample_records):
+        path = export_audit_bundle(sample_records, SigningPolicy.ed25519(), tmp_path / "b.zip")
+        report = ReplayEngine().replay(path)
+        assert report.ok
+        assert report.record_count == 4
+        assert report.checked_tool_calls == 1
+        assert report.checked_retrievals == 1
+        assert report.checked_decisions == 1
+        assert report.skipped_llm_calls == 1  # LLM determinism is optional, never enforced
+
+    def test_tool_output_matches_when_executor_reexecutes_it(self, tmp_path, sample_records):
+        path = export_audit_bundle(sample_records, SigningPolicy.ed25519(), tmp_path / "b.zip")
+
+        def calculator(inp):
+            left, _, right = inp["expr"].partition("+")
+            return int(left) + int(right)
+
+        report = ReplayEngine(tool_executors={"calculator": calculator}).replay(path)
+        assert report.ok
+
+    def test_retrieval_refs_match_against_a_live_corpus(self, tmp_path, sample_records):
+        path = export_audit_bundle(sample_records, SigningPolicy.ed25519(), tmp_path / "b.zip")
+        corpus = {"doc-1": "Paris is the capital of France.", "doc-2": "France is in Europe."}
+        report = ReplayEngine(retrieval_resolver=corpus.get).replay(path)
+        assert report.ok
+
+    def test_policy_hash_matches_recorded_policy(self, tmp_path, sample_records):
+        path = export_audit_bundle(sample_records, SigningPolicy.ed25519(), tmp_path / "b.zip")
+        report = ReplayEngine().replay(path)
+        assert not any(m.kind == EventKind.DECISION.value for m in report.mismatches)
+
+
+class TestReplayMismatches:
+    def test_tool_output_mismatch_is_detected(self, tmp_path, sample_records):
+        path = export_audit_bundle(sample_records, SigningPolicy.ed25519(), tmp_path / "b.zip")
+
+        def wrong_calculator(inp):
+            return 999999
+
+        report = ReplayEngine(tool_executors={"calculator": wrong_calculator}).replay(path)
+        assert not report.ok
+        assert any("different output" in m.reason for m in report.mismatches)
+
+    def test_missing_retrieval_ref_is_detected(self, tmp_path, sample_records):
+        path = export_audit_bundle(sample_records, SigningPolicy.ed25519(), tmp_path / "b.zip")
+        corpus = {"doc-1": "only doc-1 exists"}
+        report = ReplayEngine(retrieval_resolver=corpus.get).replay(path)
+        assert not report.ok
+        assert any("no longer resolves" in m.reason for m in report.mismatches)
+
+    def test_policy_hash_mismatch_is_detected(self, tmp_path):
+        tracer = AuditTracer()
+        tracer.record(
+            EventKind.DECISION,
+            {
+                "policy": {"rule": "a"},
+                "policy_hash": hash_value({"rule": "different"}),
+                "decision": "x",
+            },
+        )
+        path = export_audit_bundle(tracer.drain(), SigningPolicy.ed25519(), tmp_path / "b.zip")
+        report = ReplayEngine().replay(path)
+        assert not report.ok
+        assert any("policy_hash" in m.reason for m in report.mismatches)
+
+    def test_llm_output_is_never_required_to_match(self, tmp_path):
+        # No executor for llm calls at all — replay must not fail on this basis.
+        tracer = AuditTracer()
+        tracer.record(
+            EventKind.LLM_CALL,
+            {"model": "m", "prompt": "p", "response": "any nondeterministic text"},
+        )
+        path = export_audit_bundle(tracer.drain(), SigningPolicy.ed25519(), tmp_path / "b.zip")
+        report = ReplayEngine().replay(path)
+        assert report.ok
+        assert report.skipped_llm_calls == 1

--- a/tests/audit/test_selective_disclosure.py
+++ b/tests/audit/test_selective_disclosure.py
@@ -1,0 +1,87 @@
+"""Selective disclosure — exporting a subset of records must stay verifiable.
+
+A subset export can't recompute the full original Merkle batch (most
+leaves are intentionally missing), so each kept record carries its own
+Merkle inclusion proof against the original signed root instead.
+"""
+
+from __future__ import annotations
+
+from synapsekit.audit import EventKind, export_selective_bundle
+from synapsekit.audit.verifier import load_bundle, verify
+
+
+class TestSelectiveDisclosure:
+    def test_only_tool_calls_are_kept(self, tmp_path, bundle_path):
+        out = export_selective_bundle(
+            bundle_path, tmp_path / "tool_only.zip", kinds=[EventKind.TOOL_CALL.value]
+        )
+        loaded = load_bundle(out)
+        assert all(r.kind == EventKind.TOOL_CALL.value for r in loaded.records)
+        assert len(loaded.records) == 1
+
+    def test_only_retrieval_events_are_kept(self, tmp_path, bundle_path):
+        out = export_selective_bundle(
+            bundle_path, tmp_path / "retrieval_only.zip", kinds=[EventKind.RETRIEVAL.value]
+        )
+        loaded = load_bundle(out)
+        assert all(r.kind == EventKind.RETRIEVAL.value for r in loaded.records)
+
+    def test_selective_bundle_still_verifies(self, tmp_path, bundle_path):
+        out = export_selective_bundle(
+            bundle_path, tmp_path / "subset.zip", kinds=[EventKind.LLM_CALL.value]
+        )
+        result = verify(out)
+        assert result.ok
+        assert result.errors == []
+        assert result.record_count == 1
+
+    def test_original_signatures_are_carried_through_unchanged(self, tmp_path, bundle_path):
+        original = load_bundle(bundle_path)
+        out = export_selective_bundle(
+            bundle_path, tmp_path / "subset.zip", kinds=[EventKind.LLM_CALL.value]
+        )
+        subset = load_bundle(out)
+        assert subset.signatures_doc == original.signatures_doc
+
+    def test_manifest_flags_selective_disclosure(self, tmp_path, bundle_path):
+        out = export_selective_bundle(
+            bundle_path, tmp_path / "flagged.zip", kinds=[EventKind.LLM_CALL.value]
+        )
+        loaded = load_bundle(out)
+        assert loaded.manifest["selective_disclosure"] is True
+        assert loaded.manifest["record_count"] == 1
+
+    def test_tampering_a_disclosed_record_is_still_detected(self, tmp_path, bundle_path):
+        from .conftest import (
+            dump_trace_lines,
+            load_trace_lines,
+            read_zip_entries,
+            write_zip_entries,
+        )
+
+        out = export_selective_bundle(
+            bundle_path, tmp_path / "subset.zip", kinds=[EventKind.LLM_CALL.value]
+        )
+        entries = read_zip_entries(out)
+        records = load_trace_lines(entries)
+        records[0]["payload"] = {**records[0]["payload"], "prompt": "INJECTED"}
+        dump_trace_lines(entries, records)
+        tampered = tmp_path / "subset_tampered.zip"
+        write_zip_entries(tampered, entries)
+
+        result = verify(tampered)
+        assert not result.ok
+
+    def test_multi_batch_bundle_selective_disclosure_still_verifies(self, tmp_path, sample_records):
+        from synapsekit.audit import SigningPolicy, export_audit_bundle
+
+        path = export_audit_bundle(
+            sample_records, SigningPolicy.ed25519(), tmp_path / "multi.zip", batch_size=2
+        )
+        out = export_selective_bundle(
+            path, tmp_path / "multi_subset.zip", kinds=[EventKind.DECISION.value]
+        )
+        result = verify(out)
+        assert result.ok
+        assert result.record_count == 1

--- a/tests/audit/test_serializer.py
+++ b/tests/audit/test_serializer.py
@@ -1,0 +1,44 @@
+"""Deterministic canonical serialization must not depend on ordering/whitespace/platform quirks."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from synapsekit.audit.serializer import DeterministicSerializer, canonical_json, hash_value
+
+
+class TestCanonicalJSON:
+    def test_key_order_does_not_affect_output(self):
+        a = {"b": 1, "a": 2, "c": 3}
+        b = {"c": 3, "a": 2, "b": 1}
+        assert canonical_json(a) == canonical_json(b)
+
+    def test_no_whitespace_variance(self):
+        assert canonical_json({"a": 1}) == b'{"a":1}'
+
+    def test_nested_structures_are_deterministic(self):
+        a = {"x": {"z": 1, "y": 2}, "list": [3, 2, 1]}
+        b = {"list": [3, 2, 1], "x": {"y": 2, "z": 1}}
+        assert canonical_json(a) == canonical_json(b)
+
+    def test_datetime_is_normalized_to_utc_isoformat(self):
+        dt = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        out = canonical_json({"ts": dt})
+        assert b"2026-01-01T12:00:00+00:00" in out
+
+    def test_rejects_nan(self):
+        with pytest.raises(ValueError):
+            canonical_json({"x": float("nan")})
+
+    def test_hash_is_stable_across_key_order(self):
+        assert hash_value({"a": 1, "b": 2}) == hash_value({"b": 2, "a": 1})
+
+    def test_hash_changes_with_content(self):
+        assert hash_value({"a": 1}) != hash_value({"a": 2})
+
+    def test_deterministic_serializer_matches_module_functions(self):
+        value = {"z": 1, "a": [1, 2, 3]}
+        assert DeterministicSerializer.canonicalize(value) == canonical_json(value)
+        assert DeterministicSerializer.hash(value) == hash_value(value)

--- a/tests/audit/test_serializer.py
+++ b/tests/audit/test_serializer.py
@@ -42,3 +42,46 @@ class TestCanonicalJSON:
         value = {"z": 1, "a": [1, 2, 3]}
         assert DeterministicSerializer.canonicalize(value) == canonical_json(value)
         assert DeterministicSerializer.hash(value) == hash_value(value)
+
+
+class TestUnicodeNormalization:
+    """Regression test: payloads that render identically to a human but
+    use different Unicode encodings (combining vs precomposed
+    characters) must hash to the SAME value -- otherwise the "hash
+    commits to the logical value" claim in the module docstring is
+    false. On the buggy code these two forms of the same string hashed
+    differently; on the fixed code they must be equal.
+    """
+
+    # "cafe" + precomposed U+00E9 (LATIN SMALL LETTER E WITH ACUTE) --
+    # a single code point that renders as an accented e.
+    _PRECOMPOSED = "café"
+    # "cafe" + plain "e" (U+0065) + combining U+0301 (COMBINING ACUTE
+    # ACCENT) -- two code points that render identically to the
+    # precomposed form above, but are a different Python string.
+    _COMBINING = "café"
+
+    def test_precomposed_and_combining_forms_are_different_python_strings(self):
+        # Sanity check the fixture itself is testing what it claims to.
+        assert self._PRECOMPOSED != self._COMBINING
+        assert len(self._PRECOMPOSED) != len(self._COMBINING)
+
+    def test_combining_and_precomposed_accents_hash_the_same(self):
+        assert hash_value({"name": self._PRECOMPOSED}) == hash_value({"name": self._COMBINING})
+
+    def test_combining_and_precomposed_accents_produce_identical_canonical_json(self):
+        assert canonical_json(self._PRECOMPOSED) == canonical_json(self._COMBINING)
+
+    def test_normalization_applies_to_dict_keys_too(self):
+        precomposed_key = {self._PRECOMPOSED: 1}
+        combining_key = {self._COMBINING: 1}
+        assert hash_value(precomposed_key) == hash_value(combining_key)
+
+    def test_normalization_applies_inside_nested_lists(self):
+        a = {"items": [self._PRECOMPOSED, "normal"]}
+        b = {"items": [self._COMBINING, "normal"]}
+        assert hash_value(a) == hash_value(b)
+
+    def test_genuinely_different_strings_still_hash_differently(self):
+        # Negative case: normalization must not collapse distinct content.
+        assert hash_value({"x": "cafe"}) != hash_value({"x": self._PRECOMPOSED})

--- a/tests/audit/test_signer.py
+++ b/tests/audit/test_signer.py
@@ -1,0 +1,143 @@
+"""Signing strategy: Ed25519 default, BYOK, and the SigningPolicy batching wrapper."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from synapsekit.audit.signer import (
+    BYOKSigningProvider,
+    Ed25519SigningProvider,
+    SigningPolicy,
+    verify_signature,
+)
+
+
+class TestEd25519SigningProvider:
+    def test_generates_a_usable_keypair_when_none_given(self):
+        provider = Ed25519SigningProvider()
+        sig = provider.sign(b"hello world")
+        assert verify_signature(
+            algorithm="ed25519",
+            public_key_bytes=provider.public_key_bytes(),
+            data=b"hello world",
+            signature=sig,
+        )
+
+    def test_reloading_from_private_bytes_reproduces_the_same_key(self):
+        provider = Ed25519SigningProvider()
+        raw = provider.private_key_bytes()
+        reloaded = Ed25519SigningProvider(raw)
+        assert reloaded.public_key_bytes() == provider.public_key_bytes()
+
+    def test_signature_does_not_verify_with_a_different_key(self):
+        provider = Ed25519SigningProvider()
+        other = Ed25519SigningProvider()
+        sig = provider.sign(b"data")
+        assert not verify_signature(
+            algorithm="ed25519",
+            public_key_bytes=other.public_key_bytes(),
+            data=b"data",
+            signature=sig,
+        )
+
+    def test_signature_does_not_verify_for_tampered_data(self):
+        provider = Ed25519SigningProvider()
+        sig = provider.sign(b"data")
+        assert not verify_signature(
+            algorithm="ed25519",
+            public_key_bytes=provider.public_key_bytes(),
+            data=b"tampered",
+            signature=sig,
+        )
+
+    def test_key_id_defaults_to_a_stable_value(self):
+        provider = Ed25519SigningProvider(key_id="my-key")
+        assert provider.key_id == "my-key"
+
+
+class TestEncryptedPrivateKeyExport:
+    def test_round_trips_through_encrypted_pem(self):
+        provider = Ed25519SigningProvider(key_id="my-key")
+        encrypted = provider.export_encrypted_private_key(b"correct horse battery staple")
+
+        reloaded = Ed25519SigningProvider.from_encrypted_private_key(
+            encrypted, b"correct horse battery staple", key_id="my-key"
+        )
+        assert reloaded.public_key_bytes() == provider.public_key_bytes()
+
+        sig = reloaded.sign(b"data")
+        assert verify_signature(
+            algorithm="ed25519",
+            public_key_bytes=provider.public_key_bytes(),
+            data=b"data",
+            signature=sig,
+        )
+
+    def test_wrong_passphrase_fails_to_load(self):
+        provider = Ed25519SigningProvider()
+        encrypted = provider.export_encrypted_private_key(b"the-real-passphrase")
+
+        with pytest.raises(Exception):
+            Ed25519SigningProvider.from_encrypted_private_key(encrypted, b"wrong-passphrase")
+
+    def test_encrypted_export_is_not_the_same_bytes_as_the_raw_export(self):
+        provider = Ed25519SigningProvider()
+        raw = provider.private_key_bytes()
+        encrypted = provider.export_encrypted_private_key(b"secret")
+        assert raw not in encrypted
+
+
+class TestVerifySignature:
+    def test_unsupported_algorithm_raises(self):
+        with pytest.raises(ValueError):
+            verify_signature(algorithm="rsa-3072", public_key_bytes=b"x", data=b"y", signature=b"z")
+
+
+class TestBYOKSigningProvider:
+    def test_wraps_a_caller_supplied_sign_function(self):
+        # A trivial (insecure, test-only) HMAC-shaped signer.
+        import hashlib
+        import hmac
+
+        secret = b"super-secret"
+
+        def sign_fn(data: bytes) -> bytes:
+            return hmac.new(secret, data, hashlib.sha256).digest()
+
+        provider = BYOKSigningProvider(sign_fn=sign_fn, public_key=b"unused", key_id="byok-1")
+        assert provider.sign(b"payload") == sign_fn(b"payload")
+        assert provider.key_id == "byok-1"
+        assert provider.algorithm == "byok"
+
+
+class TestSigningPolicy:
+    def test_ed25519_classmethod_signs_a_merkle_root(self):
+        policy = SigningPolicy.ed25519()
+        root = "ab" * 32
+        signature = policy.sign_batch(root, start_index=0, end_index=3)
+        assert signature.merkle_root == root
+        assert signature.algorithm == "ed25519"
+        assert verify_signature(
+            algorithm=signature.algorithm,
+            public_key_bytes=base64.b64decode(signature.public_key_b64),
+            data=bytes.fromhex(root),
+            signature=base64.b64decode(signature.signature_b64),
+        )
+
+    def test_kms_rejects_unknown_provider(self):
+        with pytest.raises(ValueError):
+            SigningPolicy.kms("not-a-real-cloud", key_id="k1")
+
+    def test_sign_manifest_hash_produces_a_verifiable_signature(self):
+        policy = SigningPolicy.ed25519()
+        manifest_hash = "cd" * 32
+        sig = policy.sign_manifest_hash(manifest_hash)
+        assert sig["key_id"] == policy.provider.key_id
+        assert verify_signature(
+            algorithm=sig["algorithm"],
+            public_key_bytes=base64.b64decode(sig["public_key_b64"]),
+            data=bytes.fromhex(manifest_hash),
+            signature=base64.b64decode(sig["signature_b64"]),
+        )

--- a/tests/audit/test_sink.py
+++ b/tests/audit/test_sink.py
@@ -1,0 +1,119 @@
+"""Audit sinks persist already-signed batches; they never touch signing."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from synapsekit.audit import AuditTracer, EventKind, SigningPolicy
+from synapsekit.audit.merkle import MerkleHasher
+from synapsekit.audit.sink import FileAuditSink, KafkaAuditSink, MultiSink, S3AuditSink, SignedBatch
+
+
+def _make_batch(records):
+    policy = SigningPolicy.ed25519()
+    leaves = [r.hash for r in records]
+    root = MerkleHasher.root(leaves)
+    signature = policy.sign_batch(root, start_index=0, end_index=len(records) - 1)
+    return SignedBatch(records=records, signature=signature, leaves=leaves)
+
+
+class TestFileAuditSink:
+    def test_appends_one_line_per_batch(self, tmp_path):
+        path = tmp_path / "audit.jsonl"
+        sink = FileAuditSink(path)
+
+        tracer = AuditTracer()
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        batch1 = _make_batch(tracer.drain())
+        sink.write(batch1)
+
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 2})
+        batch2 = _make_batch(tracer.drain())
+        sink.write(batch2)
+
+        lines = path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2
+        parsed = json.loads(lines[0])
+        assert parsed["signature"]["merkle_root"] == batch1.signature.merkle_root
+
+    def test_sink_receives_a_signature_it_never_computed_itself(self, tmp_path):
+        # The sink has no signing key and no SigningPolicy reference at all —
+        # it only ever sees the already-computed Signature dataclass.
+        path = tmp_path / "audit.jsonl"
+        sink = FileAuditSink(path)
+        assert not hasattr(sink, "provider")
+        assert not hasattr(sink, "sign")
+
+
+class TestMultiSink:
+    def test_fans_out_to_all_sinks(self, tmp_path):
+        path_a, path_b = tmp_path / "a.jsonl", tmp_path / "b.jsonl"
+        multi = MultiSink([FileAuditSink(path_a), FileAuditSink(path_b)])
+        tracer = AuditTracer()
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        multi.write(_make_batch(tracer.drain()))
+        assert path_a.exists() and path_b.exists()
+
+    def test_raises_if_any_sink_fails(self, tmp_path):
+        class BrokenSink:
+            def write(self, batch):
+                raise RuntimeError("disk full")
+
+        multi = MultiSink([FileAuditSink(tmp_path / "ok.jsonl"), BrokenSink()])
+        tracer = AuditTracer()
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        try:
+            multi.write(_make_batch(tracer.drain()))
+            raised = False
+        except RuntimeError:
+            raised = True
+        assert raised
+
+
+class TestAsyncSinkSupport:
+    """Sinks must not block the event loop — see the module docstring."""
+
+    @pytest.mark.asyncio
+    async def test_file_sink_awrite_works(self, tmp_path):
+        path = tmp_path / "audit.jsonl"
+        sink = FileAuditSink(path)
+        tracer = AuditTracer()
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        await sink.awrite(_make_batch(tracer.drain()))
+        assert path.exists()
+        assert len(path.read_text(encoding="utf-8").splitlines()) == 1
+
+    @pytest.mark.asyncio
+    async def test_multi_sink_awrite_fans_out_concurrently(self, tmp_path):
+        path_a, path_b = tmp_path / "a.jsonl", tmp_path / "b.jsonl"
+        multi = MultiSink([FileAuditSink(path_a), FileAuditSink(path_b)])
+        tracer = AuditTracer()
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        await multi.awrite(_make_batch(tracer.drain()))
+        assert path_a.exists() and path_b.exists()
+
+    @pytest.mark.asyncio
+    async def test_multi_sink_awrite_raises_if_any_sink_fails(self, tmp_path):
+        class BrokenAsyncSink:
+            async def awrite(self, batch):
+                raise RuntimeError("disk full")
+
+        multi = MultiSink([FileAuditSink(tmp_path / "ok.jsonl"), BrokenAsyncSink()])
+        tracer = AuditTracer()
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        with pytest.raises(RuntimeError):
+            await multi.awrite(_make_batch(tracer.drain()))
+
+
+class TestLazyClientConstruction:
+    """Instantiating a network-backed sink must never itself open a connection."""
+
+    def test_s3_sink_does_not_construct_a_client_at_init(self):
+        sink = S3AuditSink("my-bucket")
+        assert sink._client is None
+
+    def test_kafka_sink_does_not_construct_a_producer_at_init(self):
+        sink = KafkaAuditSink("my-topic")
+        assert sink._producer is None

--- a/tests/audit/test_trace_and_merkle.py
+++ b/tests/audit/test_trace_and_merkle.py
@@ -1,0 +1,206 @@
+"""Hash-chain integrity (trace.py) and Merkle tree correctness (merkle.py)."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+from types import MappingProxyType
+
+import pytest
+
+from synapsekit.audit.merkle import MerkleHasher
+from synapsekit.audit.redact import PIIRedactor
+from synapsekit.audit.trace import AuditTracer, ChainIntegrityError
+from synapsekit.audit.types import GENESIS_HASH, EventKind
+
+
+class TestAuditTracer:
+    def test_first_record_chains_from_genesis(self):
+        tracer = AuditTracer()
+        rec = tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        assert rec.prev_hash == GENESIS_HASH
+
+    def test_records_chain_sequentially(self):
+        tracer = AuditTracer()
+        r1 = tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        r2 = tracer.record(EventKind.SYSTEM_EVENT, {"x": 2})
+        assert r2.prev_hash == r1.hash
+
+    def test_same_payload_produces_different_hash_due_to_chain_position(self):
+        tracer = AuditTracer()
+        r1 = tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        r2 = tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        assert r1.hash != r2.hash  # prev_hash differs even though payload is identical
+
+    def test_drain_empties_and_returns_records(self):
+        tracer = AuditTracer()
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        drained = tracer.drain()
+        assert len(drained) == 1
+        assert len(tracer) == 0
+
+    def test_verify_chain_passes_for_untampered_chain(self):
+        tracer = AuditTracer()
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 2})
+        AuditTracer.verify_chain(list(tracer.records))  # should not raise
+
+    def test_verify_chain_detects_payload_tamper(self):
+        tracer = AuditTracer()
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        records = list(tracer.records)
+        tampered = dataclasses.replace(records[0], payload={"x": 999})
+        with pytest.raises(ChainIntegrityError):
+            AuditTracer.verify_chain([tampered])
+
+    def test_verify_chain_detects_reordering(self):
+        tracer = AuditTracer()
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 2})
+        records = list(tracer.records)
+        with pytest.raises(ChainIntegrityError):
+            AuditTracer.verify_chain([records[1], records[0]])
+
+    def test_verify_chain_detects_direct_hash_tamper(self):
+        tracer = AuditTracer()
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        records = list(tracer.records)
+        tampered = dataclasses.replace(records[0], hash="0" * 64)
+        with pytest.raises(ChainIntegrityError):
+            AuditTracer.verify_chain([tampered])
+
+    def test_verify_chain_detects_bad_parent_prev_hash_link(self):
+        tracer = AuditTracer()
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 2})
+        records = list(tracer.records)
+        tampered_second = dataclasses.replace(records[1], prev_hash="f" * 64)
+        with pytest.raises(ChainIntegrityError):
+            AuditTracer.verify_chain([records[0], tampered_second])
+
+
+class TestPayloadImmutability:
+    """A record's payload must never be able to drift from the content its hash commits to."""
+
+    def test_payload_is_frozen_into_a_mappingproxy(self):
+        tracer = AuditTracer()
+        rec = tracer.record(EventKind.SYSTEM_EVENT, {"a": 1, "nested": {"b": [1, 2, 3]}})
+        assert isinstance(rec.payload, MappingProxyType)
+        assert isinstance(rec.payload["nested"], MappingProxyType)
+        assert rec.payload["nested"]["b"] == (1, 2, 3)
+
+    def test_mutating_stored_payload_raises(self):
+        tracer = AuditTracer()
+        rec = tracer.record(EventKind.SYSTEM_EVENT, {"a": 1})
+        with pytest.raises(TypeError):
+            rec.payload["a"] = 999
+
+    def test_mutating_nested_stored_payload_raises(self):
+        tracer = AuditTracer()
+        rec = tracer.record(EventKind.SYSTEM_EVENT, {"nested": {"b": 1}})
+        with pytest.raises(TypeError):
+            rec.payload["nested"]["b"] = 999
+
+    def test_mutating_the_caller_supplied_dict_after_record_does_not_affect_the_stored_copy(self):
+        tracer = AuditTracer()
+        payload = {"a": 1}
+        rec = tracer.record(EventKind.SYSTEM_EVENT, payload)
+        payload["a"] = 999
+        payload["new_key"] = "sneaky"
+        assert rec.payload["a"] == 1
+        assert "new_key" not in rec.payload
+
+    def test_to_dict_yields_plain_json_friendly_containers(self):
+        tracer = AuditTracer()
+        rec = tracer.record(EventKind.SYSTEM_EVENT, {"nested": {"b": [1, 2]}})
+        d = rec.to_dict()
+        assert type(d["payload"]) is dict
+        assert type(d["payload"]["nested"]) is dict
+        assert type(d["payload"]["nested"]["b"]) is list
+
+    def test_frozen_payload_still_hashes_deterministically(self):
+        tracer = AuditTracer()
+        r1 = tracer.record(EventKind.SYSTEM_EVENT, {"a": 1, "b": {"c": 2}})
+        tracer2 = AuditTracer(run_id=tracer.run_id)
+        r2 = tracer2.record(
+            EventKind.SYSTEM_EVENT,
+            {"a": 1, "b": {"c": 2}},
+            event_id=r1.event_id,
+            timestamp=r1.timestamp,
+        )
+        assert r1.hash == r2.hash
+
+
+class TestTracerLevelRedaction:
+    """Redaction can be enforced at the AuditTracer itself, not only via VerifiableAgent."""
+
+    def test_tracer_with_redactor_redacts_before_hashing(self):
+        tracer = AuditTracer(redactor=PIIRedactor())
+        rec = tracer.record(EventKind.TOOL_CALL, {"note": "email alice@example.com now"})
+        assert "alice@example.com" not in rec.payload["note"]
+        assert "[REDACTED:EMAIL]" in rec.payload["note"]
+
+    def test_tracer_without_redactor_does_not_redact(self):
+        tracer = AuditTracer()
+        rec = tracer.record(EventKind.TOOL_CALL, {"note": "email alice@example.com now"})
+        assert "alice@example.com" in rec.payload["note"]
+
+
+class TestMerkleHasher:
+    def test_empty_root_is_stable(self):
+        assert MerkleHasher.root([]) == MerkleHasher.EMPTY_ROOT
+
+    def test_single_leaf_root_equals_leaf(self):
+        assert MerkleHasher.root(["a" * 64]) == "a" * 64
+
+    def test_root_is_order_sensitive(self):
+        leaves = ["1" * 64, "2" * 64, "3" * 64]
+        assert MerkleHasher.root(leaves) != MerkleHasher.root(list(reversed(leaves)))
+
+    def test_root_handles_odd_leaf_counts(self):
+        leaves = ["1" * 64, "2" * 64, "3" * 64]
+        # Should not raise, and should be deterministic.
+        assert MerkleHasher.root(leaves) == MerkleHasher.root(leaves)
+
+    @pytest.mark.parametrize("n", [1, 2, 3, 4, 5, 7, 8, 9, 16])
+    def test_proof_verifies_for_every_leaf(self, n):
+        leaves = [f"{i:064x}" for i in range(n)]
+        root = MerkleHasher.root(leaves)
+        for i in range(n):
+            proof = MerkleHasher.proof(leaves, i)
+            assert MerkleHasher.verify(proof, root)
+
+    def test_proof_fails_against_wrong_root(self):
+        leaves = [f"{i:064x}" for i in range(5)]
+        proof = MerkleHasher.proof(leaves, 2)
+        assert not MerkleHasher.verify(proof, "0" * 64)
+
+    def test_proof_out_of_range_raises(self):
+        with pytest.raises(IndexError):
+            MerkleHasher.proof(["a" * 64], 5)
+
+    def test_proof_on_empty_tree_raises(self):
+        with pytest.raises(ValueError):
+            MerkleHasher.proof([], 0)
+
+
+class TestMerkleDuplicateLeafAmbiguity:
+    """Regression test for the CVE-2012-2459 class of bug: a tree must
+    never produce the same root for two structurally different leaf
+    sets just because an odd count got padded with a duplicate.
+    """
+
+    def test_three_leaves_and_a_duplicated_fourth_leaf_produce_different_roots(self):
+        leaves3 = ["1" * 64, "2" * 64, "3" * 64]
+        leaves4_with_duplicate = [*leaves3, "3" * 64]
+        assert MerkleHasher.root(leaves3) != MerkleHasher.root(leaves4_with_duplicate)
+
+    def test_internal_node_hash_is_domain_separated_from_a_raw_leaf(self):
+        # An internal node hash must not collide with a value that could
+        # plausibly be presented as a leaf: sha256(leaf_a || leaf_b)
+        # without the 0x01 node-domain prefix would be indistinguishable
+        # from "just another leaf hash".
+        a, b = "1" * 64, "2" * 64
+        node_hash = MerkleHasher.root([a, b])
+        undomained = hashlib.sha256(bytes.fromhex(a) + bytes.fromhex(b)).hexdigest()
+        assert node_hash != undomained

--- a/tests/audit/test_trace_and_merkle.py
+++ b/tests/audit/test_trace_and_merkle.py
@@ -78,6 +78,38 @@ class TestAuditTracer:
         with pytest.raises(ChainIntegrityError):
             AuditTracer.verify_chain([records[0], tampered_second])
 
+    def test_verify_chain_rejects_unfiltered_multi_run_record_list(self):
+        """Regression test: verify_chain had no run_id awareness — given
+        an unfiltered multi-run record list, a record from run B whose
+        prev_hash was forged to equal run A's last hash would previously
+        be accepted as a legitimate cross-run link (the old code only
+        checked prev_hash linkage, never run_id). It must now reject
+        mixed-run input outright rather than silently validating a bogus
+        cross-run chain.
+        """
+        run_a = AuditTracer(run_id="run-a")
+        run_a.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        rec_a = run_a.records[0]
+
+        run_b = AuditTracer(run_id="run-b")
+        run_b.record(EventKind.SYSTEM_EVENT, {"x": 2})
+        rec_b = run_b.records[0]
+        # Forge run B's first record to chain from run A's last hash —
+        # on the old code this "links" cleanly and passes.
+        forged_rec_b = dataclasses.replace(rec_b, prev_hash=rec_a.hash)
+
+        with pytest.raises(ChainIntegrityError):
+            AuditTracer.verify_chain([rec_a, forged_rec_b], expect_genesis=True)
+
+    def test_verify_chain_accepts_single_run_records(self):
+        tracer = AuditTracer(run_id="run-only")
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 1})
+        tracer.record(EventKind.SYSTEM_EVENT, {"x": 2})
+        AuditTracer.verify_chain(list(tracer.records))  # should not raise
+
+    def test_verify_chain_accepts_empty_list(self):
+        AuditTracer.verify_chain([])  # should not raise
+
 
 class TestPayloadImmutability:
     """A record's payload must never be able to drift from the content its hash commits to."""
@@ -204,3 +236,55 @@ class TestMerkleDuplicateLeafAmbiguity:
         node_hash = MerkleHasher.root([a, b])
         undomained = hashlib.sha256(bytes.fromhex(a) + bytes.fromhex(b)).hexdigest()
         assert node_hash != undomained
+
+
+class TestLeafHashDomainSeparation:
+    """Regression test: before the fix, only internal Merkle nodes got
+    domain separation (0x01 prefix, RFC 6962-style) -- leaf hashes were
+    used raw, un-prefixed. Full RFC 6962 also domain-separates leaves
+    with a 0x00 prefix so a leaf hash can never be replayed as if it
+    were an internal node hash's input (or vice versa). This exercises
+    synapsekit.audit.merkle.hash_leaf directly.
+    """
+
+    def test_hash_leaf_is_not_the_raw_value(self):
+        from synapsekit.audit.merkle import hash_leaf
+
+        raw = "a" * 64
+        assert hash_leaf(raw) != raw
+
+    def test_hash_leaf_uses_the_0x00_domain_prefix(self):
+        from synapsekit.audit.merkle import hash_leaf
+
+        raw = "ab" * 32
+        expected = hashlib.sha256(b"\x00" + bytes.fromhex(raw)).hexdigest()
+        assert hash_leaf(raw) == expected
+
+    def test_hash_leaf_is_deterministic(self):
+        from synapsekit.audit.merkle import hash_leaf
+
+        raw = "c" * 64
+        assert hash_leaf(raw) == hash_leaf(raw)
+
+    def test_hash_leaf_output_is_domain_separated_from_hash_pair_output(self):
+        # A leaf hash (0x00 prefix) must never equal an internal node
+        # hash (0x01 prefix) computed over the same underlying bytes.
+        from synapsekit.audit.merkle import hash_leaf
+
+        a, b = "1" * 64, "2" * 64
+        node_hash = MerkleHasher.root([a, b])
+        leaf_hash_of_a = hash_leaf(a)
+        assert leaf_hash_of_a != node_hash
+
+    def test_single_record_leaf_hash_differs_from_raw_record_hash_used_as_root(self):
+        # A single-leaf tree's root is the leaf itself in MerkleHasher's
+        # generic API (see test_single_leaf_root_equals_leaf) -- but the
+        # actual leaf fed in must be the domain-separated hash_leaf(...)
+        # of the record hash, not the record hash directly, or leaves
+        # and internal nodes share an un-separated hash space.
+        from synapsekit.audit.merkle import hash_leaf
+
+        record_hash = "7" * 64
+        leaf = hash_leaf(record_hash)
+        assert MerkleHasher.root([leaf]) == leaf
+        assert MerkleHasher.root([leaf]) != record_hash

--- a/tests/audit/test_trust_anchor.py
+++ b/tests/audit/test_trust_anchor.py
@@ -1,0 +1,140 @@
+"""Trust-anchor pinning — closes the "self-certifying bundle" gap.
+
+Without ``trusted_keys``, ``verify()`` can only prove a bundle wasn't
+edited after export, since it reads public keys from the bundle's own
+manifest. These tests exercise the actual attack that gap allows (an
+attacker forging a complete, internally-consistent bundle from scratch)
+and confirm pinning closes it.
+"""
+
+from __future__ import annotations
+
+import base64
+
+from synapsekit.audit import AuditTracer, EventKind, SigningPolicy, export_audit_bundle
+from synapsekit.audit.verifier import verify
+
+
+def _forge_bundle(tmp_path):
+    """Simulate an attacker: fabricate records from scratch, sign them
+    with a freshly generated keypair they control, and export a bundle
+    that is fully self-consistent."""
+    forged_tracer = AuditTracer()
+    forged_tracer.record(EventKind.DECISION, {"decision": "approve loan", "amount": 1_000_000})
+    attacker_policy = SigningPolicy.ed25519()
+    forged_path = export_audit_bundle(
+        forged_tracer.drain(), attacker_policy, tmp_path / "forged.zip"
+    )
+    return forged_path, attacker_policy
+
+
+class TestTrustAnchorPinning:
+    def test_forged_bundle_passes_self_consistency_check_without_pinning(self, tmp_path):
+        # This documents the known, unavoidable limitation of
+        # self-consistency-only verification: a fully self-consistent
+        # forgery is indistinguishable from a real bundle unless the
+        # verifier pins an independently-known key.
+        forged_path, _ = _forge_bundle(tmp_path)
+        result = verify(forged_path)
+        assert result.ok
+        assert result.trust_anchor == "none"
+
+    def test_forged_bundle_is_rejected_when_the_real_key_is_pinned(self, tmp_path):
+        forged_path, _attacker_policy = _forge_bundle(tmp_path)
+
+        real_org_policy = SigningPolicy.ed25519(key_id="real-org-key")
+        trusted_keys = {"real-org-key": real_org_policy.provider.public_key_bytes()}
+
+        result = verify(forged_path, trusted_keys=trusted_keys)
+        assert not result.ok
+        assert result.trust_anchor == "pinned"
+        assert any("trusted key set" in e for e in result.errors)
+
+    def test_genuine_bundle_verifies_when_its_real_key_is_pinned(self, tmp_path, sample_records):
+        policy = SigningPolicy.ed25519(key_id="real-org-key")
+        path = export_audit_bundle(sample_records, policy, tmp_path / "genuine.zip")
+
+        trusted_keys = {"real-org-key": policy.provider.public_key_bytes()}
+        result = verify(path, trusted_keys=trusted_keys)
+        assert result.ok
+        assert result.trust_anchor == "pinned"
+
+    def test_pinning_ignores_a_manifest_key_masquerading_under_a_trusted_key_id(self, tmp_path):
+        """Even if an attacker labels their forged key with the SAME key_id
+        as the real signer, pinning must use the caller-supplied bytes —
+        never the manifest's own claimed public key for that id."""
+        forged_path, attacker_policy = _forge_bundle(tmp_path)
+
+        import json
+        import zipfile
+
+        with zipfile.ZipFile(forged_path) as zf:
+            manifest = json.loads(zf.read("manifest.json"))
+        attacker_key_id = next(iter(manifest["keys"]))
+
+        real_key_bytes = SigningPolicy.ed25519().provider.public_key_bytes()
+        assert real_key_bytes != attacker_policy.provider.public_key_bytes()
+
+        result = verify(forged_path, trusted_keys={attacker_key_id: real_key_bytes})
+        assert not result.ok
+
+
+class TestManifestMetadataAuthentication:
+    def test_manifest_created_at_tampering_is_detected(self, tmp_path, bundle_path):
+        import json
+
+        from .conftest import read_zip_entries, write_zip_entries
+
+        entries = read_zip_entries(bundle_path)
+        manifest = json.loads(entries["manifest.json"])
+        manifest["created_at"] = "1999-01-01T00:00:00+00:00"
+        entries["manifest.json"] = json.dumps(manifest).encode("utf-8")
+        out = tmp_path / "tampered_created_at.zip"
+        write_zip_entries(out, entries)
+
+        result = verify(out)
+        assert not result.ok
+        assert any("manifest_hash" in e or "manifest" in e.lower() for e in result.errors)
+
+    def test_manifest_run_ids_tampering_is_detected(self, tmp_path, bundle_path):
+        import json
+
+        from .conftest import read_zip_entries, write_zip_entries
+
+        entries = read_zip_entries(bundle_path)
+        manifest = json.loads(entries["manifest.json"])
+        manifest["run_ids"] = ["not-the-real-run-id"]
+        entries["manifest.json"] = json.dumps(manifest).encode("utf-8")
+        out = tmp_path / "tampered_run_ids.zip"
+        write_zip_entries(out, entries)
+
+        result = verify(out)
+        assert not result.ok
+
+    def test_missing_manifest_signature_is_rejected(self, tmp_path, bundle_path):
+        import json
+
+        from .conftest import read_zip_entries, write_zip_entries
+
+        entries = read_zip_entries(bundle_path)
+        manifest = json.loads(entries["manifest.json"])
+        del manifest["manifest_hash"]
+        del manifest["manifest_signatures"]
+        entries["manifest.json"] = json.dumps(manifest).encode("utf-8")
+        out = tmp_path / "unsigned_manifest.zip"
+        write_zip_entries(out, entries)
+
+        result = verify(out)
+        assert not result.ok
+        assert any("not signed" in e for e in result.errors)
+
+    def test_valid_manifest_signature_present_in_a_fresh_export(self, bundle_path):
+        import json
+        import zipfile
+
+        with zipfile.ZipFile(bundle_path) as zf:
+            manifest = json.loads(zf.read("manifest.json"))
+        assert "manifest_hash" in manifest
+        assert manifest["manifest_signatures"]
+        for sig in manifest["manifest_signatures"]:
+            assert base64.b64decode(sig["signature_b64"])

--- a/tests/audit/test_verdict_and_schema.py
+++ b/tests/audit/test_verdict_and_schema.py
@@ -1,0 +1,234 @@
+"""Coverage for the v2.0 schema additions: EventKind taxonomy, actor,
+payload_hash, reserved redaction fields, and the three-valued Verdict.
+"""
+
+from __future__ import annotations
+
+import json
+
+from synapsekit.audit import (
+    AuditTracer,
+    EventKind,
+    PIIRedactor,
+    SigningPolicy,
+    Verdict,
+    export_audit_bundle,
+)
+from synapsekit.audit.verifier import verify
+
+from .conftest import dump_trace_lines, load_trace_lines, read_zip_entries, write_zip_entries
+
+
+class TestEventKindTaxonomy:
+    def test_all_spec_kinds_are_present(self):
+        expected = {
+            "USER_INPUT",
+            "LLM_CALL",
+            "LLM_RESPONSE",
+            "TOOL_CALL",
+            "TOOL_RESULT",
+            "RETRIEVAL",
+            "MEMORY_READ",
+            "MEMORY_WRITE",
+            "STATE_CHANGE",
+            "DECISION",
+            "SYSTEM_EVENT",
+            "ERROR",
+        }
+        assert {k.value for k in EventKind} == expected
+
+    def test_record_rejects_nothing_but_stores_whatever_string_is_given(self):
+        # AuditTracer.record accepts EventKind OR str — the taxonomy is
+        # enforced by convention/callers (e.g. VerifiableAgent), not by
+        # a hard runtime check inside record() itself.
+        tracer = AuditTracer()
+        rec = tracer.record(EventKind.USER_INPUT, {"text": "hello"})
+        assert rec.kind == "USER_INPUT"
+
+
+class TestActorField:
+    def test_default_actor_is_system(self):
+        tracer = AuditTracer()
+        rec = tracer.record(EventKind.DECISION, {"x": 1})
+        assert rec.actor == "system"
+
+    def test_custom_actor_is_recorded(self):
+        tracer = AuditTracer()
+        rec = tracer.record(EventKind.DECISION, {"x": 1}, actor="user:alice")
+        assert rec.actor == "user:alice"
+
+    def test_actor_is_committed_to_the_hash(self):
+        tracer = AuditTracer()
+        r1 = tracer.record(EventKind.DECISION, {"x": 1}, actor="user:alice")
+        tracer2 = AuditTracer(run_id=tracer.run_id)
+        r2 = tracer2.record(
+            EventKind.DECISION,
+            {"x": 1},
+            actor="user:bob",
+            event_id=r1.event_id,
+            timestamp=r1.timestamp,
+        )
+        assert r1.hash != r2.hash
+
+
+class TestPayloadHash:
+    def test_payload_hash_is_deterministic_for_identical_payloads(self):
+        tracer = AuditTracer()
+        r1 = tracer.record(EventKind.DECISION, {"a": 1, "b": 2})
+        tracer2 = AuditTracer()
+        r2 = tracer2.record(EventKind.DECISION, {"b": 2, "a": 1})
+        assert r1.payload_hash == r2.payload_hash
+
+    def test_payload_hash_changes_with_payload(self):
+        tracer = AuditTracer()
+        r1 = tracer.record(EventKind.DECISION, {"a": 1})
+        r2 = tracer.record(EventKind.DECISION, {"a": 2})
+        assert r1.payload_hash != r2.payload_hash
+
+    def test_record_hash_commits_to_payload_hash(self):
+        tracer = AuditTracer()
+        rec = tracer.record(EventKind.DECISION, {"a": 1})
+        assert rec.payload_hash in rec.to_dict().values()
+
+    def test_tampering_payload_hash_alone_is_detected_as_drift(self, tmp_path, bundle_path):
+        entries = read_zip_entries(bundle_path)
+        records = load_trace_lines(entries)
+        records[0]["payload_hash"] = "f" * 64
+        dump_trace_lines(entries, records)
+        out = tmp_path / "bad_payload_hash.zip"
+        write_zip_entries(out, entries)
+
+        result = verify(out)
+        assert result.verdict == Verdict.DRIFT
+
+    def test_tampering_payload_without_updating_payload_hash_is_detected(
+        self, tmp_path, bundle_path
+    ):
+        entries = read_zip_entries(bundle_path)
+        records = load_trace_lines(entries)
+        records[0]["payload"] = {**records[0]["payload"], "prompt": "INJECTED"}
+        dump_trace_lines(entries, records)
+        out = tmp_path / "bad_payload.zip"
+        write_zip_entries(out, entries)
+
+        result = verify(out)
+        assert result.verdict == Verdict.DRIFT
+        assert any("payload_hash" in e for e in result.errors)
+
+
+class TestReservedRedactionFields:
+    def test_defaults_are_none_and_not_redacted(self):
+        tracer = AuditTracer()
+        rec = tracer.record(EventKind.DECISION, {"x": 1})
+        assert rec.redaction_status == "none"
+        assert rec.redaction_policy_hash is None
+
+    def test_redactor_stamps_redacted_status_and_policy_hash(self):
+        redactor = PIIRedactor()
+        tracer = AuditTracer(redactor=redactor)
+        rec = tracer.record(EventKind.TOOL_CALL, {"note": "contact alice@example.com"})
+        assert rec.redaction_status == "redacted"
+        assert rec.redaction_policy_hash == redactor.policy_fingerprint()
+
+    def test_redactor_present_but_nothing_to_redact_stays_none(self):
+        redactor = PIIRedactor()
+        tracer = AuditTracer(redactor=redactor)
+        rec = tracer.record(EventKind.TOOL_CALL, {"note": "nothing sensitive here"})
+        assert rec.redaction_status == "none"
+
+    def test_reserved_fields_round_trip_through_to_dict_and_from_dict(self):
+        from synapsekit.audit import AuditRecord
+
+        redactor = PIIRedactor()
+        tracer = AuditTracer(redactor=redactor)
+        rec = tracer.record(EventKind.TOOL_CALL, {"note": "contact alice@example.com"})
+        rebuilt = AuditRecord.from_dict(json.loads(json.dumps(rec.to_dict())))
+        assert rebuilt.redaction_status == rec.redaction_status
+        assert rebuilt.redaction_policy_hash == rec.redaction_policy_hash
+
+    def test_tampering_redaction_status_is_detected(self, tmp_path, sample_records):
+        redactor = PIIRedactor()
+        tracer = AuditTracer(redactor=redactor)
+        tracer.record(EventKind.TOOL_CALL, {"note": "contact alice@example.com"})
+        path = export_audit_bundle(tracer.drain(), SigningPolicy.ed25519(), tmp_path / "b.zip")
+
+        entries = read_zip_entries(path)
+        records = load_trace_lines(entries)
+        records[0]["redaction_status"] = "withheld"
+        dump_trace_lines(entries, records)
+        out = tmp_path / "tampered_redaction_status.zip"
+        write_zip_entries(out, entries)
+
+        result = verify(out)
+        assert result.verdict == Verdict.DRIFT
+
+
+class TestVerdictCategorization:
+    def test_valid_bundle_is_match(self, bundle_path):
+        result = verify(bundle_path)
+        assert result.verdict == Verdict.MATCH
+        assert result.ok is True
+
+    def test_tampered_hash_is_drift_not_unverifiable(self, tmp_path, bundle_path):
+        entries = read_zip_entries(bundle_path)
+        records = load_trace_lines(entries)
+        records[0]["hash"] = "0" * 64
+        dump_trace_lines(entries, records)
+        out = tmp_path / "bad_hash.zip"
+        write_zip_entries(out, entries)
+
+        result = verify(out)
+        assert result.verdict == Verdict.DRIFT
+        assert result.ok is False
+
+    def test_unsupported_schema_version_is_unverifiable_not_drift(self, tmp_path, bundle_path):
+        entries = read_zip_entries(bundle_path)
+        manifest = json.loads(entries["manifest.json"])
+        manifest["schema_version"] = "99.0"
+        entries["manifest.json"] = json.dumps(manifest).encode("utf-8")
+        out = tmp_path / "bad_schema.zip"
+        write_zip_entries(out, entries)
+
+        result = verify(out)
+        assert result.verdict == Verdict.UNVERIFIABLE
+
+    def test_corrupted_bundle_is_unverifiable(self, tmp_path):
+        bad = tmp_path / "corrupt.zip"
+        bad.write_bytes(b"not a zip file")
+        result = verify(bad)
+        assert result.verdict == Verdict.UNVERIFIABLE
+
+    def test_missing_trusted_key_is_unverifiable_not_drift(self, tmp_path, sample_records):
+        policy = SigningPolicy.ed25519(key_id="release-key")
+        path = export_audit_bundle(sample_records, policy, tmp_path / "b.zip")
+
+        # Pin a *different* key_id entirely, so the bundle's signatures
+        # reference a key we simply have no evidence about — that's
+        # "can't tell" (UNVERIFIABLE), not "proven wrong" (DRIFT).
+        result = verify(path, trusted_keys={"some-other-key-id": b"\x00" * 32})
+        assert result.verdict == Verdict.UNVERIFIABLE
+
+    def test_wrong_key_bytes_for_the_right_key_id_is_drift(self, tmp_path, sample_records):
+        policy = SigningPolicy.ed25519(key_id="release-key")
+        path = export_audit_bundle(sample_records, policy, tmp_path / "b.zip")
+
+        wrong_key = SigningPolicy.ed25519().provider.public_key_bytes()
+        result = verify(path, trusted_keys={"release-key": wrong_key})
+        assert result.verdict == Verdict.DRIFT
+
+    def test_raise_if_invalid_includes_verdict_in_message(self, tmp_path, bundle_path):
+        entries = read_zip_entries(bundle_path)
+        records = load_trace_lines(entries)
+        records[0]["hash"] = "0" * 64
+        dump_trace_lines(entries, records)
+        out = tmp_path / "bad_hash.zip"
+        write_zip_entries(out, entries)
+
+        result = verify(out)
+        try:
+            result.raise_if_invalid()
+            raised = False
+        except Exception as exc:
+            raised = True
+            assert "DRIFT" in str(exc)
+        assert raised

--- a/tests/audit/test_verdict_and_schema.py
+++ b/tests/audit/test_verdict_and_schema.py
@@ -5,6 +5,9 @@ payload_hash, reserved redaction fields, and the three-valued Verdict.
 from __future__ import annotations
 
 import json
+from types import MappingProxyType
+
+import pytest
 
 from synapsekit.audit import (
     AuditTracer,
@@ -14,7 +17,8 @@ from synapsekit.audit import (
     Verdict,
     export_audit_bundle,
 )
-from synapsekit.audit.verifier import verify
+from synapsekit.audit.types import AuditRecord
+from synapsekit.audit.verifier import load_bundle, verify
 
 from .conftest import dump_trace_lines, load_trace_lines, read_zip_entries, write_zip_entries
 
@@ -232,3 +236,60 @@ class TestVerdictCategorization:
             raised = True
             assert "DRIFT" in str(exc)
         assert raised
+
+
+class TestFromDictFreezesPayload:
+    """Regression test: AuditRecord.from_dict must deep_freeze the payload
+    it reconstructs, exactly like AuditTracer.record does — otherwise a
+    record reconstructed from a loaded bundle (verifier/replay path) has
+    a mutable payload dict, contradicting the class docstring's claim
+    that "mutation raises instead of silently succeeding". On the buggy
+    code, record.payload["x"] = ... succeeds silently; on the fixed code
+    it raises TypeError because the payload is a MappingProxyType.
+    """
+
+    def test_from_dict_payload_is_frozen(self):
+        rec = AuditRecord.from_dict(
+            {
+                "event_id": "e1",
+                "parent_id": None,
+                "run_id": "run-1",
+                "kind": "SYSTEM_EVENT",
+                "actor": "system",
+                "payload": {"x": 1, "nested": {"y": 2}},
+                "payload_hash": "deadbeef",
+                "timestamp": "2026-01-01T00:00:00+00:00",
+                "schema_version": "1.2",
+                "prev_hash": "0" * 64,
+                "hash": "1" * 64,
+            }
+        )
+        assert isinstance(rec.payload, MappingProxyType)
+        with pytest.raises(TypeError):
+            rec.payload["x"] = 999  # type: ignore[index]
+
+    def test_from_dict_nested_containers_are_also_frozen(self):
+        rec = AuditRecord.from_dict(
+            {
+                "event_id": "e1",
+                "parent_id": None,
+                "run_id": "run-1",
+                "kind": "SYSTEM_EVENT",
+                "actor": "system",
+                "payload": {"items": [1, 2, 3]},
+                "payload_hash": "deadbeef",
+                "timestamp": "2026-01-01T00:00:00+00:00",
+                "schema_version": "1.2",
+                "prev_hash": "0" * 64,
+                "hash": "1" * 64,
+            }
+        )
+        assert isinstance(rec.payload["items"], tuple)
+
+    def test_records_reloaded_from_a_bundle_have_frozen_payloads(self, tmp_path, sample_records):
+        path = export_audit_bundle(sample_records, SigningPolicy.ed25519(), tmp_path / "b.zip")
+        loaded = load_bundle(path)
+        for rec in loaded.records:
+            assert isinstance(rec.payload, MappingProxyType)
+            with pytest.raises(TypeError):
+                rec.payload["tampered"] = "value"  # type: ignore[index]

--- a/tests/audit/test_wrapper.py
+++ b/tests/audit/test_wrapper.py
@@ -1,0 +1,267 @@
+"""VerifiableAgent — wraps an agent's methods without touching its implementation."""
+
+from __future__ import annotations
+
+import pytest
+
+from synapsekit.audit import AuditTracer, EventKind, VerifiableAgent
+from synapsekit.audit.wrapper import audited, infer_kind_pair
+
+
+class DummyAgent:
+    def __init__(self):
+        self.calls = 0
+
+    async def generate(self, prompt: str) -> str:
+        self.calls += 1
+        return f"response to {prompt}"
+
+    def retrieve(self, query: str) -> list[str]:
+        return [f"doc-for-{query}"]
+
+    async def failing_tool(self, x: int) -> int:
+        raise ValueError("boom")
+
+
+class TestInferKindPair:
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("generate", (EventKind.LLM_CALL, EventKind.LLM_RESPONSE)),
+            ("chat_complete", (EventKind.LLM_CALL, EventKind.LLM_RESPONSE)),
+            ("retrieve_docs", (EventKind.RETRIEVAL, None)),
+            ("recall_memory", (EventKind.MEMORY_READ, None)),
+            ("save_memory", (EventKind.MEMORY_WRITE, None)),
+            ("decide_next_step", (EventKind.DECISION, None)),
+            ("run_tool", (EventKind.TOOL_CALL, EventKind.TOOL_RESULT)),
+            ("frobnicate", (EventKind.SYSTEM_EVENT, None)),
+        ],
+    )
+    def test_keyword_based_inference(self, name, expected):
+        assert infer_kind_pair(name) == expected
+
+
+class TestVerifiableAgent:
+    @pytest.mark.asyncio
+    async def test_paired_kind_emits_a_call_and_a_response_record(self):
+        # "generate" -> (LLM_CALL, LLM_RESPONSE): a paired kind emits two
+        # linked records, not one.
+        tracer = AuditTracer()
+        agent = VerifiableAgent(DummyAgent(), tracer=tracer)
+        result = await agent.generate("hello")
+        assert result == "response to hello"
+
+        records = tracer.records
+        assert len(records) == 2
+        call, response = records
+        assert call.kind == EventKind.LLM_CALL.value
+        assert "output" not in call.payload
+        assert response.kind == EventKind.LLM_RESPONSE.value
+        assert response.payload["output"] == "response to hello"
+        assert response.payload["status"] == "ok"
+        assert response.parent_id == call.event_id
+
+    def test_single_kind_emits_one_record(self):
+        # "retrieve" -> RETRIEVAL has no paired response kind.
+        tracer = AuditTracer()
+        agent = VerifiableAgent(DummyAgent(), tracer=tracer)
+        result = agent.retrieve("france")
+        assert result == ["doc-for-france"]
+        records = tracer.records
+        assert len(records) == 1
+        assert records[0].kind == EventKind.RETRIEVAL.value
+        # Frozen payload: lists become tuples (see types.deep_freeze).
+        assert records[0].payload["output"] == ("doc-for-france",)
+
+    @pytest.mark.asyncio
+    async def test_exceptions_are_recorded_as_error_and_reraised(self):
+        # "failing_tool" -> paired (TOOL_CALL, TOOL_RESULT); an exception
+        # replaces the result record's kind with ERROR.
+        tracer = AuditTracer()
+        agent = VerifiableAgent(DummyAgent(), tracer=tracer)
+        with pytest.raises(ValueError, match="boom"):
+            await agent.failing_tool(1)
+        records = tracer.records
+        assert len(records) == 2
+        call, error = records
+        assert call.kind == EventKind.TOOL_CALL.value
+        assert error.kind == EventKind.ERROR.value
+        assert error.payload["status"] == "error"
+        assert error.payload["error_type"] == "ValueError"
+        assert error.parent_id == call.event_id
+
+    def test_non_callable_attributes_pass_through(self):
+        tracer = AuditTracer()
+        agent = VerifiableAgent(DummyAgent(), tracer=tracer)
+        assert agent.calls == 0
+
+    def test_uses_the_tracer_instance_passed_in_even_when_empty(self):
+        # Regression: an empty AuditTracer defines __len__ == 0, which is
+        # falsy — `tracer or AuditTracer()` would silently substitute a
+        # fresh tracer instead of using the one the caller passed in.
+        tracer = AuditTracer()
+        agent = VerifiableAgent(DummyAgent(), tracer=tracer)
+        assert agent.tracer is tracer
+
+    def test_wrapped_property_exposes_the_underlying_agent(self):
+        inner = DummyAgent()
+        agent = VerifiableAgent(inner, tracer=AuditTracer())
+        assert agent.wrapped is inner
+
+    def test_pii_is_redacted_before_recording(self):
+        from synapsekit.audit.redact import PIIRedactor
+
+        tracer = AuditTracer()
+        agent = VerifiableAgent(DummyAgent(), tracer=tracer, redactor=PIIRedactor())
+        agent.retrieve("contact bob@example.com")
+        payload = tracer.records[0].payload
+        assert "bob@example.com" not in str(payload)
+
+    def test_default_actor_names_the_wrapped_agent_type(self):
+        tracer = AuditTracer()
+        agent = VerifiableAgent(DummyAgent(), tracer=tracer)
+        agent.retrieve("q")
+        assert tracer.records[0].actor == "agent:DummyAgent"
+
+    def test_custom_actor_is_used(self):
+        tracer = AuditTracer()
+        agent = VerifiableAgent(DummyAgent(), tracer=tracer, actor="user:alice")
+        agent.retrieve("q")
+        assert tracer.records[0].actor == "user:alice"
+
+
+class _Retriever:
+    async def search(self, query: str) -> list[str]:
+        return [f"doc-for-{query}"]
+
+
+class _AgentWithSubComponent:
+    def __init__(self) -> None:
+        self.retriever = _Retriever()
+
+    async def run(self, query: str) -> str:
+        # An internal self-call — NOT made through the outer proxy.
+        docs = await self.retriever.search(query)
+        return f"answer using {docs}"
+
+
+class TestInstrumentAttrs:
+    """Closes the gap where an agent's own internal calls (not made
+    through the outer proxy) were invisible to the tracer."""
+
+    @pytest.mark.asyncio
+    async def test_internal_self_call_to_an_instrumented_sub_attr_is_captured(self):
+        tracer = AuditTracer()
+        agent = VerifiableAgent(
+            _AgentWithSubComponent(), tracer=tracer, instrument_attrs=["retriever"]
+        )
+
+        result = await agent.run("hello")
+
+        assert result == "answer using ['doc-for-hello']"
+        # "run" -> paired (TOOL_CALL, TOOL_RESULT); "search" -> RETRIEVAL (single).
+        kinds = sorted(r.kind for r in tracer.records)
+        assert kinds == [
+            EventKind.RETRIEVAL.value,
+            EventKind.TOOL_CALL.value,
+            EventKind.TOOL_RESULT.value,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_captured_internal_call_has_the_outer_call_as_its_parent(self):
+        tracer = AuditTracer()
+        agent = VerifiableAgent(
+            _AgentWithSubComponent(), tracer=tracer, instrument_attrs=["retriever"]
+        )
+        await agent.run("hello")
+
+        call_record = next(r for r in tracer.records if r.kind == EventKind.TOOL_CALL.value)
+        search_record = next(r for r in tracer.records if r.kind == EventKind.RETRIEVAL.value)
+        result_record = next(r for r in tracer.records if r.kind == EventKind.TOOL_RESULT.value)
+        assert search_record.parent_id == call_record.event_id
+        assert result_record.parent_id == call_record.event_id
+
+    @pytest.mark.asyncio
+    async def test_without_instrument_attrs_the_internal_call_is_invisible(self):
+        tracer = AuditTracer()
+        agent = VerifiableAgent(_AgentWithSubComponent(), tracer=tracer)
+        await agent.run("hello")
+
+        # Documents the known limitation: only the outermost proxied call
+        # is captured (as its call/result pair) unless the sub-attribute
+        # is explicitly instrumented — the internal `search` call never
+        # appears.
+        assert len(tracer.records) == 2
+        assert all(r.payload["method"] == "run" for r in tracer.records)
+        assert {r.kind for r in tracer.records} == {
+            EventKind.TOOL_CALL.value,
+            EventKind.TOOL_RESULT.value,
+        }
+
+    def test_instrumenting_a_missing_attr_is_a_no_op(self):
+        tracer = AuditTracer()
+        # Should not raise even though DummyAgent has no 'nonexistent' attr.
+        VerifiableAgent(DummyAgent(), tracer=tracer, instrument_attrs=["nonexistent"])
+
+
+class TestAuditedDecorator:
+    @pytest.mark.asyncio
+    async def test_decorates_a_standalone_async_tool(self):
+        tracer = AuditTracer()
+
+        @audited(EventKind.TOOL_CALL, tracer=tracer)
+        async def search(query: str) -> str:
+            return f"results for {query}"
+
+        result = await search("weather")
+        assert result == "results for weather"
+        assert len(tracer.records) == 1
+        assert tracer.records[0].kind == EventKind.TOOL_CALL.value
+
+    def test_decorates_a_standalone_sync_tool(self):
+        tracer = AuditTracer()
+
+        @audited(EventKind.TOOL_CALL, tracer=tracer)
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        assert add(2, 3) == 5
+        assert tracer.records[0].payload["output"] == 5
+
+    @pytest.mark.asyncio
+    async def test_nested_audited_calls_get_correct_parent_id(self):
+        tracer = AuditTracer()
+
+        @audited(EventKind.TOOL_CALL, tracer=tracer, name="inner")
+        async def inner() -> str:
+            return "done"
+
+        @audited(EventKind.DECISION, tracer=tracer, name="outer")
+        async def outer() -> str:
+            return await inner()
+
+        await outer()
+        records = {r.payload["method"]: r for r in tracer.records}
+        assert records["inner"].parent_id == records["outer"].event_id
+
+    @pytest.mark.asyncio
+    async def test_exception_is_recorded_with_error_kind_regardless_of_declared_kind(self):
+        tracer = AuditTracer()
+
+        @audited(EventKind.TOOL_CALL, tracer=tracer)
+        async def boom() -> None:
+            raise RuntimeError("nope")
+
+        with pytest.raises(RuntimeError):
+            await boom()
+        assert tracer.records[0].kind == EventKind.ERROR.value
+
+    def test_default_actor_is_system(self):
+        tracer = AuditTracer()
+
+        @audited(EventKind.TOOL_CALL, tracer=tracer)
+        def noop() -> None:
+            return None
+
+        noop()
+        assert tracer.records[0].actor == "system"

--- a/uv.lock
+++ b/uv.lock
@@ -10722,6 +10722,7 @@ name = "synapsekit"
 version = "1.9.1"
 source = { editable = "." }
 dependencies = [
+    { name = "cryptography" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pillow" },
@@ -11223,6 +11224,7 @@ requires-dist = [
     { name = "cohere", marker = "extra == 'cohere'", specifier = ">=5.0" },
     { name = "croniter", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "croniter", marker = "extra == 'cron'", specifier = ">=2.0" },
+    { name = "cryptography", specifier = ">=42" },
     { name = "deepgram-sdk", marker = "extra == 'voice-deepgram'", specifier = ">=3.0" },
     { name = "discord-py", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "discord-py", marker = "extra == 'discord'", specifier = ">=2.0" },


### PR DESCRIPTION
Merges #766 (verifiable agents / audit system from @Abhay-Mmmm) with review fixes applied on top:

- CreditCardDetector matched any 13-16 digit run with no Luhn check, over-redacting ordinary numeric IDs. Added a Luhn checksum gate before redaction.
- AuditRecord.from_dict skipped deep_freeze on payload, so records reconstructed from a loaded bundle were mutable, unlike records created via AuditTracer.record. Fixed to freeze consistently.
- verify_chain had no run_id awareness, so an unfiltered multi-run record list could validate a bogus cross-run chain link. Now raises on mixed run_ids.
- Canonical JSON hashing had no Unicode normalization, so combining vs precomposed forms of the same text hashed differently. Added NFC normalization before hashing.
- Only internal Merkle nodes were domain separated per RFC 6962, leaves were not. Added the leaf domain prefix to match the spec fully.

Regression tests added for all five, full suite passing.

Closes #738