### PR TITLE
fix(llm): edge extra CVE + 200-task local-vs-cloud benchmark (#736)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,17 @@ jobs:
       - run: uv sync --group dev --group bench
       - run: uv run pytest benchmarks/test_world_model_retrieval_bench.py -v
 
+  # Harness-correctness check for the edge local-vs-cloud benchmark (#736). Runs
+  # against stub LLMs -- no GGUF file or ANTHROPIC_API_KEY in CI -- so it can
+  # only assert the graders and runner are right, not real model quality.
+  edge-benchmark-harness-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --group dev --group bench
+      - run: uv run pytest benchmarks/test_edge_local_vs_cloud_bench.py -v
+
   # Real-backend tests via testcontainers (Neo4j/Memgraph, Kuzu, property graph).
   # ubuntu-latest ships a running Docker daemon, so these execute for real here
   # instead of skipping. Kept as a separate job so the fast `test` job stays lean.

--- a/benchmarks/edge_local_vs_cloud_bench.py
+++ b/benchmarks/edge_local_vs_cloud_bench.py
@@ -1,0 +1,179 @@
+"""Local Llama 3.2 3B vs. cloud Claude accuracy/latency/cost comparison.
+
+Satisfies the benchmark acceptance criterion of issue #736: run a 200-task
+suite (see ``examples/edge_task_suite.py``) through a local GGUF model and a
+cloud model **directly** -- not through ``EdgeRuntime`` -- and report where
+local is good enough.
+
+The head-to-head, not the routing, is the point: the per-category accuracy gap
+is what tells ``CostQualityRouter`` (#589) which task families can stay on the
+device. ``EdgeRuntime``'s own routing behaviour is covered by
+``tests/llm/test_edge_runtime.py``.
+
+This measures model *quality*, not library wall-clock speed, so it's a
+standalone script rather than part of the ``benchmarks/pytest.ini`` timing
+suite. See ``test_edge_local_vs_cloud_bench.py`` for the CI-enforced check that
+the harness itself is correct.
+
+Usage:
+    python benchmarks/edge_local_vs_cloud_bench.py \
+        --model-path /models/Llama-3.2-3B-Instruct-Q4_K_M.gguf --n-tasks 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
+
+from edge_task_suite import CATEGORIES, EdgeTask, generate_tasks, grade
+
+from synapsekit.evaluation.dataset import EvalRecord
+from synapsekit.llm.base import BaseLLM, LLMConfig
+from synapsekit.observability.tracer import COST_TABLE
+
+LOCAL_COST_USD = 0.0
+
+
+def _cost_usd(llm: BaseLLM, prev_in: int, prev_out: int) -> float:
+    """USD cost of the tokens consumed since the snapshot; 0.0 for local models."""
+    pricing = COST_TABLE.get(llm.config.model)
+    if not pricing:
+        return LOCAL_COST_USD
+    delta_in = max(0, llm._input_tokens - prev_in)
+    delta_out = max(0, llm._output_tokens - prev_out)
+    return delta_in * pricing["input"] + delta_out * pricing["output"]
+
+
+async def run_task(llm: BaseLLM, task: EdgeTask) -> EvalRecord:
+    """Run one task and return its scored record.
+
+    A provider failure scores 0.0 rather than aborting the run -- a model that
+    errors on a task is worse at that task, which is exactly what the benchmark
+    is measuring.
+    """
+    prev_in, prev_out = llm._input_tokens, llm._output_tokens
+    started = time.perf_counter()
+    try:
+        output = await llm.generate(task.prompt)
+    except Exception as exc:  # noqa: BLE001 - a failed task is a scored 0, not a crash
+        output = f"<error: {exc}>"
+    latency_ms = (time.perf_counter() - started) * 1000
+
+    return EvalRecord(
+        name=task.name,
+        score=grade(task, output),
+        cost_usd=_cost_usd(llm, prev_in, prev_out),
+        latency_ms=latency_ms,
+        input=task.prompt,
+        output=output,
+        ideal=task.expected,
+        raw={"category": task.category, "model": llm.config.model},
+    )
+
+
+async def run_suite(llm: BaseLLM, tasks: list[EdgeTask]) -> list[EvalRecord]:
+    """Run every task sequentially, so latency samples aren't skewed by contention."""
+    return [await run_task(llm, task) for task in tasks]
+
+
+def summarize(records: list[EvalRecord]) -> dict[str, float]:
+    """Aggregate accuracy, latency percentiles, and total cost for one model."""
+    scores = [r.score or 0.0 for r in records]
+    latencies = sorted(r.latency_ms or 0.0 for r in records)
+    return {
+        "accuracy": sum(scores) / len(scores) if scores else 0.0,
+        "p50_ms": statistics.median(latencies) if latencies else 0.0,
+        "p95_ms": latencies[min(int(len(latencies) * 0.95), len(latencies) - 1)]
+        if latencies
+        else 0.0,
+        "total_cost_usd": sum(r.cost_usd or 0.0 for r in records),
+    }
+
+
+def accuracy_by_category(records: list[EvalRecord]) -> dict[str, float]:
+    """Mean accuracy per task category."""
+    result = {}
+    for category in CATEGORIES:
+        scores = [
+            r.score or 0.0 for r in records if (r.raw or {}).get("category") == category
+        ]
+        result[category] = sum(scores) / len(scores) if scores else 0.0
+    return result
+
+
+def report(local: list[EvalRecord], cloud: list[EvalRecord]) -> None:
+    """Print the comparison table and the per-category gap."""
+    local_stats, cloud_stats = summarize(local), summarize(cloud)
+
+    print(f"{'model':<10}{'accuracy':>10}{'p50 ms':>10}{'p95 ms':>10}{'cost USD':>12}")
+    for label, stats in (("local", local_stats), ("cloud", cloud_stats)):
+        print(
+            f"{label:<10}{stats['accuracy']:>10.3f}{stats['p50_ms']:>10.0f}"
+            f"{stats['p95_ms']:>10.0f}{stats['total_cost_usd']:>12.4f}"
+        )
+    print()
+
+    local_cat, cloud_cat = accuracy_by_category(local), accuracy_by_category(cloud)
+    print(f"{'category':<16}{'local':>10}{'cloud':>10}{'gap':>10}")
+    for category in CATEGORIES:
+        gap = local_cat[category] - cloud_cat[category]
+        print(
+            f"{category:<16}{local_cat[category]:>10.3f}"
+            f"{cloud_cat[category]:>10.3f}{gap:>+10.3f}"
+        )
+    print()
+    print("Negative gap = cloud is better; near-zero = local is good enough to keep on-device.")
+
+
+async def run(
+    model_path: str, cloud_model: str, n_tasks: int, seed: int, n_ctx: int
+) -> None:
+    from synapsekit.llm.anthropic import AnthropicLLM
+    from synapsekit.llm.llamacpp import LlamaCppLLM
+
+    tasks = generate_tasks(n=n_tasks, seed=seed)
+
+    local = LlamaCppLLM(
+        LLMConfig(model="llama-3.2-3b", api_key="", provider="llamacpp"),
+        model_path=model_path,
+        n_ctx=n_ctx,
+    )
+    cloud = AnthropicLLM(
+        LLMConfig(
+            model=cloud_model,
+            api_key=os.environ["ANTHROPIC_API_KEY"],
+            provider="anthropic",
+        )
+    )
+
+    print(f"suite: {len(tasks)} tasks, seed={seed}")
+    print(f"local: {model_path}")
+    print(f"cloud: {cloud_model}\n")
+
+    local_records = await run_suite(local, tasks)
+    cloud_records = await run_suite(cloud, tasks)
+    report(local_records, cloud_records)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-path", required=True, help="path to a local GGUF file")
+    parser.add_argument("--cloud-model", default="claude-haiku-4-5-20251001")
+    parser.add_argument("--n-tasks", type=int, default=200)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--n-ctx", type=int, default=4096)
+    args = parser.parse_args()
+    asyncio.run(
+        run(args.model_path, args.cloud_model, args.n_tasks, args.seed, args.n_ctx)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/test_edge_local_vs_cloud_bench.py
+++ b/benchmarks/test_edge_local_vs_cloud_bench.py
@@ -1,0 +1,185 @@
+"""CI-enforced check that the edge benchmark harness itself is correct.
+
+CI has no GGUF file and no ``ANTHROPIC_API_KEY``, so this cannot assert on real
+local-vs-cloud quality -- those numbers come from running
+``edge_local_vs_cloud_bench.py`` by hand and land in ``docs/edge.md``. What it
+*can* pin down, and what actually rots silently, is the harness: that graders
+score known-good and known-bad answers correctly, that every task produces a
+record, and that latency and cost are measured per model.
+
+A grader that quietly starts returning 1.0 for everything would make the
+published benchmark meaningless, which is why the grader cases below are
+exhaustive over the four grader modes rather than a smoke test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
+
+from edge_local_vs_cloud_bench import accuracy_by_category, run_suite, summarize
+from edge_task_suite import CATEGORIES, EdgeTask, generate_tasks, grade
+
+from synapsekit.llm.base import BaseLLM, LLMConfig
+
+_N_TASKS = 20
+_SEED = 7
+
+
+class StubLLM(BaseLLM):
+    """Answers each task correctly or incorrectly on demand, with no network."""
+
+    def __init__(self, model: str, *, correct: bool) -> None:
+        super().__init__(LLMConfig(model=model, api_key="", provider="stub"))
+        self._correct = correct
+        self.prompts: list[str] = []
+
+    async def stream(self, prompt: str, **kw: Any) -> AsyncGenerator[str]:
+        self.prompts.append(prompt)
+        self._input_tokens += 10
+        self._output_tokens += 5
+        yield _ideal_answer(prompt) if self._correct else "definitely wrong"
+
+
+def _ideal_answer(prompt: str) -> str:
+    """Produce a response that should score 1.0 for the task with this prompt."""
+    task = _TASKS_BY_PROMPT[prompt]
+    if task.category == "json":
+        fields = dict(pair.split("=", 1) for pair in task.expected.split(";"))
+        return f'{{"name": "{fields["name"]}", "age": {fields["age"]}}}'
+    if task.category == "format":
+        return task.expected.replace(r"\b", "")
+    return task.expected
+
+
+_TASKS = generate_tasks(n=_N_TASKS, seed=_SEED)
+_TASKS_BY_PROMPT = {t.prompt: t for t in _TASKS}
+
+
+# --------------------------------------------------------------------------- #
+# Graders
+# --------------------------------------------------------------------------- #
+
+
+def test_every_category_is_represented() -> None:
+    assert {t.category for t in _TASKS} == set(CATEGORIES)
+
+
+def test_generate_tasks_is_deterministic_for_a_seed() -> None:
+    assert generate_tasks(n=_N_TASKS, seed=_SEED) == _TASKS
+
+
+def test_graders_accept_the_ideal_answer() -> None:
+    for task in _TASKS:
+        assert grade(task, _ideal_answer(task.prompt)) == 1.0, task.name
+
+
+def test_graders_reject_a_wrong_answer() -> None:
+    for task in _TASKS:
+        assert grade(task, "definitely wrong") == 0.0, task.name
+
+
+def test_graders_tolerate_surrounding_prose() -> None:
+    for task in _TASKS:
+        padded = f"Sure! The answer is {_ideal_answer(task.prompt)} -- hope that helps."
+        assert grade(task, padded) == 1.0, task.name
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        ("negative", 0.0),
+        ("this is not positive at all", 0.0),
+        ("positive", 1.0),
+    ],
+)
+def test_label_grader_uses_first_label_mentioned(output: str, expected: float) -> None:
+    task = EdgeTask("t", "classification", "p", "positive", "label")
+    assert grade(task, output) == expected
+
+
+def test_json_grader_rejects_wrong_field_value() -> None:
+    task = EdgeTask("t", "json", "p", "name=Ivan Kim;age=41", "json_field")
+    assert grade(task, '{"name": "Ivan Kim", "age": 41}') == 1.0
+    assert grade(task, '{"name": "Ivan Kim", "age": 42}') == 0.0
+    assert grade(task, "no json here") == 0.0
+
+
+def test_json_grader_finds_json_inside_a_fenced_block() -> None:
+    task = EdgeTask("t", "json", "p", "name=Hana Voss;age=30", "json_field")
+    fenced = 'Here you go:\n```json\n{"name": "Hana Voss", "age": 30}\n```'
+    assert grade(task, fenced) == 1.0
+
+
+def test_unknown_grader_raises() -> None:
+    with pytest.raises(ValueError, match="unknown grader"):
+        grade(EdgeTask("t", "extraction", "p", "x", "nope"), "x")
+
+
+# --------------------------------------------------------------------------- #
+# Runner
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def suite_records() -> tuple[list, list]:
+    async def _run() -> tuple[list, list]:
+        good = await run_suite(StubLLM("local-stub", correct=True), _TASKS)
+        bad = await run_suite(StubLLM("claude-haiku-4-5-20251001", correct=False), _TASKS)
+        return good, bad
+
+    return asyncio.run(_run())
+
+
+def test_every_task_produces_one_record(suite_records) -> None:
+    good, bad = suite_records
+    assert len(good) == len(bad) == _N_TASKS
+    assert [r.name for r in good] == [t.name for t in _TASKS]
+
+
+def test_summary_separates_a_correct_model_from_a_wrong_one(suite_records) -> None:
+    good, bad = suite_records
+    assert summarize(good)["accuracy"] == 1.0
+    assert summarize(bad)["accuracy"] == 0.0
+
+
+def test_latency_is_recorded_for_every_task(suite_records) -> None:
+    good, _ = suite_records
+    assert all(r.latency_ms is not None and r.latency_ms >= 0 for r in good)
+
+
+def test_cost_is_zero_for_unpriced_local_models_and_nonzero_for_cloud(
+    suite_records,
+) -> None:
+    good, bad = suite_records
+    assert summarize(good)["total_cost_usd"] == 0.0
+    assert summarize(bad)["total_cost_usd"] > 0.0
+
+
+def test_accuracy_by_category_covers_every_category(suite_records) -> None:
+    good, _ = suite_records
+    by_category = accuracy_by_category(good)
+    assert set(by_category) == set(CATEGORIES)
+    assert all(score == 1.0 for score in by_category.values())
+
+
+def test_provider_failure_scores_zero_instead_of_crashing() -> None:
+    class BoomLLM(BaseLLM):
+        def __init__(self) -> None:
+            super().__init__(LLMConfig(model="boom", api_key="", provider="stub"))
+
+        async def stream(self, prompt: str, **kw: Any) -> AsyncGenerator[str]:
+            raise RuntimeError("model exploded")
+            yield ""  # pragma: no cover - unreachable, makes this an async generator
+
+    records = asyncio.run(run_suite(BoomLLM(), _TASKS[:3]))
+    assert len(records) == 3
+    assert all(r.score == 0.0 for r in records)
+    assert all("model exploded" in (r.output or "") for r in records)

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -9,10 +9,21 @@ agents that need to work on laptops, edge servers, and offline environments.
 Install only the backends you need:
 
 ```bash
-pip install "synapsekit[llamacpp,sqlite-vec]"
-pip install "synapsekit[onnx]"
-pip install "synapsekit[edge]"
+pip install "synapsekit[edge]"     # ONNX Runtime + SQLite-vec
+pip install "synapsekit[onnx]"     # ONNX embeddings only
+pip install "synapsekit[mlx]"      # Apple Silicon
 ```
+
+The llama.cpp backend is **not** bundled in any extra and must be installed
+directly:
+
+```bash
+pip install llama-cpp-python
+```
+
+It is excluded because its `diskcache` dependency has no patched release for
+CVE-2025-69872. Installing it is your call; SynapseKit will not pull it into
+your dependency tree on your behalf.
 
 The core package does not import llama.cpp, ONNX Runtime, or MLX unless you
 instantiate those providers.
@@ -136,3 +147,40 @@ synapsekit edge quantize model-f16.gguf model-q4.gguf --quantization Q4_K_M
 Mobile Swift/Kotlin wrappers are intentionally left for a future PR. The
 runtime added here is the Python policy and provider foundation those bindings
 can call into later.
+
+## Local vs. cloud tradeoffs
+
+`benchmarks/edge_local_vs_cloud_bench.py` runs a 200-task suite (extraction,
+classification, structured JSON, and date formatting; see
+`examples/edge_task_suite.py`) through a local GGUF model and a cloud model
+directly, and reports accuracy, p50/p95 latency, and USD cost per category.
+This is a head-to-head model comparison, not a test of `EdgeRuntime`'s
+routing -- it tells you which task families are safe to keep on-device before
+you set `FallbackPolicy` gates.
+
+Reproduce it locally (needs a GGUF file and `ANTHROPIC_API_KEY`; CI only runs
+the harness-correctness checks in `test_edge_local_vs_cloud_bench.py` against
+stub models, since it has neither):
+
+```bash
+python benchmarks/edge_local_vs_cloud_bench.py \
+    --model-path /models/Llama-3.2-3B-Instruct-Q4_K_M.gguf --n-tasks 200
+```
+
+<!--
+Fill in with real numbers from a Llama-3.2-3B-Instruct-Q4_K_M run once
+available -- this table is the "document tradeoffs" acceptance criterion for
+issue #736 and should not stay empty.
+-->
+
+| model | accuracy | p50 ms | p95 ms | cost USD |
+|---|---|---|---|---|
+| local (Llama 3.2 3B Q4_K_M) | _pending_ | _pending_ | _pending_ | 0.0000 |
+| cloud (`claude-haiku-4-5-20251001`) | _pending_ | _pending_ | _pending_ | _pending_ |
+
+| category | local | cloud | gap |
+|---|---|---|---|
+| extraction | _pending_ | _pending_ | _pending_ |
+| classification | _pending_ | _pending_ | _pending_ |
+| json | _pending_ | _pending_ | _pending_ |
+| format | _pending_ | _pending_ | _pending_ |

--- a/examples/edge_task_suite.py
+++ b/examples/edge_task_suite.py
@@ -1,0 +1,257 @@
+"""Deterministic 200-task suite for the edge local-vs-cloud benchmark.
+
+Generates seeded tasks across four families that cover the work a small local
+model is actually asked to do in an edge deployment (see issue #736): field
+**extraction**, **classification**, **json** structured output, and date
+**format** normalization.
+
+Every task is graded programmatically -- exact-ish containment, first-label-wins,
+JSON field equality, or regex -- so scoring is free, deterministic, and needs no
+API calls of its own.
+
+ponytail: programmatic graders only, so the suite is limited to tasks with one
+objectively checkable answer. If open-ended quality (tone, coherence, long-form
+summarization) ever needs measuring, add an LLM-judge grader mode alongside
+these -- don't loosen the existing ones into fuzzy matching.
+
+Shared by ``benchmarks/edge_local_vs_cloud_bench.py`` (real models) and
+``benchmarks/test_edge_local_vs_cloud_bench.py`` (CI harness check).
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import re
+from dataclasses import dataclass
+
+CATEGORIES = ("extraction", "classification", "json", "format")
+
+_LABELS = ("positive", "negative", "neutral")
+_NEGATORS = ("not ", "n't ", "non-")
+
+_FIRST_NAMES = [
+    "Alice", "Bianca", "Carlos", "Diana", "Ewan", "Farah", "Gustavo", "Hana",
+    "Ivan", "Julia", "Kenji", "Lena", "Mateo", "Nadia", "Omar", "Priya",
+]
+_LAST_NAMES = [
+    "Chen", "Okafor", "Silva", "Novak", "Haddad", "Kim", "Rossi", "Patel",
+    "Nguyen", "Larsen", "Costa", "Ibrahim", "Voss", "Reyes", "Singh",
+]
+_PRODUCTS = [
+    "Nimbus Platform", "Orion Gateway", "Falcon Engine", "Vertex Pipeline",
+    "Atlas Console", "Cobalt Ledger", "Ember Beacon", "Juniper Router",
+]
+_MONTHS = [
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+]
+_POSITIVE = [
+    "works exactly as advertised and setup took minutes",
+    "has been rock solid since we rolled it out",
+    "saved our team hours of manual work every week",
+]
+_NEGATIVE = [
+    "crashed twice during our launch window",
+    "corrupted our export and support never replied",
+    "is far slower than the documentation claims",
+]
+_NEUTRAL = [
+    "was installed on the staging cluster on Tuesday",
+    "is documented in the internal runbook",
+    "ships with the standard configuration defaults",
+]
+
+
+@dataclass(frozen=True)
+class EdgeTask:
+    """One benchmark task with an objectively checkable answer.
+
+    ``grader`` selects the scoring mode in :func:`grade`; ``expected`` is
+    interpreted per mode (a literal string, a label, ``k=v;k=v`` JSON fields,
+    or a regex).
+    """
+
+    name: str
+    category: str
+    prompt: str
+    expected: str
+    grader: str
+
+
+def _first_json_object(text: str) -> dict | None:
+    """Return the first parseable JSON object in ``text``, if any.
+
+    Models routinely wrap JSON in prose or fences, so scan for balanced braces
+    rather than trying to parse the whole response.
+    """
+    for start in (m.start() for m in re.finditer(r"\{", text)):
+        depth = 0
+        for i in range(start, len(text)):
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    try:
+                        parsed = json.loads(text[start : i + 1])
+                    except ValueError:
+                        break
+                    if isinstance(parsed, dict):
+                        return parsed
+                    break
+    return None
+
+
+def grade(task: EdgeTask, output: str) -> float:
+    """Score a model response as 1.0 (correct) or 0.0 (incorrect).
+
+    Graders tolerate surrounding prose -- small models rarely honour "reply with
+    only X" -- but never tolerate a wrong answer.
+    """
+    text = output.strip()
+    lowered = text.lower()
+
+    if task.grader == "contains":
+        return 1.0 if task.expected.lower() in lowered else 0.0
+
+    if task.grader == "label":
+        # First label mentioned wins, so trailing rambling can't flip a correct
+        # answer. A short "not "/"non-" prefix check keeps "not positive" from
+        # scoring as positive.
+        # ponytail: only catches simple adjacent negation, not "far from positive"
+        # or sarcasm -- widen the prefix window or add an LLM judge if that
+        # shows up in real model output.
+        hits = []
+        for lbl in _LABELS:
+            for m in re.finditer(rf"\b{lbl}\b", lowered):
+                prefix = lowered[max(0, m.start() - 5) : m.start()]
+                if any(neg in prefix for neg in _NEGATORS):
+                    continue
+                hits.append((m.start(), lbl))
+        if not hits:
+            return 0.0
+        return 1.0 if min(hits)[1] == task.expected else 0.0
+
+    if task.grader == "json_field":
+        parsed = _first_json_object(text)
+        if parsed is None:
+            return 0.0
+        for pair in task.expected.split(";"):
+            key, _, value = pair.partition("=")
+            if str(parsed.get(key, "")).strip().lower() != value.lower():
+                return 0.0
+        return 1.0
+
+    if task.grader == "regex":
+        return 1.0 if re.search(task.expected, text) else 0.0
+
+    raise ValueError(f"unknown grader: {task.grader!r}")
+
+
+def _extraction_task(rng: random.Random, i: int) -> EdgeTask:
+    product = rng.choice(_PRODUCTS)
+    total = f"${rng.randint(100, 9999):,}.{rng.randint(0, 99):02d}"
+    invoice = f"INV-{rng.randint(1000, 9999)}"
+    return EdgeTask(
+        name=f"extraction-{i:03d}",
+        category="extraction",
+        prompt=(
+            f"Invoice {invoice} from {product}, issued "
+            f"{rng.choice(_MONTHS)} {rng.randint(1, 28)}, 2023, total {total}, "
+            f"paid by card.\n\n"
+            "Extract the invoice total. Reply with only the amount."
+        ),
+        expected=total,
+        grader="contains",
+    )
+
+
+def _classification_task(rng: random.Random, i: int) -> EdgeTask:
+    label = rng.choice(_LABELS)
+    body = {
+        "positive": _POSITIVE,
+        "negative": _NEGATIVE,
+        "neutral": _NEUTRAL,
+    }[label]
+    return EdgeTask(
+        name=f"classification-{i:03d}",
+        category="classification",
+        prompt=(
+            f'Review: "{rng.choice(_PRODUCTS)} {rng.choice(body)}."\n\n'
+            "Classify the sentiment as positive, negative, or neutral. "
+            "Reply with one word."
+        ),
+        expected=label,
+        grader="label",
+    )
+
+
+def _json_task(rng: random.Random, i: int) -> EdgeTask:
+    name = f"{rng.choice(_FIRST_NAMES)} {rng.choice(_LAST_NAMES)}"
+    age = rng.randint(21, 65)
+    return EdgeTask(
+        name=f"json-{i:03d}",
+        category="json",
+        prompt=(
+            f"{name} is {age} years old and works on {rng.choice(_PRODUCTS)}.\n\n"
+            'Return a JSON object with exactly the keys "name" and "age". '
+            "Reply with only JSON."
+        ),
+        expected=f"name={name};age={age}",
+        grader="json_field",
+    )
+
+
+def _format_task(rng: random.Random, i: int) -> EdgeTask:
+    month = rng.randint(1, 12)
+    day = rng.randint(1, 28)
+    year = rng.randint(2019, 2024)
+    return EdgeTask(
+        name=f"format-{i:03d}",
+        category="format",
+        prompt=(
+            f"Convert the date '{_MONTHS[month - 1]} {day}, {year}' to "
+            "YYYY-MM-DD format. Reply with only the date."
+        ),
+        expected=rf"\b{year}-{month:02d}-{day:02d}\b",
+        grader="regex",
+    )
+
+
+_BUILDERS = {
+    "extraction": _extraction_task,
+    "classification": _classification_task,
+    "json": _json_task,
+    "format": _format_task,
+}
+
+
+def generate_tasks(n: int = 200, seed: int = 42) -> list[EdgeTask]:
+    """Build ``n`` tasks split evenly across the four categories.
+
+    Deterministic for a given ``seed``. ``n`` is rounded down to a multiple of
+    ``len(CATEGORIES)`` so every category is equally weighted and per-category
+    accuracies stay comparable.
+    """
+    if n < len(CATEGORIES):
+        raise ValueError(f"n must be at least {len(CATEGORIES)}, got {n}")
+
+    rng = random.Random(seed)
+    per_category = n // len(CATEGORIES)
+    tasks = [
+        _BUILDERS[category](rng, i)
+        for category in CATEGORIES
+        for i in range(per_category)
+    ]
+    rng.shuffle(tasks)
+    return tasks
+
+
+if __name__ == "__main__":
+    suite = generate_tasks()
+    print(f"{len(suite)} tasks across {len(CATEGORIES)} categories\n")
+    for task in suite[:4]:
+        print(f"--- {task.name} ({task.grader}) ---")
+        print(task.prompt)
+        print(f"expected: {task.expected}\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,12 +123,13 @@ cloudflare = ["httpx>=0.27"]
 aleph-alpha = ["aleph-alpha-client>=7.0"]
 # llama-cpp-python currently pulls diskcache, which has no patched release for
 # CVE-2025-69872. Keep the integration import-optional until upstream removes it.
+# This applies to every extra: `edge` must not pull it back in either -- install
+# llama-cpp-python directly if you want the llama.cpp backend.
 llamacpp = []
 gpt4all = ["gpt4all>=2.0"]
 onnx = ["onnxruntime>=1.17"]
 mlx = ["mlx-lm>=0.20; platform_system == 'Darwin' and platform_machine == 'arm64'"]
 edge = [
-    "llama-cpp-python>=0.2",
     "onnxruntime>=1.17",
     "sqlite-vec>=0.1",
 ]

--- a/src/synapsekit/llm/llamacpp.py
+++ b/src/synapsekit/llm/llamacpp.py
@@ -46,7 +46,9 @@ class LlamaCppLLM(BaseLLM):
                 from llama_cpp import Llama
             except ImportError:
                 raise ImportError(
-                    "llama-cpp-python required: pip install synapsekit[llamacpp]"
+                    "llama-cpp-python required: pip install llama-cpp-python "
+                    "(not bundled in any synapsekit extra: its diskcache dependency "
+                    "has no patched release for CVE-2025-69872)"
                 ) from None
             self._model = Llama(
                 model_path=self._model_path,

--- a/uv.lock
+++ b/uv.lock
@@ -1766,15 +1766,6 @@ wheels = [
 ]
 
 [[package]]
-name = "diskcache"
-version = "5.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
-]
-
-[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3243,7 +3234,7 @@ name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe" },
+    { name = "markupsafe", marker = "(python_full_version < '3.11' and platform_machine != 's390x' and sys_platform == 'emscripten') or (python_full_version < '3.11' and platform_machine != 's390x' and sys_platform == 'win32') or (platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
@@ -3609,19 +3600,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
     { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
 ]
-
-[[package]]
-name = "llama-cpp-python"
-version = "0.3.32"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "diskcache" },
-    { name = "jinja2" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/18/c8/3eb9c10c138eaa9d6148471701476169322eafbd825fdc13ec326552b516/llama_cpp_python-0.3.32.tar.gz", hash = "sha256:b06502361770f82eb08b7f1a192eb084b9ead2b88fe32cda8c397a2782eabde6", size = 70308017, upload-time = "2026-06-29T05:59:48.626Z" }
 
 [[package]]
 name = "lxml"
@@ -10958,7 +10936,6 @@ dynamodb = [
     { name = "boto3" },
 ]
 edge = [
-    { name = "llama-cpp-python" },
     { name = "onnxruntime", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "onnxruntime", version = "1.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sqlite-vec" },
@@ -11398,7 +11375,6 @@ requires-dist = [
     { name = "kuzu", marker = "extra == 'mesh'", specifier = ">=0.8" },
     { name = "lancedb", marker = "extra == 'all'", specifier = ">=0.5" },
     { name = "lancedb", marker = "extra == 'lancedb'", specifier = ">=0.5" },
-    { name = "llama-cpp-python", marker = "extra == 'edge'", specifier = ">=0.2" },
     { name = "lxml", marker = "extra == 'all'", specifier = ">=6.1.0" },
     { name = "lxml", marker = "extra == 'html'", specifier = ">=6.1.0" },
     { name = "marqo", marker = "extra == 'all'", specifier = ">=3.0" },


### PR DESCRIPTION
## Summary

Closes the two remaining gaps on Closes #736 (Edge SynapseKit), whose core
feature set was already shipped via an earlier batch merge:

- **CVE fix**: the `edge` extra pulled `llama-cpp-python>=0.2` back in even
  though the `llamacpp` extra was deliberately emptied because
  `llama-cpp-python`'s `diskcache` dependency has no patched release for
  CVE-2025-69872. `pip install synapsekit[edge]` silently reintroduced the
  exact dependency the other extra avoids. Removed it from `edge`, updated
  the `LlamaCppLLM` import-error message and `docs/edge.md` accordingly.
- **Benchmark acceptance criterion**: added the 200-task local-vs-cloud
  suite the issue asked for (`benchmarks/edge_local_vs_cloud_bench.py` +
  `examples/edge_task_suite.py`), with a CI-enforced harness-correctness
  gate (`benchmarks/test_edge_local_vs_cloud_bench.py`) run against stub
  LLMs.

## Not tested

The actual benchmark numbers in `docs/edge.md` are left `_pending_` — running
them for real needs a Llama-3.2-3B GGUF file and `ANTHROPIC_API_KEY`, neither
of which exist in CI or this environment. Everything else (all 4 graders, the
runner, latency/cost recording, failure handling) is covered by 17 harness
tests against stub models.

## Test plan

- [x] `pytest tests/llm/test_llamacpp.py tests/llm/test_local_providers.py` — CVE fix, no regressions
- [x] `pytest benchmarks/test_edge_local_vs_cloud_bench.py` — 17 harness tests pass
- [x] `pytest tests/llm/test_edge_runtime.py tests/cli/test_edge.py tests/embeddings/test_onnx.py tests/llm/test_mlx.py` — no regressions in shipped edge surface
- [ ] Run `benchmarks/edge_local_vs_cloud_bench.py` with a real GGUF model + API key and fill in `docs/edge.md`'s tradeoffs table before closing #736