### PR TITLE
ci(docker): publish official images to GHCR on every release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Keep the build context small and reproducible — only ship src + package metadata.
+.git
+.github
+.venv
+.idea
+.vscode
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.benchmarks
+__pycache__
+*.py[cod]
+*.so
+build/
+dist/
+*.egg-info/
+
+# Tests, docs, examples, benchmarks — not needed in the runtime image.
+tests
+docs
+examples
+benchmarks
+assets
+typescript
+scripts
+
+# Local state / caches / coverage that must never leak into an image layer.
+.coverage
+coverage.json
+.env
+*.log
+.DS_Store
+.discord_*state.json
+uv.lock

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,119 @@
+name: Publish Docker image (GHCR)
+
+# Publishes the official SynapseKit image to GitHub Container Registry.
+#   ghcr.io/synapsekit/synapsekit:<version>   / :latest        (core lib + CLI)
+#   ghcr.io/synapsekit/synapsekit:<version>-all / :all         (all extras baked in)
+#
+# A matching image is published automatically on every GitHub Release (the same
+# `release: published` event that drives the PyPI publish), so a Docker version
+# ships with every release. It can also be triggered manually (workflow_dispatch)
+# to publish an :edge test image, or to (re)publish a specific version on demand.
+# Each image is smoke-tested locally before it is pushed, so a broken build never
+# reaches the registry.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 2.0.0). Leave empty for an :edge test build."
+        required: false
+        default: ""
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: core
+            extras: ""
+            suffix: ""
+            moving_tag: latest
+            platforms: linux/amd64,linux/arm64
+          - variant: all
+            extras: "[all]"
+            suffix: "-all"
+            moving_tag: all
+            # `all` pulls heavy/native wheels; keep it amd64 to stay reliable.
+            platforms: linux/amd64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      # GHCR login uses the built-in token — no external secrets to manage.
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Compute image tags. On a Release (or a manual run with a version input) we
+      # publish that version plus the moving tag (:latest / :all). On a manual run
+      # with no version we publish only an :edge / :edge-all test image.
+      - name: Compute tags
+        id: tags
+        env:
+          SUFFIX: ${{ matrix.suffix }}
+          MOVING_TAG: ${{ matrix.moving_tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          set -euo pipefail
+          image="${IMAGE,,}"   # GHCR requires a lowercase path
+          # Release event → release tag; manual run → optional version input.
+          version="${RELEASE_TAG:-$INPUT_VERSION}"
+          version="${version#v}"   # strip a leading v if present
+          if [ -n "$version" ]; then
+            tags="${image}:${version}${SUFFIX},${image}:${MOVING_TAG}"
+          else
+            tags="${image}:edge${SUFFIX}"
+          fi
+          echo "image=${image}" >> "$GITHUB_OUTPUT"
+          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
+          echo "Tags: ${tags}"
+
+      # 1) Build a single-arch image loaded into the local daemon and smoke-test it.
+      - name: Build (smoke)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          push: false
+          tags: synapsekit:smoke-${{ matrix.variant }}
+          build-args: |
+            EXTRAS=${{ matrix.extras }}
+          cache-from: type=gha,scope=${{ matrix.variant }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.variant }}
+
+      - name: Smoke test image
+        run: |
+          set -euo pipefail
+          echo "→ synapsekit --version"
+          docker run --rm synapsekit:smoke-${{ matrix.variant }} --version
+          echo "→ import synapsekit"
+          docker run --rm --entrypoint python synapsekit:smoke-${{ matrix.variant }} \
+            -c "import synapsekit; print('import OK', synapsekit.__version__)"
+
+      # 2) Only after the smoke test passes, build multi-arch and push.
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platforms }}
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            EXTRAS=${{ matrix.extras }}
+          cache-from: type=gha,scope=${{ matrix.variant }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.variant }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# syntax=docker/dockerfile:1
+
+# ── SynapseKit official image ────────────────────────────────────────────────
+# Two variants are produced from this single Dockerfile via the EXTRAS build arg:
+#   EXTRAS=""      → core library + CLI            (small, published as :latest / :<version>)
+#   EXTRAS="[all]" → batteries-included, all extras (published as :all / :<version>-all)
+#
+# Build locally:
+#   docker build -t synapsekit:latest .
+#   docker build --build-arg EXTRAS="[all]" -t synapsekit:all .
+#
+# The optional Rust-accelerated chunker (synapsekit._rust_core) is built
+# separately with maturin and is NOT included here — SynapseKit falls back to
+# its pure-Python chunker automatically.
+
+# ── Stage 1: builder ─────────────────────────────────────────────────────────
+FROM python:3.12-slim AS builder
+
+# uv provides fast, reproducible installs (matches the project's package manager).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_DOWNLOADS=never
+
+WORKDIR /app
+
+# Which optional-dependency group to bake in ("" = core only, "[all]" = everything).
+ARG EXTRAS=""
+
+# Copy only what the build backend needs to resolve + install the package.
+COPY pyproject.toml README.md ./
+COPY src ./src
+
+# Install into an isolated venv so the runtime stage stays lean.
+RUN uv venv /opt/venv \
+    && VIRTUAL_ENV=/opt/venv uv pip install --no-cache ".${EXTRAS}"
+
+# ── Stage 2: runtime ─────────────────────────────────────────────────────────
+FROM python:3.12-slim AS runtime
+
+LABEL org.opencontainers.image.title="SynapseKit" \
+      org.opencontainers.image.description="Async-first Python framework for RAG, agents, and LLM apps" \
+      org.opencontainers.image.source="https://github.com/SynapseKit/synapsekit" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+ENV VIRTUAL_ENV=/opt/venv \
+    PATH="/opt/venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+# Run as a non-root user.
+RUN useradd --create-home --uid 1000 synapse
+COPY --from=builder --chown=synapse:synapse /opt/venv /opt/venv
+
+USER synapse
+WORKDIR /home/synapse
+
+# `synapsekit` is the console entrypoint (see [project.scripts]).
+# Default to showing help; override with e.g. `docker run ... synapsekit serve app:rag --host 0.0.0.0`.
+ENTRYPOINT ["synapsekit"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -748,6 +748,21 @@ poetry add synapsekit[openai]
 poetry add "synapsekit[all]"
 ```
 
+**Docker** — official images on GitHub Container Registry, no Python setup required:
+```bash
+# Core library + CLI
+docker pull ghcr.io/synapsekit/synapsekit:latest
+docker run --rm ghcr.io/synapsekit/synapsekit --version
+
+# Batteries-included (all extras baked in)
+docker pull ghcr.io/synapsekit/synapsekit:all
+
+# Serve a SynapseKit app as an HTTP API (bind 0.0.0.0 inside the container)
+docker run --rm -p 8000:8000 -v "$PWD:/app" -w /app \
+  ghcr.io/synapsekit/synapsekit serve my_module:rag --host 0.0.0.0
+```
+Tags: `:latest` / `:<version>` (core) and `:all` / `:<version>-all` (all extras). A matching image is published automatically on every release.
+
 Full installation options → [docs](https://synapsekit.github.io/synapsekit-docs/docs/getting-started/installation)
 
 Observability guide → [docs/observability.md](docs/observability.md)


### PR DESCRIPTION
Adds an official Docker image published to **GitHub Container Registry** so users can `docker pull` and run without setting up Python/uv or the large `[all]` dependency set.

## What's here
- **`Dockerfile`** — multi-stage, uv-based, non-root, `synapsekit` CLI entrypoint. One `EXTRAS` build arg → two variants (core / `[all]`).
- **`.dockerignore`** — trims context to `src/` + metadata.
- **`.github/workflows/docker-publish.yml`** — GHCR publish, core multi-arch (amd64+arm64), smoke-tests each image (`synapsekit --version` + import) **before** pushing. Coupled to `release: published` so **every release ships a matching Docker version**; `workflow_dispatch` supports `:edge` builds and on-demand version publishing.
- **README** — Docker install subsection.

## Tags
- `ghcr.io/synapsekit/synapsekit:<version>` + `:latest` (core, amd64+arm64)
- `ghcr.io/synapsekit/synapsekit:<version>-all` + `:all` (all extras, amd64)

## Post-merge rollout
1. `workflow_dispatch` (no version) → `:edge` smoke check
2. `workflow_dispatch` version=2.0.0 → publish `:2.0.0` / `:latest` / `:all`
3. Set GHCR package visibility to public (one-time)

Closes #874