### PR TITLE
fix(retrieval): Neo4j subgraph confidence/as_of parity + run integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,14 @@ jobs:
       - uses: astral-sh/setup-uv@v5
       - run: uv sync --group dev --group bench
       - run: uv run pytest benchmarks/test_world_model_retrieval_bench.py -v
+
+  # Real-backend tests via testcontainers (Neo4j/Memgraph, Kuzu, property graph).
+  # ubuntu-latest ships a running Docker daemon, so these execute for real here
+  # instead of skipping. Kept as a separate job so the fast `test` job stays lean.
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --group dev --group integration
+      - run: uv run pytest tests/retrieval/test_world_model.py tests/retrieval/test_property_graph.py -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ SynapseKit uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Spec test for a replayable `AgentSwarm` auction receipt (`tests/agents/test_agent_swarm_receipt.py`, `xfail` pending implementation) — captures task_id, reputation-prior version, budget consumed, and outcome-score provenance per auction so a reviewer can tell whether a market win reflects a real outcome or a stale/self-reported score; added as an acceptance criterion on #734 (h/t @clementineCU)
+- **`WorldModelRAG` Neo4j/Memgraph backend** — `Neo4jWorldGraphBackend` (Bolt; serves both Neo4j and Memgraph) with write-through persistence and live bounded-hop Cypher reads; selectable via `graph_backend="neo4j"` / `"memgraph"` (honoring `NEO4J_URI` / `NEO4J_USERNAME` / `NEO4J_PASSWORD`) or `WorldModelRAG.neo4j(...)`; plus a 10k-document offline demo and a hybrid-vs-vector-only retrieval accuracy benchmark with a CI regression gate; completes the remaining #735 acceptance criteria; contributed by [@Abhay-Mmmm](https://github.com/Abhay-Mmmm)
+
+### Fixed
+
+- **`Neo4jWorldGraphBackend.query_subgraph` now filters nodes and documents by `min_confidence` / `as_of`, not just the returned edges** (#826) — a `neo4j` / `memgraph` graph backend previously returned entities (and their source documents) reachable only through low-confidence or time-expired edges, diverging from the in-memory backend on confidence-filtered and time-travel queries; `upsert_relation` now also records relation-provenance documents against both endpoints. Verified for parity against a live Neo4j via testcontainers.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,6 +274,17 @@ bench = [
     "psutil>=5.9",
 ]
 
+# Real-backend integration tests. These deps + a running Docker daemon let the
+# testcontainers-based tests (Neo4j/Memgraph, Kuzu, property graph) execute for
+# real instead of skipping via importorskip. Installed by the CI `integration`
+# job; run locally with `uv sync --group dev --group integration`.
+integration = [
+    "testcontainers>=4.0",
+    "neo4j>=5.0",
+    "networkx>=3.0",
+    "kuzu>=0.8",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/synapsekit"]
 

--- a/src/synapsekit/retrieval/world_model.py
+++ b/src/synapsekit/retrieval/world_model.py
@@ -870,6 +870,19 @@ class KuzuWorldGraphBackend(InMemoryWorldGraphBackend):
         return self._conn.execute(query, parameters)
 
 
+# Cypher fragment: is a single relationship ``r`` valid under the confidence and
+# bitemporal filters? Mirrors ``InMemoryWorldGraphBackend`` traversal pruning:
+# ``edge.confidence >= min_confidence`` and ``_edge_active(edge, as_of)``.
+_REL_VALID_PREDICATE = (
+    "coalesce(r.confidence, 1.0) >= $min_confidence "
+    "AND ($as_of IS NULL OR r.valid_at IS NULL OR r.valid_at <= $as_of) "
+    "AND ($as_of IS NULL OR r.valid_until IS NULL OR r.valid_until > $as_of)"
+)
+# Same predicate applied to *every* relationship on a traversed path, so a node
+# reachable only through an invalid/expired/low-confidence edge is not returned.
+_REL_LIST_VALID_PREDICATE = f"all(r IN rels WHERE {_REL_VALID_PREDICATE})"
+
+
 class Neo4jWorldGraphBackend(InMemoryWorldGraphBackend):
     """Neo4j/Memgraph-backed world graph with live bounded-hop Cypher reads.
 
@@ -908,12 +921,7 @@ class Neo4jWorldGraphBackend(InMemoryWorldGraphBackend):
         node = super().upsert_entity(entity, doc_id)
         self._persist_entity(node)
         self._persist_document(doc_id)
-        self._run(
-            "MATCH (d:WorldModelDocument {id: $doc_id}), (e:WorldModelEntity {id: $entity_id}) "
-            "MERGE (d)-[:MENTIONS]->(e)",
-            doc_id=doc_id,
-            entity_id=node.id,
-        )
+        self._persist_mention(doc_id, node.id)
         return node
 
     def upsert_relation(self, relation: RelationMention, doc_id: str) -> WorldModelEdge | None:
@@ -921,6 +929,12 @@ class Neo4jWorldGraphBackend(InMemoryWorldGraphBackend):
         if edge is None:
             return None
         self._persist_document(doc_id)
+        # Mirror the in-memory backend, which records the relation's document
+        # against *both* endpoints (``_documents_by_node``); without these
+        # MENTIONS edges, ``query_subgraph`` would drop relation-provenance
+        # documents that in-memory keeps.
+        self._persist_mention(doc_id, edge.subject_id)
+        self._persist_mention(doc_id, edge.object_id)
         self._persist_edge(edge)
         return edge
 
@@ -950,31 +964,30 @@ class Neo4jWorldGraphBackend(InMemoryWorldGraphBackend):
         as_of_iso = timestamp.isoformat() if timestamp else None
 
         with self._driver.session(database=self._database) as session:
-            node_rows = session.run(
-                f"""
-                MATCH path=(n:WorldModelEntity)-[:WORLD_RELATES*0..{hops}]-(m:WorldModelEntity)
-                WHERE n.id IN $ids
-                UNWIND nodes(path) AS node
-                RETURN DISTINCT node
-                """,
-                ids=seeds,
-            )
-            nodes = {row["node"]["id"]: self._node_from_record(row["node"]) for row in node_rows}
+            # Nodes/documents: only those reachable via a fully-valid path, so
+            # confidence/as_of filtering prunes the traversal exactly like the
+            # in-memory BFS (a node reached only through an invalid edge, and its
+            # documents, must not leak into the result).
+            nodes = self._valid_path_nodes(session, seeds, hops, min_confidence, as_of_iso)
 
             edges: dict[str, WorldModelEdge] = {}
             if hops > 0:
+                # BFS-edge parity: an edge is returned iff it is itself valid AND
+                # at least one endpoint is reachable via a fully-valid path of
+                # length <= hops-1 -- i.e. a node the in-memory BFS would expand.
+                # That endpoint's neighbour is then within hops, so both ends are
+                # already in ``nodes``.
+                inner_ids = list(
+                    self._valid_path_nodes(session, seeds, hops - 1, min_confidence, as_of_iso)
+                )
                 edge_rows = session.run(
                     f"""
-                    MATCH path=(n:WorldModelEntity)-[:WORLD_RELATES*1..{hops}]-(m:WorldModelEntity)
-                    WHERE n.id IN $ids
-                    UNWIND relationships(path) AS rel
-                    WITH DISTINCT rel
-                    WHERE coalesce(rel.confidence, 1.0) >= $min_confidence
-                      AND ($as_of IS NULL OR rel.valid_at IS NULL OR rel.valid_at <= $as_of)
-                      AND ($as_of IS NULL OR rel.valid_until IS NULL OR rel.valid_until > $as_of)
-                    RETURN startNode(rel).id AS subject_id, endNode(rel).id AS object_id, rel
+                    MATCH (s:WorldModelEntity)-[r:WORLD_RELATES]->(o:WorldModelEntity)
+                    WHERE (s.id IN $inner_ids OR o.id IN $inner_ids)
+                      AND {_REL_VALID_PREDICATE}
+                    RETURN s.id AS subject_id, o.id AS object_id, r AS rel
                     """,
-                    ids=seeds,
+                    inner_ids=inner_ids,
                     min_confidence=min_confidence,
                     as_of=as_of_iso,
                 )
@@ -998,6 +1011,36 @@ class Neo4jWorldGraphBackend(InMemoryWorldGraphBackend):
             documents=documents,
             query_entities=[self.nodes[seed].name for seed in seeds if seed in self.nodes],
         )
+
+    def _valid_path_nodes(
+        self,
+        session: Any,
+        seeds: list[str],
+        hops: int,
+        min_confidence: float,
+        as_of_iso: str | None,
+    ) -> dict[str, WorldModelNode]:
+        """Nodes reachable from ``seeds`` via paths of length ``0..hops`` whose
+        every relationship passes the confidence/temporal filters.
+
+        The Neo4j analogue of ``InMemoryWorldGraphBackend``'s pruned BFS: the
+        zero-length path always yields the seed itself, so isolated seeds are
+        still returned, and a node reachable only through an invalid edge is not.
+        """
+        if hops < 0:
+            return {}
+        rows = session.run(
+            f"""
+            MATCH path=(n:WorldModelEntity)-[rels:WORLD_RELATES*0..{hops}]-(m:WorldModelEntity)
+            WHERE n.id IN $ids AND {_REL_LIST_VALID_PREDICATE}
+            UNWIND nodes(path) AS node
+            RETURN DISTINCT node
+            """,
+            ids=seeds,
+            min_confidence=min_confidence,
+            as_of=as_of_iso,
+        )
+        return {row["node"]["id"]: self._node_from_record(row["node"]) for row in rows}
 
     def to_mermaid(self, result: GraphQueryResult | None = None) -> str:
         if result is None:
@@ -1057,6 +1100,14 @@ class Neo4jWorldGraphBackend(InMemoryWorldGraphBackend):
 
     def _persist_document(self, doc_id: str) -> None:
         self._run("MERGE (:WorldModelDocument {id: $id})", id=doc_id)
+
+    def _persist_mention(self, doc_id: str, entity_id: str) -> None:
+        self._run(
+            "MATCH (d:WorldModelDocument {id: $doc_id}), (e:WorldModelEntity {id: $entity_id}) "
+            "MERGE (d)-[:MENTIONS]->(e)",
+            doc_id=doc_id,
+            entity_id=entity_id,
+        )
 
     def _persist_entity(self, node: WorldModelNode) -> None:
         self._run(

--- a/tests/retrieval/test_world_model.py
+++ b/tests/retrieval/test_world_model.py
@@ -381,6 +381,88 @@ def test_neo4j_backend_roundtrip_with_testcontainers():
             backend.close()
 
 
+def _populate_parity_graph(backend) -> None:
+    """Alpha links to Bravo (expired edge), Charlie (valid), Delta (low confidence).
+
+    Each entity carries its own document and each relation a distinct document,
+    so both entity-provenance and relation-provenance can be checked for leaks.
+    """
+    backend.upsert_entity(EntityMention(name="Alpha"), "docA")
+    backend.upsert_entity(EntityMention(name="Bravo"), "docB")
+    backend.upsert_entity(EntityMention(name="Charlie"), "docC")
+    backend.upsert_entity(EntityMention(name="Delta"), "docD")
+    backend.upsert_relation(
+        RelationMention(
+            subject="Alpha",
+            predicate="linked_to",
+            object="Bravo",
+            valid_at=datetime(2020, 1, 1, tzinfo=UTC),
+            valid_until=datetime(2023, 1, 1, tzinfo=UTC),  # expired before the as_of below
+        ),
+        "relAB",
+    )
+    backend.upsert_relation(
+        RelationMention(subject="Alpha", predicate="linked_to", object="Charlie", confidence=0.9),
+        "relAC",
+    )
+    backend.upsert_relation(
+        RelationMention(subject="Alpha", predicate="linked_to", object="Delta", confidence=0.2),
+        "relAD",
+    )
+
+
+def _subgraph_signature(result) -> tuple:
+    return (
+        sorted(node.name for node in result.nodes),
+        sorted(result.documents),
+        sorted((edge.subject_id, edge.predicate, edge.object_id) for edge in result.edges),
+    )
+
+
+def test_neo4j_query_subgraph_matches_in_memory_for_as_of_and_min_confidence():
+    """Regression for #826: the Neo4j backend must prune nodes AND documents by
+    confidence/as_of exactly like the in-memory backend, not just the edge list."""
+    pytest.importorskip("neo4j")
+    container_mod = pytest.importorskip("testcontainers.core.container")
+    wait_mod = pytest.importorskip("testcontainers.core.waiting_utils")
+    from synapsekit.retrieval.world_model import Neo4jWorldGraphBackend
+
+    password = "synapsekit-password"
+    with (
+        container_mod.DockerContainer("neo4j:5")
+        .with_env("NEO4J_AUTH", f"neo4j/{password}")
+        .with_exposed_ports(7687) as container
+    ):
+        wait_mod.wait_for_logs(container, "Bolt enabled", timeout=60)
+        host = container.get_container_host_ip()
+        port = container.get_exposed_port(7687)
+        neo4j_backend = Neo4jWorldGraphBackend(
+            f"bolt://{host}:{port}", username="neo4j", password=password
+        )
+        try:
+            in_memory = InMemoryWorldGraphBackend()
+            _populate_parity_graph(in_memory)
+            _populate_parity_graph(neo4j_backend)
+
+            # Time travel: the Alpha->Bravo edge has expired, so Bravo (and its
+            # entity document docB) must vanish from both backends identically.
+            mem_tt = in_memory.query_subgraph("Alpha", max_hops=2, as_of="2025-01-01")
+            neo_tt = neo4j_backend.query_subgraph("Alpha", max_hops=2, as_of="2025-01-01")
+            assert "Bravo" not in {n.name for n in neo_tt.nodes}
+            assert "docB" not in neo_tt.documents
+            assert _subgraph_signature(neo_tt) == _subgraph_signature(mem_tt)
+
+            # Confidence filter: the low-confidence Alpha->Delta edge drops Delta
+            # (and docD) from both backends identically.
+            mem_conf = in_memory.query_subgraph("Alpha", max_hops=2, min_confidence=0.5)
+            neo_conf = neo4j_backend.query_subgraph("Alpha", max_hops=2, min_confidence=0.5)
+            assert "Delta" not in {n.name for n in neo_conf.nodes}
+            assert "docD" not in neo_conf.documents
+            assert _subgraph_signature(neo_conf) == _subgraph_signature(mem_conf)
+        finally:
+            neo4j_backend.close()
+
+
 def test_event_ingestion_links_participants():
     graph = InMemoryWorldGraphBackend()
     graph.upsert_entity(EntityMention("Alice"), "doc_event")

--- a/uv.lock
+++ b/uv.lock
@@ -1802,6 +1802,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/7f/731ff914b0255d3d065f45fd4e626d4b8c95dbcbaada049f337a6ac16410/docker-7.2.0.tar.gz", hash = "sha256:cebb93773d334f778e023a7ee352a8d6e13ab1bd3b863a4d4a59dec897df43ac", size = 118731, upload-time = "2026-07-09T14:53:46.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/23/529140fe1aab80fc6992f93a706deec709140a6397439139a054e1515c45/docker-7.2.0-py3-none-any.whl", hash = "sha256:a3f45fdeb9165e2d25d9a1d02ddf3bc70fb572cf5ebbf9b58558c22caf29b71f", size = 148775, upload-time = "2026-07-09T14:53:45.224Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -11228,6 +11242,13 @@ dev = [
     { name = "ruff" },
     { name = "tzdata" },
 ]
+integration = [
+    { name = "kuzu" },
+    { name = "neo4j" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "testcontainers" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -11476,6 +11497,12 @@ dev = [
     { name = "ruff", specifier = ">=0.9" },
     { name = "tzdata", specifier = ">=2024.1" },
 ]
+integration = [
+    { name = "kuzu", specifier = ">=0.8" },
+    { name = "neo4j", specifier = ">=5.0" },
+    { name = "networkx", specifier = ">=3.0" },
+    { name = "testcontainers", specifier = ">=4.0" },
+]
 
 [[package]]
 name = "tabulate"
@@ -11507,6 +11534,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a3/4d/6a19536c50b849338fcbe9290d562b52cbdcf30d8963d3588a68a4107df1/tenacity-8.5.0.tar.gz", hash = "sha256:8bc6c0c8a09b31e6cad13c47afbed1a567518250a9a171418582ed8d9c20ca78", size = 47309, upload-time = "2024-07-05T07:25:31.836Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/3f/8ba87d9e287b9d385a02a7114ddcef61b26f86411e121c9003eb509a1773/tenacity-8.5.0-py3-none-any.whl", hash = "sha256:b594c2a5945830c267ce6b79a166228323ed52718f30302c1359836112346687", size = 28165, upload-time = "2024-07-05T07:25:29.591Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Post-merge follow-up to #823 (WorldModelRAG). Two separate concerns:

### 1. Fix Neo4j backend parity bug — closes #826
`Neo4jWorldGraphBackend.query_subgraph` applied the `min_confidence` / `as_of` filters only to the returned **edges**, not to the node/document traversal. So the `neo4j` / `memgraph` backend returned entities (and their source documents) reachable only through low-confidence or time-expired edges — diverging from `InMemoryWorldGraphBackend` on confidence-filtered and **time-travel** queries.

- Node/document traversal now prunes on a per-path validity predicate (`all(r IN rels WHERE …)`), matching the in-memory BFS.
- `upsert_relation` now writes `MENTIONS` for **both** endpoints, so relation-provenance documents match too (a second, related parity gap).

### 2. Run testcontainers integration tests in CI — closes #827
The bug reached `main` because the only Neo4j test was `testcontainers`-gated and `testcontainers` was never a declared dependency — so it **skipped in CI**. Added an `integration` dependency-group + a dedicated CI `integration` job that runs the container-backed retrieval tests for real (GitHub runners have Docker). The fast `test` job stays lean.

## Verification (real backends, not mocks)
- `31 passed` across `test_world_model.py` + `test_property_graph.py` with live Neo4j + Kuzu containers.
- **Regression proven**: the new parity test **fails on the pre-fix code** (`assert 'Bravo' not in {'Alpha','Bravo','Charlie','Delta'}` — the expired-edge node leaked) and passes on the fix.

## Commits (separated by concern)
- `fix(retrieval): filter Neo4j subgraph nodes and documents by confidence/as_of (#826)`
- `ci(test): run testcontainers integration tests in CI (#827)`
