### PR TITLE
chore: gitignore pytest-benchmark output artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,4 +82,6 @@ typescript
 
 # ASV machine profiles (contributor-specific, not project config)
 benchmarks/asv/machine.json
+# pytest-benchmark output artifact (--benchmark-json), regenerated each run
+benchmarks/benchmark.json
 .asv/


### PR DESCRIPTION
`benchmarks/benchmark.json` is a generated pytest-benchmark artifact (`--benchmark-json` in `benchmarks/pytest.ini`), uploaded by CI and consumed by `benchmarks/report.py` — not source. It kept showing up as an untracked stray (empty) file. Gitignore it.