### PR TITLE
feat: add signed portable agent marketplace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ docs/*
 !docs/architecture/
 !docs/production-checklist.md
 !docs/comparison-matrix.md
+!docs/agent-bundle-v1.md
 
 # Saved vectorstores
 *.npz

--- a/docs/agent-bundle-v1.md
+++ b/docs/agent-bundle-v1.md
@@ -1,0 +1,63 @@
+# SynapseKit Agent Bundle Format 1.0
+
+Status: open, versioned reference specification for issue #751.
+
+An agent bundle is a ZIP archive with the `.agent` extension. Consumers must
+treat every bundle as untrusted input. Verification and installation must not
+import or execute any bundled file.
+
+## Required layout
+
+```text
+example.agent
+|-- manifest.json
+|-- signature.ed25519
+|-- README.md
+`-- evals/
+    `-- ... at least one eval-suite file
+```
+
+`prompts/`, `tools/`, `memory/`, `router/`, and `style.md` are portable payload
+conventions. Memory content declares `ump/1.0` in the manifest when present.
+An optional entrypoint uses `relative/file.py:object_name` syntax, but an
+installer never loads it directly.
+
+## Manifest
+
+`manifest.json` uses UTF-8 JSON and `schema_version: "1.0"`. It records the
+agent identity, version, author, tags, optional eval score, publisher identity,
+sandbox policy, and a sorted inventory of payload files. Every inventory item
+contains a POSIX relative path, byte size, and lowercase SHA-256 digest.
+
+The signature is calculated over canonical JSON: keys sorted, no insignificant
+whitespace, ASCII JSON escapes, and no NaN values. `signature.ed25519` contains
+the 64 raw Ed25519 signature bytes. The manifest embeds the signer's key id and
+raw public key in base64.
+
+An embedded public key proves that the bundle was not modified after signing;
+it does not prove who signed it. Authenticity requires pinning the public key
+through an independent channel.
+
+## Verification and extraction
+
+Readers must reject duplicate ZIP entries, absolute or parent-relative paths,
+backslashes, drive-qualified paths, symbolic links, untracked payloads, missing
+payloads, oversized archives, invalid hashes, and invalid signatures. Readers
+must verify the complete archive before extracting it.
+
+Untrusted installs are inert and require a sandbox runner before use. Trusting
+a publisher does not make extraction execute code; it only records that the
+signature matched a caller-pinned key.
+
+## Registry
+
+The reference registry is a static directory containing `index.json`, immutable
+bundles under `packages/NAME/VERSION/`, and signed reviews under
+`reviews/NAME/VERSION/`. This layout can be served by any static HTTP server.
+Publishing requires a pinned publisher key unless the registry operator
+explicitly enables open, self-signed publication.
+
+Ranking uses the publisher's eval score as 70% of the score and the mean signed
+review quality as 30%. Review quality is the mean of its eval score and its
+one-to-five rating normalized to zero-to-one. Without publisher evals, signed
+review quality is the score; without either, the score is zero.

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -286,6 +286,26 @@ from .loaders.text import StringLoader, TextLoader
 from .loaders.tsv import TSVLoader
 from .loaders.web import WebLoader
 from .loaders.wikipedia import WikipediaLoader
+from .marketplace import (
+    AgentBundleFile,
+    AgentBundleVerification,
+    AgentManifest,
+    AgentMarketplaceError,
+    AgentSandbox,
+    FileAgentRegistry,
+    InstalledAgent,
+    InvalidAgentBundleError,
+    PublisherIdentity,
+    RankedRegistryEntry,
+    RegistryEntry,
+    SandboxRequiredError,
+    SignedAgentReview,
+    UntrustedPublisherError,
+    install_agent,
+    pack_agent,
+    unpack_agent,
+    verify_agent_bundle,
+)
 from .mcp import MCPClient, MCPServer, MCPToolAdapter
 from .memory import (
     AgentMemory,
@@ -1034,6 +1054,25 @@ __all__ = [
     "AuditMetrics",
     "VerifiableAgent",
     "AuditPIIRedactor",
+    # Portable agent marketplace
+    "AgentBundleFile",
+    "AgentBundleVerification",
+    "AgentManifest",
+    "AgentMarketplaceError",
+    "AgentSandbox",
+    "FileAgentRegistry",
+    "InstalledAgent",
+    "InvalidAgentBundleError",
+    "PublisherIdentity",
+    "RankedRegistryEntry",
+    "RegistryEntry",
+    "SandboxRequiredError",
+    "SignedAgentReview",
+    "UntrustedPublisherError",
+    "install_agent",
+    "pack_agent",
+    "unpack_agent",
+    "verify_agent_bundle",
 ]
 
 # Lazy imports for optional backends

--- a/src/synapsekit/cli/agent.py
+++ b/src/synapsekit/cli/agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 from pathlib import Path
 from typing import Any
@@ -14,7 +15,162 @@ def run_agent(args: Any) -> None:
     if subcommand == "inspect-evolution":
         _run_inspect_evolution(args)
         return
-    raise SystemExit("Missing agent subcommand. Use: inspect-evolution")
+    if subcommand == "keygen":
+        _run_keygen(args)
+        return
+    if subcommand == "pack":
+        _run_pack(args)
+        return
+    if subcommand == "verify":
+        _run_verify(args)
+        return
+    if subcommand == "unpack":
+        _run_unpack(args)
+        return
+    if subcommand == "install":
+        _run_install(args)
+        return
+    if subcommand == "publish":
+        _run_publish(args)
+        return
+    raise SystemExit(
+        "Missing agent subcommand. Use: inspect-evolution, keygen, pack, verify, unpack, "
+        "install, or publish"
+    )
+
+
+def _parse_trusted_keys(raw: list[str] | None) -> dict[str, bytes] | None:
+    if not raw:
+        return None
+    trusted: dict[str, bytes] = {}
+    for entry in raw:
+        key_id, separator, encoded = entry.partition(":")
+        if not separator or not key_id or not encoded:
+            raise SystemExit(f"invalid --trusted-key {entry!r}; expected KEY_ID:BASE64_PUBLIC_KEY")
+        try:
+            public_key = base64.b64decode(encoded, validate=True)
+        except ValueError as exc:
+            raise SystemExit(f"invalid base64 public key for {key_id!r}") from exc
+        if len(public_key) != 32:
+            raise SystemExit(f"Ed25519 public key for {key_id!r} must be 32 bytes")
+        trusted[key_id] = public_key
+    return trusted
+
+
+def _run_keygen(args: Any) -> None:
+    from ..audit.signer import Ed25519SigningProvider
+
+    private_path = Path(args.private_key)
+    if private_path.exists():
+        raise SystemExit(f"Refusing to overwrite existing private key: {private_path}")
+    provider = Ed25519SigningProvider(key_id=args.key_id)
+    private_path.parent.mkdir(parents=True, exist_ok=True)
+    private_path.write_bytes(provider.private_key_bytes())
+    private_path.chmod(0o600)
+    public_key_b64 = base64.b64encode(provider.public_key_bytes()).decode("ascii")
+    if args.public_key is not None:
+        public_path = Path(args.public_key)
+        if public_path.exists():
+            private_path.unlink()
+            raise SystemExit(f"Refusing to overwrite existing public key: {public_path}")
+        public_path.parent.mkdir(parents=True, exist_ok=True)
+        public_path.write_text(public_key_b64 + "\n", encoding="ascii")
+    print(f"Generated publisher key {provider.key_id} at {private_path}")
+    print(f"Trusted key: {provider.key_id}:{public_key_b64}")
+
+
+def _run_pack(args: Any) -> None:
+    from ..marketplace import pack_agent
+
+    private_key = Path(args.private_key).read_bytes()
+    if len(private_key) != 32:
+        raise SystemExit("Ed25519 private-key file must contain exactly 32 raw bytes")
+    output = pack_agent(
+        args.source,
+        args.output,
+        name=args.name,
+        version=args.agent_version,
+        author=args.author,
+        signing_provider=private_key,
+        description=args.description,
+        entrypoint=args.entrypoint,
+        tags=args.tags,
+        eval_score=args.eval_score,
+        key_id=args.key_id,
+    )
+    print(f"Packed signed agent bundle: {output}")
+
+
+def _run_verify(args: Any) -> None:
+    from ..marketplace import verify_agent_bundle
+
+    trusted_keys = _parse_trusted_keys(args.trusted_keys)
+    result = verify_agent_bundle(args.bundle, trusted_keys=trusted_keys)
+    accepted = result.integrity_valid and (result.trusted or not args.require_trusted)
+    if args.output_format == "json":
+        print(
+            json.dumps(
+                {
+                    "integrity_valid": result.integrity_valid,
+                    "trusted": result.trusted,
+                    "bundle_sha256": result.bundle_sha256,
+                    "publisher_key_id": (
+                        result.manifest.publisher.key_id if result.manifest is not None else None
+                    ),
+                    "errors": result.errors,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(f"Bundle: {args.bundle}")
+        print(f"Integrity: {'VALID' if result.integrity_valid else 'INVALID'}")
+        print(f"Publisher: {'TRUSTED' if result.trusted else 'UNPINNED'}")
+        for error in result.errors:
+            print(f"  - {error}")
+    raise SystemExit(0 if accepted else 1)
+
+
+def _run_unpack(args: Any) -> None:
+    from ..marketplace import unpack_agent
+
+    manifest = unpack_agent(
+        args.bundle,
+        args.output,
+        trusted_keys=_parse_trusted_keys(args.trusted_keys),
+        require_trusted=args.require_trusted,
+    )
+    print(f"Unpacked {manifest.name} {manifest.version} to {Path(args.output)}")
+
+
+def _run_install(args: Any) -> None:
+    from ..marketplace import install_agent
+
+    installed = install_agent(
+        args.bundle,
+        install_root=args.install_root,
+        trusted_keys=_parse_trusted_keys(args.trusted_keys),
+        require_trusted=args.require_trusted,
+    )
+    trust = "trusted publisher" if installed.trusted else "untrusted; sandbox required"
+    print(f"Installed {installed.manifest.name} {installed.manifest.version} at {installed.path}")
+    print(f"Execution policy: {trust}")
+
+
+def _run_publish(args: Any) -> None:
+    from ..marketplace import FileAgentRegistry
+
+    trusted_keys = _parse_trusted_keys(args.trusted_keys)
+    if args.require_trusted and args.allow_untrusted:
+        raise SystemExit("--require-trusted and --allow-untrusted cannot be used together")
+    if args.require_trusted and trusted_keys is None:
+        raise SystemExit("--require-trusted needs at least one --trusted-key")
+    entry = FileAgentRegistry(args.registry).publish(
+        args.bundle,
+        trusted_keys=trusted_keys,
+        allow_untrusted=args.allow_untrusted,
+    )
+    print(f"Published {entry.name} {entry.version} to {Path(args.registry)}")
 
 
 def _run_inspect_evolution(args: Any) -> None:

--- a/src/synapsekit/cli/main.py
+++ b/src/synapsekit/cli/main.py
@@ -190,6 +190,64 @@ def _add_agent_parser(subparsers: argparse._SubParsersAction) -> None:  # type: 
         help="Output format",
     )
 
+    keygen = agent_sub.add_parser("keygen", help="Generate an Ed25519 publisher key")
+    keygen.add_argument("private_key", help="New raw private-key file")
+    keygen.add_argument("--public-key", default=None, help="Optional base64 public-key output")
+    keygen.add_argument("--key-id", default=None, help="Optional stable publisher key id")
+
+    pack = agent_sub.add_parser("pack", help="Pack and sign a portable .agent bundle")
+    pack.add_argument("source", help="Agent source directory")
+    pack.add_argument("--output", required=True, help="Output .agent path")
+    pack.add_argument("--name", required=True, help="Portable agent name")
+    pack.add_argument("--agent-version", required=True, help="Portable agent version")
+    pack.add_argument("--author", required=True, help="Publisher or author name")
+    pack.add_argument("--private-key", required=True, help="Raw Ed25519 private-key file")
+    pack.add_argument("--key-id", default=None, help="Publisher key id")
+    pack.add_argument("--description", default="", help="Agent description")
+    pack.add_argument("--entrypoint", default=None, help="Optional bundled FILE:SYMBOL")
+    pack.add_argument("--tag", dest="tags", action="append", default=[], help="Agent tag")
+    pack.add_argument("--eval-score", type=float, default=None, help="Eval score from 0 to 1")
+
+    def add_trust_options(command: argparse.ArgumentParser) -> None:
+        command.add_argument(
+            "--trusted-key",
+            dest="trusted_keys",
+            action="append",
+            default=None,
+            metavar="KEY_ID:BASE64_PUBLIC_KEY",
+            help="Pin an independently obtained publisher key (repeatable)",
+        )
+        command.add_argument(
+            "--require-trusted",
+            action="store_true",
+            help="Reject bundles whose publisher key is not pinned",
+        )
+
+    verify = agent_sub.add_parser("verify", help="Verify hashes, signature, and publisher trust")
+    verify.add_argument("bundle", help="Path to a .agent bundle")
+    verify.add_argument("--format", dest="output_format", choices=["text", "json"], default="text")
+    add_trust_options(verify)
+
+    unpack = agent_sub.add_parser("unpack", help="Verify and unpack a .agent bundle")
+    unpack.add_argument("bundle", help="Path to a .agent bundle")
+    unpack.add_argument("output", help="New destination directory")
+    add_trust_options(unpack)
+
+    install = agent_sub.add_parser("install", help="Verify and install an inert agent bundle")
+    install.add_argument("bundle", help="Path to a .agent bundle")
+    install.add_argument("--install-root", default=None, help="Agent installation root")
+    add_trust_options(install)
+
+    publish = agent_sub.add_parser("publish", help="Publish a bundle to a file-backed registry")
+    publish.add_argument("bundle", help="Path to a .agent bundle")
+    publish.add_argument("--registry", required=True, help="Registry root directory")
+    publish.add_argument(
+        "--allow-untrusted",
+        action="store_true",
+        help="Explicitly allow self-signed publishers in this registry",
+    )
+    add_trust_options(publish)
+
 
 def _add_memory_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = subparsers.add_parser("memory", help="Manage Living Memory patches")

--- a/src/synapsekit/marketplace/__init__.py
+++ b/src/synapsekit/marketplace/__init__.py
@@ -1,0 +1,51 @@
+"""Portable, signed agent bundles and the reference marketplace registry."""
+
+from .bundle import (
+    AGENT_BUNDLE_FORMAT,
+    AGENT_BUNDLE_SCHEMA_VERSION,
+    AgentBundleFile,
+    AgentBundleVerification,
+    AgentManifest,
+    AgentSandbox,
+    InstalledAgent,
+    PublisherIdentity,
+    install_agent,
+    pack_agent,
+    unpack_agent,
+    verify_agent_bundle,
+)
+from .errors import (
+    AgentMarketplaceError,
+    InvalidAgentBundleError,
+    SandboxRequiredError,
+    UntrustedPublisherError,
+)
+from .registry import (
+    FileAgentRegistry,
+    RankedRegistryEntry,
+    RegistryEntry,
+    SignedAgentReview,
+)
+
+__all__ = [
+    "AGENT_BUNDLE_FORMAT",
+    "AGENT_BUNDLE_SCHEMA_VERSION",
+    "AgentBundleFile",
+    "AgentBundleVerification",
+    "AgentManifest",
+    "AgentMarketplaceError",
+    "AgentSandbox",
+    "FileAgentRegistry",
+    "InstalledAgent",
+    "InvalidAgentBundleError",
+    "PublisherIdentity",
+    "RankedRegistryEntry",
+    "RegistryEntry",
+    "SandboxRequiredError",
+    "SignedAgentReview",
+    "UntrustedPublisherError",
+    "install_agent",
+    "pack_agent",
+    "unpack_agent",
+    "verify_agent_bundle",
+]

--- a/src/synapsekit/marketplace/bundle.py
+++ b/src/synapsekit/marketplace/bundle.py
@@ -1,0 +1,660 @@
+"""Signed, portable ``.agent`` bundle creation and installation.
+
+The archive is deliberately inert: verification and installation never import
+or execute files from the bundle. A caller must supply a sandbox runner before
+an installed agent can be used.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import re
+import shutil
+import stat
+import tempfile
+import zipfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Protocol
+
+from ..audit.serializer import canonical_json
+from ..audit.signer import Ed25519SigningProvider, SigningProvider, verify_signature
+from .errors import InvalidAgentBundleError, SandboxRequiredError, UntrustedPublisherError
+
+AGENT_BUNDLE_FORMAT = "synapsekit-agent"
+AGENT_BUNDLE_SCHEMA_VERSION = "1.0"
+MANIFEST_PATH = "manifest.json"
+SIGNATURE_PATH = "signature.ed25519"
+INSTALL_METADATA_PATH = ".synapsekit-install.json"
+MAX_ARCHIVE_FILES = 2048
+MAX_FILE_SIZE = 64 * 1024 * 1024
+MAX_ARCHIVE_SIZE = 256 * 1024 * 1024
+
+_FIXED_ZIP_DATE_TIME = (1980, 1, 1, 0, 0, 0)
+_SAFE_COMPONENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$")
+_WINDOWS_RESERVED_NAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    *(f"COM{number}" for number in range(1, 10)),
+    *(f"LPT{number}" for number in range(1, 10)),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class AgentBundleFile:
+    """A content file authenticated by an agent manifest."""
+
+    path: str
+    sha256: str
+    size: int
+
+    def __post_init__(self) -> None:
+        _validate_archive_path(self.path)
+        if not re.fullmatch(r"[0-9a-f]{64}", self.sha256):
+            raise ValueError(f"Invalid SHA-256 digest for {self.path!r}.")
+        if self.size < 0 or self.size > MAX_FILE_SIZE:
+            raise ValueError(f"Invalid file size for {self.path!r}: {self.size}.")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"path": self.path, "sha256": self.sha256, "size": self.size}
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> AgentBundleFile:
+        return cls(path=str(value["path"]), sha256=str(value["sha256"]), size=int(value["size"]))
+
+
+@dataclass(frozen=True, slots=True)
+class PublisherIdentity:
+    """Public identity embedded in a signed agent bundle."""
+
+    algorithm: str
+    key_id: str
+    public_key_b64: str
+
+    def __post_init__(self) -> None:
+        if self.algorithm != "ed25519":
+            raise ValueError(f"Unsupported publisher algorithm: {self.algorithm!r}.")
+        if not self.key_id:
+            raise ValueError("Publisher key_id must not be empty.")
+        try:
+            public_key = base64.b64decode(self.public_key_b64, validate=True)
+        except ValueError as exc:
+            raise ValueError("Publisher public key is not valid base64.") from exc
+        if len(public_key) != 32:
+            raise ValueError("Ed25519 public keys must contain exactly 32 bytes.")
+
+    @property
+    def public_key_bytes(self) -> bytes:
+        return base64.b64decode(self.public_key_b64, validate=True)
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "algorithm": self.algorithm,
+            "key_id": self.key_id,
+            "public_key_b64": self.public_key_b64,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> PublisherIdentity:
+        return cls(
+            algorithm=str(value["algorithm"]),
+            key_id=str(value["key_id"]),
+            public_key_b64=str(value["public_key_b64"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AgentManifest:
+    """Versioned metadata and content inventory for an agent bundle."""
+
+    name: str
+    version: str
+    author: str
+    publisher: PublisherIdentity
+    files: tuple[AgentBundleFile, ...]
+    description: str = ""
+    entrypoint: str | None = None
+    tags: tuple[str, ...] = ()
+    eval_score: float | None = None
+    memory_format: str | None = None
+    router_path: str | None = None
+    format: str = AGENT_BUNDLE_FORMAT
+    schema_version: str = AGENT_BUNDLE_SCHEMA_VERSION
+    sandbox_required_for_untrusted: bool = True
+
+    def __post_init__(self) -> None:
+        _validate_component(self.name, "Agent name")
+        _validate_component(self.version, "Agent version")
+        if not self.author.strip():
+            raise ValueError("Agent author must not be empty.")
+        if self.format != AGENT_BUNDLE_FORMAT:
+            raise ValueError(f"Unsupported agent bundle format: {self.format!r}.")
+        if self.schema_version != AGENT_BUNDLE_SCHEMA_VERSION:
+            raise ValueError(f"Unsupported agent bundle schema: {self.schema_version!r}.")
+        paths = [item.path for item in self.files]
+        if len(paths) != len(set(paths)):
+            raise ValueError("Agent manifest contains duplicate file paths.")
+        if len(paths) != len({path.casefold() for path in paths}):
+            raise ValueError("Agent manifest contains case-insensitive path collisions.")
+        if MANIFEST_PATH in paths or SIGNATURE_PATH in paths:
+            raise ValueError("Control files must not appear in the manifest file inventory.")
+        if "README.md" not in paths:
+            raise ValueError("Agent bundles must include README.md.")
+        if not any(path.startswith("evals/") for path in paths):
+            raise ValueError("Agent bundles must include at least one file under evals/.")
+        if self.entrypoint is not None:
+            entry_file, separator, symbol = self.entrypoint.partition(":")
+            _validate_archive_path(entry_file)
+            if (
+                not separator
+                or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_.]*", symbol)
+                or entry_file not in paths
+            ):
+                raise ValueError("Entrypoint must use FILE:SYMBOL and reference a bundled file.")
+        if self.eval_score is not None and not 0.0 <= self.eval_score <= 1.0:
+            raise ValueError("eval_score must be between 0.0 and 1.0.")
+        if self.router_path is not None and not self.router_path.startswith("router/"):
+            raise ValueError("router_path must be located under router/.")
+        if any(not isinstance(tag, str) or not tag.strip() for tag in self.tags):
+            raise ValueError("Agent tags must be non-empty strings.")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "format": self.format,
+            "schema_version": self.schema_version,
+            "name": self.name,
+            "version": self.version,
+            "author": self.author,
+            "description": self.description,
+            "entrypoint": self.entrypoint,
+            "tags": list(self.tags),
+            "evals": {"path": "evals/", "score": self.eval_score},
+            "protocols": {"memory": self.memory_format},
+            "router": {"path": self.router_path},
+            "sandbox": {"required_for_untrusted": self.sandbox_required_for_untrusted},
+            "publisher": self.publisher.to_dict(),
+            "files": [item.to_dict() for item in self.files],
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> AgentManifest:
+        publisher = _mapping(value.get("publisher"), "publisher")
+        evals = _mapping(value.get("evals", {}), "evals")
+        protocols = _mapping(value.get("protocols", {}), "protocols")
+        router = _mapping(value.get("router", {}), "router")
+        sandbox = _mapping(value.get("sandbox", {}), "sandbox")
+        raw_files = value.get("files")
+        if not isinstance(raw_files, list):
+            raise ValueError("Manifest files must be a list.")
+        files = tuple(AgentBundleFile.from_dict(_mapping(item, "file entry")) for item in raw_files)
+        raw_tags = value.get("tags", [])
+        if not isinstance(raw_tags, list) or not all(isinstance(tag, str) for tag in raw_tags):
+            raise ValueError("Manifest tags must be a list of strings.")
+        raw_score = evals.get("score")
+        raw_entrypoint = value.get("entrypoint")
+        raw_memory = protocols.get("memory")
+        raw_router = router.get("path")
+        sandbox_required = sandbox.get("required_for_untrusted", True)
+        if not isinstance(sandbox_required, bool):
+            raise ValueError("sandbox.required_for_untrusted must be a boolean.")
+        if not sandbox_required:
+            raise ValueError("Agent bundle schema 1.0 requires sandboxing for untrusted agents.")
+        return cls(
+            format=str(value.get("format", "")),
+            schema_version=str(value.get("schema_version", "")),
+            name=str(value["name"]),
+            version=str(value["version"]),
+            author=str(value["author"]),
+            description=str(value.get("description", "")),
+            entrypoint=None if raw_entrypoint is None else str(raw_entrypoint),
+            tags=tuple(raw_tags),
+            eval_score=None if raw_score is None else float(raw_score),
+            memory_format=None if raw_memory is None else str(raw_memory),
+            router_path=None if raw_router is None else str(raw_router),
+            sandbox_required_for_untrusted=sandbox_required,
+            publisher=PublisherIdentity.from_dict(publisher),
+            files=files,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AgentBundleVerification:
+    """Integrity and trust result for a bundle verification."""
+
+    integrity_valid: bool
+    trusted: bool
+    errors: tuple[str, ...]
+    manifest: AgentManifest | None = None
+    bundle_sha256: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        """Whether the archive is structurally valid and untampered."""
+        return self.integrity_valid
+
+    def require_valid(self) -> AgentManifest:
+        if not self.integrity_valid or self.manifest is None:
+            details = "; ".join(self.errors) or "unknown verification error"
+            raise InvalidAgentBundleError(details)
+        return self.manifest
+
+    def require_trusted(self) -> AgentManifest:
+        manifest = self.require_valid()
+        if not self.trusted:
+            raise UntrustedPublisherError(
+                f"Publisher key {manifest.publisher.key_id!r} was not independently trusted."
+            )
+        return manifest
+
+
+class AgentSandbox(Protocol):
+    """Execution boundary required for installed agent bundles."""
+
+    async def run(
+        self,
+        agent_path: Path,
+        manifest: AgentManifest,
+        prompt: str,
+        **kwargs: Any,
+    ) -> Any: ...
+
+
+@dataclass(frozen=True, slots=True)
+class InstalledAgent:
+    """An installed, inert agent bundle that can be bound to a sandbox."""
+
+    path: Path
+    manifest: AgentManifest
+    trusted: bool
+    bundle_sha256: str
+
+    @property
+    def sandbox_required(self) -> bool:
+        return not self.trusted and self.manifest.sandbox_required_for_untrusted
+
+    async def run(
+        self,
+        prompt: str,
+        *,
+        sandbox: AgentSandbox | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        if sandbox is None:
+            raise SandboxRequiredError(
+                "Installed agent bundles are inert. Supply an AgentSandbox to execute this agent."
+            )
+        return await sandbox.run(self.path, self.manifest, prompt, **kwargs)
+
+
+def pack_agent(
+    source: str | Path,
+    output: str | Path,
+    *,
+    name: str,
+    version: str,
+    author: str,
+    signing_provider: SigningProvider | bytes,
+    description: str = "",
+    entrypoint: str | None = None,
+    tags: tuple[str, ...] | list[str] = (),
+    eval_score: float | None = None,
+    key_id: str | None = None,
+) -> Path:
+    """Pack and sign a source directory as a deterministic ``.agent`` archive."""
+    source_path = Path(source).resolve()
+    output_path = Path(output).resolve()
+    if not source_path.is_dir():
+        raise FileNotFoundError(f"Agent source directory does not exist: {source_path}")
+    if output_path.suffix != ".agent":
+        raise ValueError("Agent bundle output must use the .agent extension.")
+    if _is_relative_to(output_path, source_path):
+        raise ValueError("Agent bundle output must be outside the source directory.")
+
+    provider = (
+        Ed25519SigningProvider(signing_provider, key_id=key_id)
+        if isinstance(signing_provider, bytes)
+        else signing_provider
+    )
+    if provider.algorithm != "ed25519":
+        raise ValueError("Agent bundle schema 1.0 supports Ed25519 signing only.")
+
+    payloads = _collect_source_files(source_path)
+    inventory = tuple(
+        AgentBundleFile(path=path, sha256=_sha256(data), size=len(data))
+        for path, data in payloads.items()
+    )
+    paths = set(payloads)
+    manifest = AgentManifest(
+        name=name,
+        version=version,
+        author=author,
+        description=description,
+        entrypoint=entrypoint,
+        tags=tuple(tags),
+        eval_score=eval_score,
+        memory_format="ump/1.0" if any(path.startswith("memory/") for path in paths) else None,
+        router_path="router/" if any(path.startswith("router/") for path in paths) else None,
+        publisher=PublisherIdentity(
+            algorithm=provider.algorithm,
+            key_id=provider.key_id,
+            public_key_b64=base64.b64encode(provider.public_key_bytes()).decode("ascii"),
+        ),
+        files=inventory,
+    )
+    manifest_bytes = canonical_json(manifest.to_dict())
+    signature = provider.sign(manifest_bytes)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(output_path, "w") as archive:
+        _write_zip_entry(archive, MANIFEST_PATH, _pretty_json(manifest.to_dict()))
+        _write_zip_entry(archive, SIGNATURE_PATH, signature)
+        for path, data in payloads.items():
+            _write_zip_entry(archive, path, data)
+    return output_path
+
+
+def verify_agent_bundle(
+    bundle: str | Path,
+    *,
+    trusted_keys: Mapping[str, bytes] | None = None,
+) -> AgentBundleVerification:
+    """Verify archive safety, content hashes, signature, and optional trust pin."""
+    try:
+        data = _read_bundle_bytes(Path(bundle))
+    except (InvalidAgentBundleError, OSError) as exc:
+        return AgentBundleVerification(False, False, (str(exc),))
+    return _verify_agent_bundle_data(data, trusted_keys=trusted_keys)
+
+
+def _verify_agent_bundle_data(
+    data: bytes,
+    *,
+    trusted_keys: Mapping[str, bytes] | None = None,
+) -> AgentBundleVerification:
+    digest = _sha256(data)
+    try:
+        manifest, signature = _read_verified_archive(data)
+        embedded_key = manifest.publisher.public_key_bytes
+        if not verify_signature(
+            algorithm=manifest.publisher.algorithm,
+            public_key_bytes=embedded_key,
+            data=canonical_json(manifest.to_dict()),
+            signature=signature,
+        ):
+            raise InvalidAgentBundleError("Manifest signature is invalid.")
+
+        trusted = False
+        if trusted_keys is not None and manifest.publisher.key_id in trusted_keys:
+            pinned_key = trusted_keys[manifest.publisher.key_id]
+            if pinned_key != embedded_key:
+                raise InvalidAgentBundleError(
+                    f"Pinned key for {manifest.publisher.key_id!r} does not match the bundle."
+                )
+            trusted = verify_signature(
+                algorithm=manifest.publisher.algorithm,
+                public_key_bytes=pinned_key,
+                data=canonical_json(manifest.to_dict()),
+                signature=signature,
+            )
+        return AgentBundleVerification(True, trusted, (), manifest, digest)
+    except (
+        InvalidAgentBundleError,
+        OSError,
+        ValueError,
+        KeyError,
+        json.JSONDecodeError,
+        zipfile.BadZipFile,
+    ) as exc:
+        return AgentBundleVerification(False, False, (str(exc),), bundle_sha256=digest)
+
+
+def unpack_agent(
+    bundle: str | Path,
+    output: str | Path,
+    *,
+    trusted_keys: Mapping[str, bytes] | None = None,
+    require_trusted: bool = False,
+) -> AgentManifest:
+    """Verify and atomically unpack a bundle without executing its contents."""
+    data = _read_bundle_bytes(Path(bundle))
+    verification = _verify_agent_bundle_data(data, trusted_keys=trusted_keys)
+    manifest = verification.require_trusted() if require_trusted else verification.require_valid()
+    _extract_archive(data, Path(output))
+    return manifest
+
+
+def install_agent(
+    bundle: str | Path,
+    *,
+    install_root: str | Path | None = None,
+    trusted_keys: Mapping[str, bytes] | None = None,
+    require_trusted: bool = False,
+) -> InstalledAgent:
+    """Verify and install a bundle under ``NAME/VERSION`` without executing it."""
+    data = _read_bundle_bytes(Path(bundle))
+    verification = _verify_agent_bundle_data(data, trusted_keys=trusted_keys)
+    manifest = verification.require_trusted() if require_trusted else verification.require_valid()
+    assert verification.bundle_sha256 is not None
+    root = (
+        Path(install_root) if install_root is not None else Path.home() / ".synapsekit" / "agents"
+    )
+    destination = root / manifest.name / manifest.version
+    metadata = {
+        "bundle_sha256": verification.bundle_sha256,
+        "publisher_key_id": manifest.publisher.key_id,
+        "trusted": verification.trusted,
+        "sandbox_required": not verification.trusted and manifest.sandbox_required_for_untrusted,
+    }
+
+    if destination.exists():
+        metadata_path = destination / INSTALL_METADATA_PATH
+        if metadata_path.is_file():
+            installed_metadata = _load_json(metadata_path.read_bytes())
+            if installed_metadata.get("bundle_sha256") == verification.bundle_sha256:
+                return InstalledAgent(
+                    destination,
+                    manifest,
+                    verification.trusted,
+                    verification.bundle_sha256,
+                )
+        raise FileExistsError(f"A different agent is already installed at {destination}.")
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f".{manifest.name}-", dir=destination.parent))
+    try:
+        _extract_archive_contents(data, staging)
+        (staging / INSTALL_METADATA_PATH).write_bytes(_pretty_json(metadata))
+        staging.replace(destination)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return InstalledAgent(
+        destination,
+        manifest,
+        verification.trusted,
+        verification.bundle_sha256,
+    )
+
+
+def _read_verified_archive(data: bytes) -> tuple[AgentManifest, bytes]:
+    with zipfile.ZipFile(io.BytesIO(data)) as archive:
+        infos = archive.infolist()
+        if len(infos) > MAX_ARCHIVE_FILES + 2:
+            raise InvalidAgentBundleError("Agent bundle contains too many files.")
+        names: set[str] = set()
+        casefolded_names: set[str] = set()
+        total_size = 0
+        for info in infos:
+            name = _validate_archive_path(info.filename)
+            if name in names:
+                raise InvalidAgentBundleError(f"Duplicate archive entry: {name}")
+            names.add(name)
+            casefolded_name = name.casefold()
+            if casefolded_name in casefolded_names:
+                raise InvalidAgentBundleError(f"Case-insensitive archive path collision: {name}")
+            casefolded_names.add(casefolded_name)
+            if info.is_dir():
+                raise InvalidAgentBundleError(f"Explicit directory entries are not allowed: {name}")
+            if stat.S_IFMT(info.external_attr >> 16) == stat.S_IFLNK:
+                raise InvalidAgentBundleError(f"Symbolic links are not allowed: {name}")
+            if info.file_size > MAX_FILE_SIZE:
+                raise InvalidAgentBundleError(f"Archive entry exceeds size limit: {name}")
+            total_size += info.file_size
+            if total_size > MAX_ARCHIVE_SIZE:
+                raise InvalidAgentBundleError("Agent bundle exceeds the total size limit.")
+        if MANIFEST_PATH not in names or SIGNATURE_PATH not in names:
+            raise InvalidAgentBundleError(
+                "Agent bundle is missing manifest.json or signature.ed25519."
+            )
+
+        manifest = AgentManifest.from_dict(_load_json(archive.read(MANIFEST_PATH)))
+        expected = {item.path: item for item in manifest.files}
+        actual = names - {MANIFEST_PATH, SIGNATURE_PATH}
+        if actual != set(expected):
+            missing = sorted(set(expected) - actual)
+            extra = sorted(actual - set(expected))
+            raise InvalidAgentBundleError(
+                f"Manifest inventory mismatch (missing={missing}, extra={extra})."
+            )
+        for name, item in expected.items():
+            data = archive.read(name)
+            if len(data) != item.size or _sha256(data) != item.sha256:
+                raise InvalidAgentBundleError(f"Content hash mismatch for {name!r}.")
+        signature = archive.read(SIGNATURE_PATH)
+        if len(signature) != 64:
+            raise InvalidAgentBundleError("Ed25519 signature must contain exactly 64 bytes.")
+        return manifest, signature
+
+
+def _collect_source_files(source: Path) -> dict[str, bytes]:
+    payloads: dict[str, bytes] = {}
+    casefolded_paths: set[str] = set()
+    for path in sorted(source.rglob("*"), key=lambda item: item.as_posix()):
+        if path.is_symlink():
+            raise InvalidAgentBundleError(f"Symbolic links are not allowed: {path}")
+        if not path.is_file():
+            continue
+        relative = path.relative_to(source).as_posix()
+        _validate_archive_path(relative)
+        reserved_paths = {MANIFEST_PATH, SIGNATURE_PATH, INSTALL_METADATA_PATH}
+        if relative.casefold() in {item.casefold() for item in reserved_paths}:
+            raise InvalidAgentBundleError(f"Reserved bundle path in source: {relative}")
+        casefolded = relative.casefold()
+        if casefolded in casefolded_paths:
+            raise InvalidAgentBundleError(f"Case-insensitive source path collision: {relative}")
+        casefolded_paths.add(casefolded)
+        data = path.read_bytes()
+        if len(data) > MAX_FILE_SIZE:
+            raise InvalidAgentBundleError(f"Source file exceeds size limit: {relative}")
+        payloads[relative] = data
+    if len(payloads) > MAX_ARCHIVE_FILES:
+        raise InvalidAgentBundleError("Agent source contains too many files.")
+    if sum(len(data) for data in payloads.values()) > MAX_ARCHIVE_SIZE:
+        raise InvalidAgentBundleError("Agent source exceeds the total size limit.")
+    return payloads
+
+
+def _extract_archive(bundle: bytes, output: Path) -> None:
+    if output.exists():
+        raise FileExistsError(f"Unpack destination already exists: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f".{output.name}-", dir=output.parent))
+    try:
+        _extract_archive_contents(bundle, staging)
+        staging.replace(output)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+
+def _extract_archive_contents(bundle: bytes, output: Path) -> None:
+    with zipfile.ZipFile(io.BytesIO(bundle)) as archive:
+        for info in archive.infolist():
+            relative = PurePosixPath(_validate_archive_path(info.filename))
+            destination = output.joinpath(*relative.parts)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with archive.open(info) as source, destination.open("wb") as target:
+                shutil.copyfileobj(source, target)
+
+
+def _write_zip_entry(archive: zipfile.ZipFile, name: str, data: bytes) -> None:
+    info = zipfile.ZipInfo(name, date_time=_FIXED_ZIP_DATE_TIME)
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.external_attr = 0o100644 << 16
+    archive.writestr(info, data)
+
+
+def _load_json(data: bytes) -> dict[str, Any]:
+    def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"Duplicate JSON key: {key!r}.")
+            result[key] = value
+        return result
+
+    value = json.loads(data.decode("utf-8"), object_pairs_hook=reject_duplicates)
+    if not isinstance(value, dict):
+        raise ValueError("Expected a JSON object.")
+    return value
+
+
+def _mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"Manifest {label} must be an object.")
+    return value
+
+
+def _validate_component(value: str, label: str) -> None:
+    reserved_name = value.split(".", 1)[0].upper()
+    if (
+        not _SAFE_COMPONENT.fullmatch(value)
+        or value in {".", ".."}
+        or value.endswith((".", " "))
+        or reserved_name in _WINDOWS_RESERVED_NAMES
+    ):
+        raise ValueError(f"{label} contains unsafe characters: {value!r}.")
+
+
+def _validate_archive_path(value: str) -> str:
+    if not value or "\\" in value or "\x00" in value:
+        raise InvalidAgentBundleError(f"Unsafe archive path: {value!r}")
+    raw_parts = value.split("/")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in raw_parts):
+        raise InvalidAgentBundleError(f"Unsafe archive path: {value!r}")
+    for part in raw_parts:
+        reserved_name = part.split(".", 1)[0].upper()
+        if ":" in part or part.endswith((".", " ")) or reserved_name in _WINDOWS_RESERVED_NAMES:
+            raise InvalidAgentBundleError(f"Unsafe archive path: {value!r}")
+    return path.as_posix()
+
+
+def _pretty_json(value: Mapping[str, Any]) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True) + "\n").encode("utf-8")
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _read_bundle_bytes(path: Path) -> bytes:
+    if not path.is_file():
+        raise InvalidAgentBundleError(f"Agent bundle does not exist: {path}")
+    if path.stat().st_size > MAX_ARCHIVE_SIZE + 4 * 1024 * 1024:
+        raise InvalidAgentBundleError("Agent bundle exceeds the compressed size limit.")
+    return path.read_bytes()
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True

--- a/src/synapsekit/marketplace/errors.py
+++ b/src/synapsekit/marketplace/errors.py
@@ -1,0 +1,19 @@
+"""Exceptions raised by the agent marketplace package."""
+
+from __future__ import annotations
+
+
+class AgentMarketplaceError(Exception):
+    """Base class for agent bundle and registry errors."""
+
+
+class InvalidAgentBundleError(AgentMarketplaceError):
+    """Raised when a bundle is malformed, incomplete, or tampered with."""
+
+
+class UntrustedPublisherError(AgentMarketplaceError):
+    """Raised when an operation requires an independently trusted signer."""
+
+
+class SandboxRequiredError(AgentMarketplaceError):
+    """Raised when an installed agent has no sandbox runner attached."""

--- a/src/synapsekit/marketplace/registry.py
+++ b/src/synapsekit/marketplace/registry.py
@@ -1,0 +1,427 @@
+"""File-backed reference registry for signed agent bundles."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+import shutil
+import threading
+from builtins import list as builtin_list
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import fmean
+from typing import Any
+from uuid import uuid4
+
+from ..audit.serializer import canonical_json
+from ..audit.signer import SigningProvider, verify_signature
+from .bundle import PublisherIdentity, verify_agent_bundle
+from .errors import InvalidAgentBundleError, UntrustedPublisherError
+
+REGISTRY_SCHEMA_VERSION = "1.0"
+REVIEW_SCHEMA_VERSION = "1.0"
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryEntry:
+    """Published agent version recorded in the registry index."""
+
+    name: str
+    version: str
+    author: str
+    description: str
+    tags: tuple[str, ...]
+    publisher_key_id: str
+    bundle_sha256: str
+    bundle_path: str
+    published_at: str
+    eval_score: float | None = None
+
+    def __post_init__(self) -> None:
+        _validate_registry_component(self.name, "agent name")
+        _validate_registry_component(self.version, "agent version")
+        if not re.fullmatch(r"[0-9a-f]{64}", self.bundle_sha256):
+            raise ValueError("Registry bundle_sha256 must be a lowercase SHA-256 digest.")
+        expected_path = (
+            Path("packages") / self.name / self.version / f"{self.name}-{self.version}.agent"
+        ).as_posix()
+        if self.bundle_path != expected_path:
+            raise ValueError("Registry entry bundle_path does not match its name and version.")
+        if self.eval_score is not None and not 0.0 <= self.eval_score <= 1.0:
+            raise ValueError("Registry eval_score must be between 0.0 and 1.0.")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "author": self.author,
+            "description": self.description,
+            "tags": list(self.tags),
+            "publisher_key_id": self.publisher_key_id,
+            "bundle_sha256": self.bundle_sha256,
+            "bundle_path": self.bundle_path,
+            "published_at": self.published_at,
+            "eval_score": self.eval_score,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> RegistryEntry:
+        raw_tags = value.get("tags", [])
+        if not isinstance(raw_tags, list) or not all(isinstance(tag, str) for tag in raw_tags):
+            raise ValueError("Registry entry tags must be a list of strings.")
+        raw_score = value.get("eval_score")
+        return cls(
+            name=str(value["name"]),
+            version=str(value["version"]),
+            author=str(value["author"]),
+            description=str(value.get("description", "")),
+            tags=tuple(raw_tags),
+            publisher_key_id=str(value["publisher_key_id"]),
+            bundle_sha256=str(value["bundle_sha256"]),
+            bundle_path=str(value["bundle_path"]),
+            published_at=str(value["published_at"]),
+            eval_score=None if raw_score is None else float(raw_score),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SignedAgentReview:
+    """A cryptographically signed agent rating and eval observation."""
+
+    agent_name: str
+    agent_version: str
+    reviewer: str
+    rating: int
+    eval_score: float
+    comment: str
+    signed_at: str
+    reviewer_identity: PublisherIdentity
+    signature_b64: str
+    schema_version: str = REVIEW_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != REVIEW_SCHEMA_VERSION:
+            raise ValueError(f"Unsupported review schema: {self.schema_version!r}.")
+        if not self.agent_name or not self.agent_version or not self.reviewer.strip():
+            raise ValueError("Review agent name, version, and reviewer are required.")
+        _validate_registry_component(self.agent_name, "review agent name")
+        _validate_registry_component(self.agent_version, "review agent version")
+        if not 1 <= self.rating <= 5:
+            raise ValueError("Review rating must be between 1 and 5.")
+        if not 0.0 <= self.eval_score <= 1.0:
+            raise ValueError("Review eval_score must be between 0.0 and 1.0.")
+        try:
+            signature = base64.b64decode(self.signature_b64, validate=True)
+        except ValueError as exc:
+            raise ValueError("Review signature is not valid base64.") from exc
+        if len(signature) != 64:
+            raise ValueError("Ed25519 review signatures must contain exactly 64 bytes.")
+
+    @classmethod
+    def sign(
+        cls,
+        *,
+        agent_name: str,
+        agent_version: str,
+        reviewer: str,
+        rating: int,
+        eval_score: float,
+        signing_provider: SigningProvider,
+        comment: str = "",
+        signed_at: str | None = None,
+    ) -> SignedAgentReview:
+        if signing_provider.algorithm != "ed25519":
+            raise ValueError("Review schema 1.0 supports Ed25519 signing only.")
+        identity = PublisherIdentity(
+            algorithm=signing_provider.algorithm,
+            key_id=signing_provider.key_id,
+            public_key_b64=base64.b64encode(signing_provider.public_key_bytes()).decode("ascii"),
+        )
+        timestamp = signed_at or datetime.now(timezone.utc).isoformat()
+        unsigned = {
+            "schema_version": REVIEW_SCHEMA_VERSION,
+            "agent_name": agent_name,
+            "agent_version": agent_version,
+            "reviewer": reviewer,
+            "rating": rating,
+            "eval_score": eval_score,
+            "comment": comment,
+            "signed_at": timestamp,
+            "reviewer_identity": identity.to_dict(),
+        }
+        signature = signing_provider.sign(canonical_json(unsigned))
+        return cls(
+            agent_name=agent_name,
+            agent_version=agent_version,
+            reviewer=reviewer,
+            rating=rating,
+            eval_score=eval_score,
+            comment=comment,
+            signed_at=timestamp,
+            reviewer_identity=identity,
+            signature_b64=base64.b64encode(signature).decode("ascii"),
+        )
+
+    def unsigned_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "agent_name": self.agent_name,
+            "agent_version": self.agent_version,
+            "reviewer": self.reviewer,
+            "rating": self.rating,
+            "eval_score": self.eval_score,
+            "comment": self.comment,
+            "signed_at": self.signed_at,
+            "reviewer_identity": self.reviewer_identity.to_dict(),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {**self.unsigned_dict(), "signature_b64": self.signature_b64}
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> SignedAgentReview:
+        identity = value.get("reviewer_identity")
+        if not isinstance(identity, dict):
+            raise ValueError("Review reviewer_identity must be an object.")
+        return cls(
+            schema_version=str(value.get("schema_version", "")),
+            agent_name=str(value["agent_name"]),
+            agent_version=str(value["agent_version"]),
+            reviewer=str(value["reviewer"]),
+            rating=int(value["rating"]),
+            eval_score=float(value["eval_score"]),
+            comment=str(value.get("comment", "")),
+            signed_at=str(value["signed_at"]),
+            reviewer_identity=PublisherIdentity.from_dict(identity),
+            signature_b64=str(value["signature_b64"]),
+        )
+
+    def verify(self, trusted_keys: Mapping[str, bytes] | None = None) -> tuple[bool, bool]:
+        public_key = self.reviewer_identity.public_key_bytes
+        signature = base64.b64decode(self.signature_b64, validate=True)
+        integrity_valid = verify_signature(
+            algorithm=self.reviewer_identity.algorithm,
+            public_key_bytes=public_key,
+            data=canonical_json(self.unsigned_dict()),
+            signature=signature,
+        )
+        if not integrity_valid or trusted_keys is None:
+            return integrity_valid, False
+        pinned_key = trusted_keys.get(self.reviewer_identity.key_id)
+        return integrity_valid, pinned_key == public_key
+
+
+@dataclass(frozen=True, slots=True)
+class RankedRegistryEntry:
+    """A registry entry plus its deterministic quality ranking."""
+
+    entry: RegistryEntry
+    score: float
+    review_count: int
+
+
+class FileAgentRegistry:
+    """Self-hostable registry backed by a directory and static JSON index."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.index_path = self.root / "index.json"
+        self._lock = threading.RLock()
+
+    def publish(
+        self,
+        bundle: str | Path,
+        *,
+        trusted_keys: Mapping[str, bytes] | None = None,
+        allow_untrusted: bool = False,
+    ) -> RegistryEntry:
+        """Verify and publish one immutable agent version."""
+        verification = verify_agent_bundle(bundle, trusted_keys=trusted_keys)
+        manifest = verification.require_valid()
+        if not verification.trusted and not allow_untrusted:
+            raise UntrustedPublisherError(
+                "Registry publishing requires a pinned publisher key. "
+                "Use allow_untrusted=True only for an intentionally open registry."
+            )
+        assert verification.bundle_sha256 is not None
+        relative = (
+            Path("packages")
+            / manifest.name
+            / manifest.version
+            / (f"{manifest.name}-{manifest.version}.agent")
+        )
+        destination = self.root / relative
+        entry = RegistryEntry(
+            name=manifest.name,
+            version=manifest.version,
+            author=manifest.author,
+            description=manifest.description,
+            tags=manifest.tags,
+            publisher_key_id=manifest.publisher.key_id,
+            bundle_sha256=verification.bundle_sha256,
+            bundle_path=relative.as_posix(),
+            published_at=datetime.now(timezone.utc).isoformat(),
+            eval_score=manifest.eval_score,
+        )
+
+        with self._lock:
+            existing = self.get(manifest.name, manifest.version)
+            if existing is not None:
+                if existing.bundle_sha256 == entry.bundle_sha256:
+                    return existing
+                raise FileExistsError(
+                    f"Registry already contains {manifest.name} {manifest.version}."
+                )
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            temporary = destination.with_name(f".{destination.name}.{uuid4().hex}.tmp")
+            try:
+                shutil.copyfile(bundle, temporary)
+                copied = verify_agent_bundle(temporary, trusted_keys=trusted_keys)
+                copied.require_valid()
+                if copied.bundle_sha256 != entry.bundle_sha256:
+                    raise InvalidAgentBundleError(
+                        "Bundle changed between verification and registry publication."
+                    )
+                if verification.trusted and not copied.trusted:
+                    raise InvalidAgentBundleError("Copied bundle lost its publisher trust anchor.")
+                temporary.replace(destination)
+                entries = self.list()
+                entries.append(entry)
+                self._write_index(entries)
+            except Exception:
+                temporary.unlink(missing_ok=True)
+                raise
+        return entry
+
+    def get(self, name: str, version: str) -> RegistryEntry | None:
+        for entry in self.list():
+            if entry.name == name and entry.version == version:
+                return entry
+        return None
+
+    def list(self) -> builtin_list[RegistryEntry]:
+        if not self.index_path.exists():
+            return []
+        data = json.loads(self.index_path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict) or data.get("schema_version") != REGISTRY_SCHEMA_VERSION:
+            raise InvalidAgentBundleError("Registry index has an unsupported schema.")
+        raw_entries = data.get("agents")
+        if not isinstance(raw_entries, list):
+            raise InvalidAgentBundleError("Registry index agents must be a list.")
+        return sorted(
+            [RegistryEntry.from_dict(_as_mapping(item, "registry entry")) for item in raw_entries],
+            key=lambda item: (item.name, item.version),
+        )
+
+    def bundle_path(self, name: str, version: str) -> Path:
+        entry = self.get(name, version)
+        if entry is None:
+            raise KeyError(f"Unknown registry agent: {name} {version}")
+        path = (self.root / entry.bundle_path).resolve()
+        try:
+            path.relative_to(self.root.resolve())
+        except ValueError as exc:
+            raise InvalidAgentBundleError("Registry index contains an unsafe bundle path.") from exc
+        return path
+
+    def add_review(
+        self,
+        review: SignedAgentReview,
+        *,
+        trusted_keys: Mapping[str, bytes] | None = None,
+        allow_untrusted: bool = False,
+    ) -> Path:
+        if self.get(review.agent_name, review.agent_version) is None:
+            raise KeyError(
+                f"Cannot review unpublished agent {review.agent_name} {review.agent_version}."
+            )
+        integrity_valid, trusted = review.verify(trusted_keys)
+        if not integrity_valid:
+            raise InvalidAgentBundleError("Review signature is invalid.")
+        if not trusted and not allow_untrusted:
+            raise UntrustedPublisherError("Registry reviews require a pinned reviewer key.")
+        data = _pretty_json(review.to_dict())
+        review_id = hashlib.sha256(canonical_json(review.to_dict())).hexdigest()
+        path = (
+            self.root / "reviews" / review.agent_name / review.agent_version / f"{review_id}.json"
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.exists() and path.read_bytes() != data:
+            raise FileExistsError(f"Review id collision at {path}.")
+        path.write_bytes(data)
+        return path
+
+    def reviews(self, name: str, version: str) -> builtin_list[SignedAgentReview]:
+        _validate_registry_component(name, "agent name")
+        _validate_registry_component(version, "agent version")
+        directory = self.root / "reviews" / name / version
+        if not directory.exists():
+            return []
+        result: builtin_list[SignedAgentReview] = []
+        for path in sorted(directory.glob("*.json")):
+            data = json.loads(path.read_text(encoding="utf-8"))
+            review = SignedAgentReview.from_dict(_as_mapping(data, "review"))
+            integrity_valid, _ = review.verify()
+            if not integrity_valid:
+                raise InvalidAgentBundleError(f"Stored review signature is invalid: {path.name}")
+            result.append(review)
+        return result
+
+    def ranked(self) -> builtin_list[RankedRegistryEntry]:
+        ranked: builtin_list[RankedRegistryEntry] = []
+        for entry in self.list():
+            reviews = self.reviews(entry.name, entry.version)
+            review_scores = [(review.eval_score + review.rating / 5.0) / 2.0 for review in reviews]
+            if entry.eval_score is None:
+                score = fmean(review_scores) if review_scores else 0.0
+            elif review_scores:
+                score = 0.7 * entry.eval_score + 0.3 * fmean(review_scores)
+            else:
+                score = entry.eval_score
+            ranked.append(RankedRegistryEntry(entry, round(score, 12), len(reviews)))
+        return sorted(ranked, key=lambda item: (-item.score, item.entry.name, item.entry.version))
+
+    def _write_index(self, entries: builtin_list[RegistryEntry]) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        data = {
+            "schema_version": REGISTRY_SCHEMA_VERSION,
+            "agents": [
+                entry.to_dict()
+                for entry in sorted(entries, key=lambda item: (item.name, item.version))
+            ],
+        }
+        temporary = self.index_path.with_name(f".{self.index_path.name}.{uuid4().hex}.tmp")
+        try:
+            temporary.write_bytes(_pretty_json(data))
+            temporary.replace(self.index_path)
+        except Exception:
+            temporary.unlink(missing_ok=True)
+            raise
+
+
+def _as_mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, dict):
+        raise InvalidAgentBundleError(f"Expected {label} to be a JSON object.")
+    return value
+
+
+def _pretty_json(value: Mapping[str, Any]) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True) + "\n").encode("utf-8")
+
+
+def _validate_registry_component(value: str, label: str) -> None:
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._+-]{0,127}", value):
+        raise ValueError(f"Unsafe {label}: {value!r}.")
+    if value.endswith((".", " ")) or value.split(".", 1)[0].upper() in {
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        *(f"COM{number}" for number in range(1, 10)),
+        *(f"LPT{number}" for number in range(1, 10)),
+    }:
+        raise ValueError(f"Unsafe {label}: {value!r}.")

--- a/tests/cli/test_agent_marketplace_cli.py
+++ b/tests/cli/test_agent_marketplace_cli.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+
+from synapsekit.audit.signer import Ed25519SigningProvider
+from synapsekit.cli.main import main
+
+
+def _source(tmp_path: Path) -> Path:
+    source = tmp_path / "source"
+    (source / "evals").mkdir(parents=True)
+    (source / "README.md").write_text("# CLI agent\n", encoding="utf-8")
+    (source / "evals" / "suite.json").write_text("{}\n", encoding="utf-8")
+    return source
+
+
+def test_agent_cli_keygen_pack_verify_install_and_publish(tmp_path: Path, capsys) -> None:
+    private_key = tmp_path / "publisher.key"
+    public_key = tmp_path / "publisher.pub"
+    main(
+        [
+            "agent",
+            "keygen",
+            str(private_key),
+            "--public-key",
+            str(public_key),
+            "--key-id",
+            "cli-publisher",
+        ]
+    )
+    assert private_key.stat().st_size == 32
+
+    bundle = tmp_path / "cli-agent.agent"
+    main(
+        [
+            "agent",
+            "pack",
+            str(_source(tmp_path)),
+            "--output",
+            str(bundle),
+            "--name",
+            "cli-agent",
+            "--agent-version",
+            "1.0.0",
+            "--author",
+            "CLI Publisher",
+            "--private-key",
+            str(private_key),
+            "--key-id",
+            "cli-publisher",
+            "--eval-score",
+            "0.95",
+        ]
+    )
+    trusted_key = f"cli-publisher:{public_key.read_text(encoding='ascii').strip()}"
+
+    with pytest.raises(SystemExit) as verified:
+        main(["agent", "verify", str(bundle), "--trusted-key", trusted_key])
+    assert verified.value.code == 0
+
+    unpacked = tmp_path / "unpacked"
+    main(
+        [
+            "agent",
+            "unpack",
+            str(bundle),
+            str(unpacked),
+            "--trusted-key",
+            trusted_key,
+            "--require-trusted",
+        ]
+    )
+    assert (unpacked / "README.md").is_file()
+
+    install_root = tmp_path / "installed"
+    main(
+        [
+            "agent",
+            "install",
+            str(bundle),
+            "--install-root",
+            str(install_root),
+            "--trusted-key",
+            trusted_key,
+            "--require-trusted",
+        ]
+    )
+    assert (install_root / "cli-agent" / "1.0.0" / "README.md").is_file()
+
+    registry = tmp_path / "registry"
+    main(
+        [
+            "agent",
+            "publish",
+            str(bundle),
+            "--registry",
+            str(registry),
+            "--trusted-key",
+            trusted_key,
+            "--require-trusted",
+        ]
+    )
+    assert (registry / "index.json").is_file()
+    output = capsys.readouterr().out
+    assert "Packed signed agent bundle" in output
+    assert "Publisher: TRUSTED" in output
+    assert "Published cli-agent 1.0.0" in output
+
+
+def test_agent_cli_verify_can_require_publisher_trust(tmp_path: Path) -> None:
+    provider = Ed25519SigningProvider(key_id="self-signed")
+    source = _source(tmp_path)
+    from synapsekit.marketplace import pack_agent
+
+    bundle = pack_agent(
+        source,
+        tmp_path / "self-signed.agent",
+        name="self-signed",
+        version="1.0.0",
+        author="Publisher",
+        signing_provider=provider,
+    )
+
+    with pytest.raises(SystemExit) as result:
+        main(["agent", "verify", str(bundle), "--require-trusted"])
+
+    assert result.value.code == 1
+
+
+def test_agent_cli_rejects_malformed_trusted_key(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit, match="expected KEY_ID"):
+        main(["agent", "verify", str(tmp_path / "missing.agent"), "--trusted-key", "bad"])
+
+
+def test_agent_cli_public_key_is_raw_ed25519_base64(tmp_path: Path) -> None:
+    private_key = tmp_path / "publisher.key"
+    public_key = tmp_path / "publisher.pub"
+    main(["agent", "keygen", str(private_key), "--public-key", str(public_key)])
+
+    decoded = base64.b64decode(public_key.read_text(encoding="ascii").strip(), validate=True)
+
+    assert len(decoded) == 32

--- a/tests/marketplace/test_bundle.py
+++ b/tests/marketplace/test_bundle.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from synapsekit.audit.serializer import canonical_json
+from synapsekit.audit.signer import Ed25519SigningProvider
+from synapsekit.marketplace import (
+    InvalidAgentBundleError,
+    SandboxRequiredError,
+    install_agent,
+    pack_agent,
+    unpack_agent,
+    verify_agent_bundle,
+)
+
+
+def _agent_source(root: Path, *, marker: str = "v1") -> Path:
+    source = root / "source"
+    (source / "evals").mkdir(parents=True)
+    (source / "memory").mkdir()
+    (source / "router").mkdir()
+    (source / "README.md").write_text("# PR reviewer\n", encoding="utf-8")
+    (source / "agent.py").write_text(f"MARKER = {marker!r}\n", encoding="utf-8")
+    (source / "evals" / "cases.json").write_text('{"cases": []}\n', encoding="utf-8")
+    (source / "memory" / "preferences.md").write_text("Be concise.\n", encoding="utf-8")
+    (source / "router" / "priors.json").write_text('{"model": "local"}\n', encoding="utf-8")
+    return source
+
+
+def _bundle(tmp_path: Path) -> tuple[Path, Ed25519SigningProvider]:
+    provider = Ed25519SigningProvider(key_id="publisher-1")
+    bundle = pack_agent(
+        _agent_source(tmp_path),
+        tmp_path / "reviewer.agent",
+        name="pr-reviewer",
+        version="1.2.0",
+        author="Team Synapse",
+        description="Reviews pull requests",
+        entrypoint="agent.py:MARKER",
+        tags=["review", "engineering"],
+        eval_score=0.91,
+        signing_provider=provider,
+    )
+    return bundle, provider
+
+
+def _rewrite_archive(source: Path, output: Path, mutate) -> Path:
+    with zipfile.ZipFile(source) as archive:
+        entries = {info.filename: archive.read(info.filename) for info in archive.infolist()}
+    mutate(entries)
+    with zipfile.ZipFile(output, "w") as archive:
+        for name, data in entries.items():
+            archive.writestr(name, data)
+    return output
+
+
+def _rewrite_signed_manifest(
+    source: Path,
+    output: Path,
+    provider: Ed25519SigningProvider,
+    mutate,
+) -> Path:
+    with zipfile.ZipFile(source) as archive:
+        entries = {info.filename: archive.read(info.filename) for info in archive.infolist()}
+    manifest = json.loads(entries["manifest.json"])
+    mutate(manifest)
+    entries["manifest.json"] = (
+        json.dumps(manifest, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+    ).encode("utf-8")
+    entries["signature.ed25519"] = provider.sign(canonical_json(manifest))
+    with zipfile.ZipFile(output, "w") as archive:
+        for name, data in entries.items():
+            archive.writestr(name, data)
+    return output
+
+
+def test_pack_verify_and_unpack_round_trip(tmp_path: Path) -> None:
+    bundle, provider = _bundle(tmp_path)
+    trusted_keys = {provider.key_id: provider.public_key_bytes()}
+
+    verification = verify_agent_bundle(bundle, trusted_keys=trusted_keys)
+
+    assert verification.ok
+    assert verification.trusted
+    assert verification.manifest is not None
+    assert verification.manifest.name == "pr-reviewer"
+    assert verification.manifest.memory_format == "ump/1.0"
+    assert verification.manifest.router_path == "router/"
+    output = tmp_path / "unpacked"
+    manifest = unpack_agent(bundle, output, trusted_keys=trusted_keys, require_trusted=True)
+    assert manifest == verification.manifest
+    assert (output / "memory" / "preferences.md").read_text(encoding="utf-8") == "Be concise.\n"
+    assert (output / "signature.ed25519").stat().st_size == 64
+
+
+def test_self_signed_bundle_has_integrity_but_not_identity_trust(tmp_path: Path) -> None:
+    bundle, _ = _bundle(tmp_path)
+
+    verification = verify_agent_bundle(bundle)
+
+    assert verification.integrity_valid
+    assert not verification.trusted
+    assert verification.errors == ()
+
+
+def test_same_inputs_create_byte_identical_bundle(tmp_path: Path) -> None:
+    source = _agent_source(tmp_path)
+    provider = Ed25519SigningProvider(key_id="deterministic")
+    first = pack_agent(
+        source,
+        tmp_path / "first.agent",
+        name="deterministic-agent",
+        version="1.0.0",
+        author="Publisher",
+        signing_provider=provider,
+    )
+    second = pack_agent(
+        source,
+        tmp_path / "second.agent",
+        name="deterministic-agent",
+        version="1.0.0",
+        author="Publisher",
+        signing_provider=provider,
+    )
+
+    assert first.read_bytes() == second.read_bytes()
+
+
+def test_payload_tampering_is_rejected(tmp_path: Path) -> None:
+    bundle, _ = _bundle(tmp_path)
+
+    tampered = _rewrite_archive(
+        bundle,
+        tmp_path / "tampered.agent",
+        lambda entries: entries.__setitem__("agent.py", b"MARKER = 'pwned'\n"),
+    )
+    verification = verify_agent_bundle(tampered)
+
+    assert not verification.ok
+    assert any("Content hash mismatch" in error for error in verification.errors)
+
+
+def test_untracked_archive_file_is_rejected(tmp_path: Path) -> None:
+    bundle, _ = _bundle(tmp_path)
+
+    tampered = _rewrite_archive(
+        bundle,
+        tmp_path / "extra.agent",
+        lambda entries: entries.__setitem__("tools/hidden.py", b"print('unexpected')\n"),
+    )
+    verification = verify_agent_bundle(tampered)
+
+    assert not verification.ok
+    assert any("inventory mismatch" in error for error in verification.errors)
+
+
+def test_path_traversal_archive_is_rejected_before_extraction(tmp_path: Path) -> None:
+    bundle, _ = _bundle(tmp_path)
+
+    tampered = _rewrite_archive(
+        bundle,
+        tmp_path / "traversal.agent",
+        lambda entries: entries.__setitem__("../escape.py", b"bad\n"),
+    )
+    verification = verify_agent_bundle(tampered)
+
+    assert not verification.ok
+    assert any("Unsafe archive path" in error for error in verification.errors)
+    assert not (tmp_path / "escape.py").exists()
+
+
+def test_case_insensitive_path_collision_is_rejected(tmp_path: Path) -> None:
+    bundle, _ = _bundle(tmp_path)
+    tampered = _rewrite_archive(
+        bundle,
+        tmp_path / "case-collision.agent",
+        lambda entries: entries.__setitem__("readme.md", b"shadow\n"),
+    )
+
+    verification = verify_agent_bundle(tampered)
+
+    assert not verification.ok
+    assert any("Case-insensitive" in error for error in verification.errors)
+
+
+def test_windows_device_path_is_rejected_cross_platform(tmp_path: Path) -> None:
+    bundle, _ = _bundle(tmp_path)
+    tampered = _rewrite_archive(
+        bundle,
+        tmp_path / "device-name.agent",
+        lambda entries: entries.__setitem__("tools/CON.py", b"shadow\n"),
+    )
+
+    verification = verify_agent_bundle(tampered)
+
+    assert not verification.ok
+    assert any("Unsafe archive path" in error for error in verification.errors)
+
+
+def test_wrong_pinned_key_is_rejected(tmp_path: Path) -> None:
+    bundle, provider = _bundle(tmp_path)
+    other = Ed25519SigningProvider()
+
+    verification = verify_agent_bundle(
+        bundle, trusted_keys={provider.key_id: other.public_key_bytes()}
+    )
+
+    assert not verification.ok
+    assert any("does not match" in error for error in verification.errors)
+
+
+def test_untrusted_bundle_cannot_disable_mandatory_sandboxing(tmp_path: Path) -> None:
+    bundle, provider = _bundle(tmp_path)
+    unsafe = _rewrite_signed_manifest(
+        bundle,
+        tmp_path / "unsafe-sandbox-policy.agent",
+        provider,
+        lambda manifest: manifest["sandbox"].__setitem__("required_for_untrusted", False),
+    )
+
+    verification = verify_agent_bundle(unsafe)
+
+    assert not verification.ok
+    assert any("requires sandboxing" in error for error in verification.errors)
+
+
+def test_pack_requires_evals_and_readme(tmp_path: Path) -> None:
+    source = tmp_path / "incomplete"
+    source.mkdir()
+    (source / "README.md").write_text("# Incomplete\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="evals"):
+        pack_agent(
+            source,
+            tmp_path / "incomplete.agent",
+            name="incomplete",
+            version="1.0.0",
+            author="Publisher",
+            signing_provider=Ed25519SigningProvider(),
+        )
+
+
+def test_pack_rejects_case_insensitive_reserved_install_metadata(tmp_path: Path) -> None:
+    source = _agent_source(tmp_path)
+    (source / ".SYNAPSEKIT-INSTALL.JSON").write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(InvalidAgentBundleError, match="Reserved bundle path"):
+        pack_agent(
+            source,
+            tmp_path / "reserved.agent",
+            name="reserved",
+            version="1.0.0",
+            author="Publisher",
+            signing_provider=Ed25519SigningProvider(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_untrusted_install_is_inert_and_uses_supplied_sandbox(tmp_path: Path) -> None:
+    bundle, _ = _bundle(tmp_path)
+    installed = install_agent(bundle, install_root=tmp_path / "installed")
+
+    assert installed.sandbox_required
+    assert (installed.path / ".synapsekit-install.json").is_file()
+    with pytest.raises(SandboxRequiredError):
+        await installed.run("review this")
+
+    class RecordingSandbox:
+        async def run(self, agent_path, manifest, prompt, **kwargs):
+            return {
+                "path": agent_path,
+                "name": manifest.name,
+                "prompt": prompt,
+                "mode": kwargs["mode"],
+            }
+
+    result = await installed.run("review this", sandbox=RecordingSandbox(), mode="strict")
+    assert result == {
+        "path": installed.path,
+        "name": "pr-reviewer",
+        "prompt": "review this",
+        "mode": "strict",
+    }
+
+
+def test_install_is_idempotent_for_same_bundle(tmp_path: Path) -> None:
+    bundle, provider = _bundle(tmp_path)
+    trusted_keys = {provider.key_id: provider.public_key_bytes()}
+
+    first = install_agent(bundle, install_root=tmp_path / "installed", trusted_keys=trusted_keys)
+    second = install_agent(bundle, install_root=tmp_path / "installed", trusted_keys=trusted_keys)
+
+    assert first.path == second.path
+    assert first.bundle_sha256 == second.bundle_sha256
+    assert not first.sandbox_required
+    metadata = json.loads((first.path / ".synapsekit-install.json").read_text(encoding="utf-8"))
+    assert metadata["trusted"] is True
+
+
+def test_invalid_component_cannot_escape_install_root(tmp_path: Path) -> None:
+    source = _agent_source(tmp_path)
+    with pytest.raises(ValueError, match="unsafe"):
+        pack_agent(
+            source,
+            tmp_path / "unsafe.agent",
+            name="../escape",
+            version="1.0.0",
+            author="Publisher",
+            signing_provider=Ed25519SigningProvider(),
+        )
+
+
+def test_unpack_never_overwrites_an_existing_directory(tmp_path: Path) -> None:
+    bundle, _ = _bundle(tmp_path)
+    output = tmp_path / "existing"
+    output.mkdir()
+
+    with pytest.raises(FileExistsError):
+        unpack_agent(bundle, output)
+
+
+def test_invalid_bundle_require_valid_raises_domain_error(tmp_path: Path) -> None:
+    invalid = tmp_path / "invalid.agent"
+    invalid.write_bytes(b"not a zip")
+
+    verification = verify_agent_bundle(invalid)
+
+    with pytest.raises(InvalidAgentBundleError):
+        verification.require_valid()

--- a/tests/marketplace/test_registry.py
+++ b/tests/marketplace/test_registry.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from synapsekit.audit.signer import Ed25519SigningProvider
+from synapsekit.marketplace import (
+    FileAgentRegistry,
+    InvalidAgentBundleError,
+    SignedAgentReview,
+    UntrustedPublisherError,
+    pack_agent,
+)
+
+
+def _pack(tmp_path: Path, name: str, score: float, marker: str = "v1"):
+    source = tmp_path / f"source-{name}-{marker}"
+    (source / "evals").mkdir(parents=True)
+    (source / "README.md").write_text(f"# {name}\n", encoding="utf-8")
+    (source / "evals" / "suite.json").write_text("{}\n", encoding="utf-8")
+    (source / "prompt.md").write_text(marker, encoding="utf-8")
+    provider = Ed25519SigningProvider(key_id=f"publisher-{name}")
+    bundle = pack_agent(
+        source,
+        tmp_path / f"{name}-{marker}.agent",
+        name=name,
+        version="1.0.0",
+        author="Publisher",
+        signing_provider=provider,
+        eval_score=score,
+    )
+    return bundle, provider
+
+
+def test_registry_requires_pinned_publisher_by_default(tmp_path: Path) -> None:
+    bundle, _ = _pack(tmp_path, "reviewer", 0.8)
+
+    with pytest.raises(UntrustedPublisherError):
+        FileAgentRegistry(tmp_path / "registry").publish(bundle)
+
+
+def test_registry_rejects_unsafe_review_lookup_path(tmp_path: Path) -> None:
+    registry = FileAgentRegistry(tmp_path / "registry")
+
+    with pytest.raises(ValueError, match="Unsafe agent name"):
+        registry.reviews("..", "1.0.0")
+
+
+def test_registry_publishes_immutable_bundle_and_static_index(tmp_path: Path) -> None:
+    bundle, provider = _pack(tmp_path, "reviewer", 0.8)
+    registry = FileAgentRegistry(tmp_path / "registry")
+    trusted_keys = {provider.key_id: provider.public_key_bytes()}
+
+    entry = registry.publish(bundle, trusted_keys=trusted_keys)
+    duplicate = registry.publish(bundle, trusted_keys=trusted_keys)
+
+    assert duplicate == entry
+    assert registry.get("reviewer", "1.0.0") == entry
+    assert registry.bundle_path("reviewer", "1.0.0").read_bytes() == bundle.read_bytes()
+    assert registry.index_path.is_file()
+
+
+def test_registry_refuses_replacing_an_existing_version(tmp_path: Path) -> None:
+    first, first_provider = _pack(tmp_path, "reviewer", 0.8, marker="v1")
+    second, second_provider = _pack(tmp_path, "reviewer", 0.9, marker="v2")
+    registry = FileAgentRegistry(tmp_path / "registry")
+    registry.publish(first, trusted_keys={first_provider.key_id: first_provider.public_key_bytes()})
+
+    with pytest.raises(FileExistsError):
+        registry.publish(
+            second,
+            trusted_keys={second_provider.key_id: second_provider.public_key_bytes()},
+        )
+
+
+def test_signed_reviews_feed_deterministic_eval_ranking(tmp_path: Path) -> None:
+    first, first_provider = _pack(tmp_path, "first-agent", 0.9)
+    second, second_provider = _pack(tmp_path, "second-agent", 0.6)
+    registry = FileAgentRegistry(tmp_path / "registry")
+    registry.publish(first, trusted_keys={first_provider.key_id: first_provider.public_key_bytes()})
+    registry.publish(
+        second,
+        trusted_keys={second_provider.key_id: second_provider.public_key_bytes()},
+    )
+    reviewer = Ed25519SigningProvider(key_id="reviewer-key")
+    review = SignedAgentReview.sign(
+        agent_name="second-agent",
+        agent_version="1.0.0",
+        reviewer="Independent Lab",
+        rating=5,
+        eval_score=1.0,
+        comment="Reproduced the eval suite.",
+        signing_provider=reviewer,
+        signed_at="2026-07-26T00:00:00+00:00",
+    )
+    registry.add_review(review, trusted_keys={reviewer.key_id: reviewer.public_key_bytes()})
+
+    ranked = registry.ranked()
+
+    assert [item.entry.name for item in ranked] == ["first-agent", "second-agent"]
+    assert ranked[0].score == 0.9
+    assert ranked[1].score == 0.72
+    assert ranked[1].review_count == 1
+
+
+def test_tampered_signed_review_is_rejected(tmp_path: Path) -> None:
+    bundle, provider = _pack(tmp_path, "reviewer", 0.8)
+    registry = FileAgentRegistry(tmp_path / "registry")
+    registry.publish(bundle, trusted_keys={provider.key_id: provider.public_key_bytes()})
+    reviewer = Ed25519SigningProvider(key_id="reviewer-key")
+    review = SignedAgentReview.sign(
+        agent_name="reviewer",
+        agent_version="1.0.0",
+        reviewer="Lab",
+        rating=4,
+        eval_score=0.8,
+        signing_provider=reviewer,
+    )
+    tampered = replace(review, comment="Changed after signing")
+
+    with pytest.raises(InvalidAgentBundleError, match="signature"):
+        registry.add_review(
+            tampered,
+            trusted_keys={reviewer.key_id: reviewer.public_key_bytes()},
+        )
+
+
+def test_ranking_rechecks_stored_review_signature(tmp_path: Path) -> None:
+    bundle, provider = _pack(tmp_path, "reviewer", 0.8)
+    registry = FileAgentRegistry(tmp_path / "registry")
+    registry.publish(bundle, trusted_keys={provider.key_id: provider.public_key_bytes()})
+    reviewer = Ed25519SigningProvider(key_id="reviewer-key")
+    review = SignedAgentReview.sign(
+        agent_name="reviewer",
+        agent_version="1.0.0",
+        reviewer="Lab",
+        rating=4,
+        eval_score=0.8,
+        signing_provider=reviewer,
+    )
+    review_path = registry.add_review(
+        review,
+        trusted_keys={reviewer.key_id: reviewer.public_key_bytes()},
+    )
+    stored = json.loads(review_path.read_text(encoding="utf-8"))
+    stored["rating"] = 5
+    review_path.write_text(json.dumps(stored), encoding="utf-8")
+
+    with pytest.raises(InvalidAgentBundleError, match="Stored review signature"):
+        registry.ranked()


### PR DESCRIPTION
## Summary

Adds the repository-side foundation for issue #751: a deterministic, signed `.agent` bundle format, safe install flow, CLI lifecycle, and a self-hostable file-backed registry with signed reviews and eval-based ranking.

Refs #751

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / internal improvement
- [ ] Dependency / tooling update

## Changes

- Add canonical Ed25519-signed manifests with per-file SHA-256 verification, UMP/router metadata, required README/evals, archive limits, and deterministic ZIP output.
- Verify from an immutable in-memory snapshot before atomic extraction or inert installation; reject traversal, symlinks, Windows device names/ADS, duplicates, and case-insensitive path collisions.
- Require an explicit sandbox runner before installed bundle execution and prevent untrusted manifests from disabling the schema 1.0 sandbox policy.
- Add `agent keygen`, `pack`, `verify`, `unpack`, `install`, and `publish` CLI commands.
- Add an immutable file-backed registry with publisher trust pinning, signed reviews, deterministic eval/review ranking, public exports, tests, and an open versioned bundle specification.

## Testing

- [ ] All existing tests pass (`uv run pytest tests/ -q`)
- [x] New tests added for new behaviour
- [x] No API keys or secrets in the code

Local validation:

- `28 passed` for `tests/marketplace` and `tests/cli/test_agent_marketplace_cli.py`
- `ruff check src/ tests/`
- `ruff format --check src/ tests/` (811 files)
- `mypy` (484 source files)
- `deptry src/`
- `git diff --check`

The full Windows suite was also split across four groups: 4,753 passed, 57 skipped, and 1 xfailed. Fifteen pre-existing Windows/environment failures remained in Unix-shell, REPL-subprocess, legacy audit-trust, and mesh temporary-ingestion tests; none touched the marketplace implementation. GitHub Actions is the authoritative full-suite gate.

## Documentation

- [x] Docstrings updated (if public API changed)
- [ ] [synapsekit-docs](https://github.com/SynapseKit/synapsekit-docs) updated (if new feature)
- [ ] CHANGELOG.md updated

The versioned repository specification is included at `docs/agent-bundle-v1.md`.

## Notes for reviewer

The hosted `agents.synapsekit.io` index, optional Stripe deployment, and five-agent community seed launch are operational/community deliverables and are intentionally not claimed by this repository PR.

Please pay particular attention to the trust boundary: an embedded key proves bundle integrity, while publisher/reviewer authenticity requires a caller-pinned key obtained independently.
