### PR TITLE
LLM contract tests via respx: OpenAI + Anthropic (replaces MagicMock) — #829

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,6 +266,9 @@ dev = [
     "beautifulsoup4>=4.14.3",
     "fastapi>=0.135.1",
     "tzdata>=2024.1",
+    "respx>=0.21",
+    "openai>=1.40",
+    "anthropic>=0.39",
 ]
 
 bench = [

--- a/tests/llm/test_anthropic_respx.py
+++ b/tests/llm/test_anthropic_respx.py
@@ -1,0 +1,128 @@
+"""AnthropicLLM HTTP-contract tests via respx (real SDK request-building + SSE parsing).
+
+Replaces MagicMock coverage: respx intercepts the real httpx call the anthropic SDK
+makes to the Messages API and streams back real event-typed SSE, exercising the
+actual request body and stream/usage parsing. Part of #829 (LLM track).
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+
+import httpx
+import pytest
+
+respx = pytest.importorskip("respx")
+pytest.importorskip("anthropic")
+
+from synapsekit.llm.anthropic import AnthropicLLM  # noqa: E402
+from synapsekit.llm.base import LLMConfig  # noqa: E402
+
+_URL = "https://api.anthropic.com/v1/messages"
+
+
+def _event(event: str, data: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+
+
+def _messages_sse(texts: list[str], input_tokens: int, output_tokens: int) -> bytes:
+    parts = [
+        _event(
+            "message_start",
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-3-5-sonnet",
+                    "content": [],
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": input_tokens, "output_tokens": 0},
+                },
+            },
+        ),
+        _event(
+            "content_block_start",
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+        ),
+    ]
+    for t in texts:
+        parts.append(
+            _event(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": t},
+                },
+            )
+        )
+    parts += [
+        _event("content_block_stop", {"type": "content_block_stop", "index": 0}),
+        _event(
+            "message_delta",
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                "usage": {"output_tokens": output_tokens},
+            },
+        ),
+        _event("message_stop", {"type": "message_stop"}),
+    ]
+    return "".join(parts).encode()
+
+
+def _llm() -> AnthropicLLM:
+    return AnthropicLLM(
+        LLMConfig(model="claude-3-5-sonnet", api_key="test-key", provider="anthropic")
+    )
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_stream_parses_events_and_counts_tokens():
+    route = respx.post(_URL).mock(
+        return_value=httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=_messages_sse(["Hello", " world"], input_tokens=5, output_tokens=2),
+        )
+    )
+    llm = _llm()
+    out = "".join([t async for t in llm.stream("hi there")])
+
+    assert out == "Hello world"
+    assert route.called
+    assert llm._input_tokens == 5
+    assert llm._output_tokens == 2
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_request_body_is_built_correctly():
+    route = respx.post(_URL).mock(
+        return_value=httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=_messages_sse(["ok"], input_tokens=1, output_tokens=1),
+        )
+    )
+    llm = _llm()
+    _ = [t async for t in llm.stream("question", max_tokens=64)]
+
+    sent = json.loads(route.calls[0].request.content)
+    assert sent["model"] == "claude-3-5-sonnet"
+    assert sent["max_tokens"] == 64
+    assert {"role": "user", "content": "question"} in sent["messages"]
+    assert route.calls[0].request.headers["x-api-key"] == "test-key"
+
+
+def test_stream_is_async_generator():
+    assert inspect.isasyncgenfunction(AnthropicLLM.stream)

--- a/tests/llm/test_openai_respx.py
+++ b/tests/llm/test_openai_respx.py
@@ -1,0 +1,95 @@
+"""OpenAILLM HTTP-contract tests via respx (real SDK request-building + SSE parsing).
+
+Replaces MagicMock coverage: respx intercepts the real httpx call the openai SDK
+makes and streams back real SSE, so this exercises the actual request body the SDK
+builds and the actual chunk parsing / token accounting — not a hand-faked client.
+Part of #829 (LLM track).
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+
+import httpx
+import pytest
+
+respx = pytest.importorskip("respx")
+pytest.importorskip("openai")
+
+from synapsekit.llm.base import LLMConfig  # noqa: E402
+from synapsekit.llm.openai import OpenAILLM  # noqa: E402
+
+_URL = "https://api.openai.com/v1/chat/completions"
+
+
+def _sse(*chunks: dict) -> bytes:
+    body = "".join(f"data: {json.dumps(c)}\n\n" for c in chunks)
+    return (body + "data: [DONE]\n\n").encode()
+
+
+def _chunk(delta: dict | None = None, usage: dict | None = None) -> dict:
+    c: dict = {
+        "id": "chatcmpl-1",
+        "object": "chat.completion.chunk",
+        "created": 1,
+        "model": "gpt-4o-mini",
+        "choices": [] if delta is None else [{"index": 0, "delta": delta, "finish_reason": None}],
+    }
+    if usage is not None:
+        c["usage"] = usage
+    return c
+
+
+def _llm() -> OpenAILLM:
+    return OpenAILLM(LLMConfig(model="gpt-4o-mini", api_key="test-key", provider="openai"))
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_stream_parses_sse_and_counts_tokens():
+    body = _sse(
+        _chunk({"content": "Hello"}),
+        _chunk({"content": " world"}),
+        _chunk(usage={"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7}),
+    )
+    route = respx.post(_URL).mock(
+        return_value=httpx.Response(
+            200, headers={"content-type": "text/event-stream"}, content=body
+        )
+    )
+    llm = _llm()
+    out = "".join([t async for t in llm.stream("hi there")])
+
+    assert out == "Hello world"
+    assert route.called
+    assert llm._input_tokens == 5
+    assert llm._output_tokens == 2
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_request_body_is_built_correctly():
+    route = respx.post(_URL).mock(
+        return_value=httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=_sse(_chunk({"content": "ok"})),
+        )
+    )
+    llm = _llm()
+    _ = [t async for t in llm.stream("question", temperature=0.7, max_tokens=50)]
+
+    sent = json.loads(route.calls[0].request.content)
+    assert sent["model"] == "gpt-4o-mini"
+    assert sent["stream"] is True
+    assert sent["temperature"] == 0.7
+    assert sent["max_tokens"] == 50
+    assert {"role": "user", "content": "question"} in sent["messages"]
+    # API key is sent as a bearer token, proving real auth-header construction.
+    assert route.calls[0].request.headers["authorization"] == "Bearer test-key"
+
+
+def test_stream_is_async_generator():
+    # SynapseKit is async-first.
+    assert inspect.isasyncgenfunction(OpenAILLM.stream)

--- a/uv.lock
+++ b/uv.lock
@@ -10150,6 +10150,18 @@ wheels = [
 ]
 
 [[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -11240,6 +11252,7 @@ bench = [
     { name = "pytest-benchmark", extra = ["histogram"] },
 ]
 dev = [
+    { name = "anthropic" },
     { name = "beautifulsoup4" },
     { name = "deptry" },
     { name = "fastapi" },
@@ -11247,12 +11260,14 @@ dev = [
     { name = "httpx" },
     { name = "lxml" },
     { name = "mypy" },
+    { name = "openai" },
     { name = "pre-commit" },
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "respx" },
     { name = "ruff" },
     { name = "tzdata" },
 ]
@@ -11511,6 +11526,7 @@ bench = [
     { name = "pytest-benchmark", extras = ["histogram"], specifier = ">=4.0" },
 ]
 dev = [
+    { name = "anthropic", specifier = ">=0.39" },
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "deptry", specifier = ">=0.16" },
     { name = "fastapi", specifier = ">=0.135.1" },
@@ -11518,12 +11534,14 @@ dev = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "lxml", specifier = ">=6.1.0" },
     { name = "mypy", specifier = ">=1.11" },
+    { name = "openai", specifier = ">=1.40" },
     { name = "pre-commit", specifier = ">=3.7" },
     { name = "pyarrow", specifier = ">=23.0.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-cov", specifier = ">=5.0" },
+    { name = "respx", specifier = ">=0.21" },
     { name = "ruff", specifier = ">=0.9" },
     { name = "tzdata", specifier = ">=2024.1" },
 ]


### PR DESCRIPTION
Opens the LLM-provider track of epic #829. Replaces MagicMock with real **respx HTTP-contract tests** for OpenAI and Anthropic: respx intercepts the real httpx call each SDK makes and streams back real SSE, so the tests exercise the actual request body, SSE/event parsing, token counting, and auth headers — not a faked client. Runs in the **fast test job** (no container). 6/6 pass. OpenAI establishes the pattern for the whole OpenAI-compatible family (Groq/DeepSeek/xAI/…); Anthropic covers the event-typed Messages stream. Both providers correct as-is. Remaining providers + a real Ollama container are tracked on #829.