### PR TITLE
feat(live): richer dashboard — subsystem activity strip + polished meters

### DIFF
--- a/src/synapsekit/live/dashboard.html
+++ b/src/synapsekit/live/dashboard.html
@@ -10,60 +10,73 @@
     --ink:#101828; --ink-2:#364152; --muted:#667085; --faint:#98A2B3;
     --brand:#16A34A; --brand-2:#22C55E; --brand-ink:#05603A; --brand-soft:#E9F9EF;
     --warn:#B54708; --warn-soft:#FEF0E6; --crit:#D92D20; --gold:#B54708;
-    --shadow:0 1px 2px rgba(16,24,40,.04),0 6px 20px rgba(16,24,40,.06);
+    --shadow:0 1px 2px rgba(16,24,40,.04),0 8px 24px rgba(16,24,40,.06);
     --sans:ui-sans-serif,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
     --mono:ui-monospace,"SF Mono","JetBrains Mono",Menlo,Consolas,monospace;
   }
   *{box-sizing:border-box}
   body{margin:0;min-height:100vh;font-family:var(--sans);color:var(--ink);line-height:1.5;
     -webkit-font-smoothing:antialiased;
-    background:radial-gradient(760px 460px at 88% -8%,#E9F9EF88,transparent 70%),
-      radial-gradient(680px 460px at -4% 108%,#EAF1FB88,transparent 70%),var(--bg);}
+    background:radial-gradient(820px 480px at 88% -8%,#E9F9EF88,transparent 70%),
+      radial-gradient(720px 480px at -4% 108%,#EAF1FB88,transparent 70%),var(--bg);}
   .wrap{max-width:1200px;margin:0 auto;padding:20px 22px 40px}
-  header{display:flex;align-items:center;gap:16px;padding:10px 4px 18px;border-bottom:1px solid var(--line);flex-wrap:wrap}
+  header{display:flex;align-items:center;gap:16px;padding:10px 4px 16px;flex-wrap:wrap}
   .brand{display:flex;align-items:center;gap:11px}
-  .brand svg{width:30px;height:30px;display:block}
-  .brand b{font-weight:650;font-size:16px}
+  .brand svg{width:32px;height:32px;display:block}
+  .brand b{font-weight:680;font-size:17px;letter-spacing:.2px}
   .live-tag{font-family:var(--mono);font-size:10.5px;color:var(--muted);text-transform:uppercase;letter-spacing:1.4px;padding-top:2px;display:flex;align-items:center;gap:6px;font-weight:600}
   .live-tag.on{color:var(--brand)}
   .pulse{width:7px;height:7px;border-radius:50%;background:var(--faint)}
-  .live-tag.on .pulse{background:var(--brand);animation:pulse 2.4s infinite}
+  .live-tag.on .pulse{background:var(--brand);animation:pulse 2.2s infinite}
   @keyframes pulse{0%{box-shadow:0 0 0 0 #16A34A44}70%{box-shadow:0 0 0 7px #16A34A00}100%{box-shadow:0 0 0 0 #16A34A00}}
-  .runmeta{margin-left:auto;display:flex;align-items:center;gap:16px;font-family:var(--mono);font-size:11.5px;color:var(--muted);flex-wrap:wrap}
-  .runmeta .k{color:var(--faint)}
-  .dep-badge{font-family:var(--mono);font-size:10.5px;font-weight:600;color:var(--brand-ink);border:1px solid #ABE5C3;background:var(--brand-soft);padding:5px 9px;border-radius:999px;white-space:nowrap}
+  .runmeta{margin-left:auto;display:flex;align-items:center;gap:14px;font-family:var(--mono);font-size:11.5px;color:var(--muted);flex-wrap:wrap}
+  .dep-badge{font-family:var(--mono);font-size:10.5px;font-weight:600;color:var(--brand-ink);border:1px solid #ABE5C3;background:var(--brand-soft);padding:5px 10px;border-radius:999px;white-space:nowrap}
   .seg{display:inline-flex;border:1px solid var(--line-2);border-radius:999px;padding:3px;background:var(--panel-2)}
   .seg button{font:inherit;font-size:12.5px;font-weight:550;color:var(--muted);background:none;border:0;cursor:pointer;padding:5px 14px;border-radius:999px;transition:.18s}
-  .seg button[aria-pressed="true"]{background:var(--brand);color:#fff}
+  .seg button[aria-pressed="true"]{background:var(--brand);color:#fff;box-shadow:0 1px 2px #05603a33}
   .seg button:focus-visible{outline:2px solid var(--brand);outline-offset:2px}
-  .grid{display:grid;gap:16px;margin-top:18px;grid-template-columns:1.7fr .95fr}
+
+  /* subsystem activity strip */
+  .activity{display:grid;grid-template-columns:repeat(8,1fr);gap:10px;margin:6px 0 16px}
+  @media(max-width:820px){.activity{grid-template-columns:repeat(4,1fr)}}
+  .chip{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:11px 12px;box-shadow:var(--shadow);transition:border-color .3s,transform .12s,box-shadow .3s}
+  .chip .top{display:flex;align-items:center;justify-content:space-between}
+  .chip .em{font-size:16px;filter:grayscale(.5);opacity:.7;transition:.3s}
+  .chip .n{font-family:var(--mono);font-size:16px;font-weight:680;font-variant-numeric:tabular-nums;color:var(--ink)}
+  .chip .lab{font-family:var(--mono);font-size:9.5px;text-transform:uppercase;letter-spacing:.6px;color:var(--faint);margin-top:5px;font-weight:600}
+  .chip.lit{border-color:#ABE5C3}
+  .chip.lit .em{filter:none;opacity:1}
+  .chip.lit .lab{color:var(--brand-ink)}
+  .chip.hot{border-color:var(--brand);box-shadow:0 0 0 3px #16A34A1f,var(--shadow);transform:translateY(-2px)}
+
+  .grid{display:grid;gap:16px;grid-template-columns:1.7fr .95fr}
   @media(max-width:820px){.grid{grid-template-columns:1fr}}
-  .panel{background:var(--panel);border:1px solid var(--line);border-radius:12px;box-shadow:var(--shadow)}
-  .panel>h2{margin:0;padding:13px 16px;font-size:11px;font-weight:650;text-transform:uppercase;letter-spacing:1.5px;color:var(--muted);border-bottom:1px solid var(--line);display:flex;align-items:center;gap:9px}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:14px;box-shadow:var(--shadow)}
+  .panel>h2{margin:0;padding:13px 16px;font-size:11px;font-weight:680;text-transform:uppercase;letter-spacing:1.5px;color:var(--muted);border-bottom:1px solid var(--line);display:flex;align-items:center;gap:9px}
   .panel>h2 .count{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--faint);font-weight:500}
-  .feed{max-height:600px;overflow-y:auto;padding:6px 6px 10px}
-  .empty{padding:44px 20px;text-align:center;color:var(--faint);font-size:13.5px}
-  .empty .big{font-size:26px;margin-bottom:8px}
-  .ev{display:grid;grid-template-columns:24px 1fr;gap:11px;padding:11px 12px;border-radius:10px;margin:2px 4px;animation:slidein .35s cubic-bezier(.2,.7,.3,1)}
-  @keyframes slidein{from{opacity:0;transform:translateY(-6px)}to{opacity:1;transform:none}}
+  .feed{max-height:560px;overflow-y:auto;padding:6px 6px 10px}
+  .empty{padding:52px 20px;text-align:center;color:var(--faint);font-size:13.5px}
+  .empty .big{font-size:30px;margin-bottom:10px;opacity:.6}
+  .ev{display:grid;grid-template-columns:26px 1fr;gap:12px;padding:12px 12px;border-radius:11px;margin:2px 4px;animation:slidein .35s cubic-bezier(.2,.7,.3,1)}
+  @keyframes slidein{from{opacity:0;transform:translateY(-7px)}to{opacity:1;transform:none}}
   .ev:hover{background:#F5F8FB}
-  .ev .ic{width:24px;height:24px;border-radius:7px;display:grid;place-items:center;font-size:12px;margin-top:1px;background:var(--brand-soft);border:1px solid #C7EED6}
+  .ev .ic{width:26px;height:26px;border-radius:8px;display:grid;place-items:center;font-size:13px;margin-top:1px;background:var(--brand-soft);border:1px solid #C7EED6}
   .ev.err .ic{background:#FEECEB;border-color:#F5B5B0}
-  .ev.warn .ic{background:var(--warn-soft);border-color:#F5C99B}
-  .ev .t{font-size:13.5px;color:var(--ink-2);line-height:1.44}
-  .ev .t b{color:var(--ink);font-weight:650}
+  .ev .t{font-size:14px;color:var(--ink-2);line-height:1.45}
+  .ev .t b{color:var(--ink);font-weight:680}
   .ev .t code{font-family:var(--mono);font-size:12px;background:#EEF2F7;padding:1px 5px;border-radius:5px;color:#344054}
   .ev .meta{font-family:var(--mono);font-size:10.5px;color:var(--faint);margin-top:5px;display:flex;gap:10px;flex-wrap:wrap}
   .ev .meta b{color:var(--muted);font-weight:600}
   .feed.trace .ev .t{font-family:var(--mono);font-size:12px;color:#475467;word-break:break-word}
   .col-c{display:flex;flex-direction:column;gap:16px}
   .meters{display:grid;grid-template-columns:1fr 1fr;gap:12px;padding:14px}
-  .meter{background:var(--panel-2);border:1px solid var(--line);border-radius:10px;padding:12px 13px}
+  .meter{background:var(--panel-2);border:1px solid var(--line);border-radius:11px;padding:13px 14px}
   .meter .lab{font-family:var(--mono);font-size:9.5px;text-transform:uppercase;letter-spacing:.8px;color:var(--faint);font-weight:600}
-  .meter .val{font-family:var(--mono);font-size:22px;font-weight:650;margin-top:5px;font-variant-numeric:tabular-nums;letter-spacing:-.5px}
-  .meter .val small{font-size:12px;color:var(--muted);font-weight:500}
-  .meter.wide{grid-column:1/-1}
+  .meter .val{font-family:var(--mono);font-size:23px;font-weight:680;margin-top:5px;font-variant-numeric:tabular-nums;letter-spacing:-.5px}
+  .meter.big{grid-column:1/-1}
+  .meter.big .val{font-size:30px}
   .val.cost{color:var(--gold)}
+  .val.live{color:var(--brand)}
   .foot{margin-top:22px;text-align:center;font-family:var(--mono);font-size:11px;color:var(--faint)}
   .foot b{color:var(--brand);font-weight:600}
   @media(prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
@@ -89,27 +102,28 @@
       <button id="mStory" aria-pressed="true">Story</button>
       <button id="mTrace" aria-pressed="false">Trace</button>
     </div>
-    <div class="runmeta">
-      <span class="dep-badge">localhost · SSE · 0 new deps</span>
-    </div>
+    <div class="runmeta"><span class="dep-badge">localhost · SSE · 0 new deps</span></div>
   </header>
+
+  <div class="activity" id="activity"></div>
 
   <div class="grid">
     <section class="panel">
       <h2>Live activity <span class="count" id="evCount">0 events</span></h2>
       <div class="feed" id="feed" aria-live="polite">
-        <div class="empty" id="empty"><div class="big">◇</div>Waiting for a SynapseKit run…<br>Execute an agent, RAG query, or graph and it appears here live.</div>
+        <div class="empty" id="empty"><div class="big">◇</div>Waiting for a SynapseKit run…<br>Execute an agent, RAG query, tool, or graph and it appears here live.</div>
       </div>
     </section>
     <aside class="col-c">
       <section class="panel">
         <h2>Telemetry</h2>
         <div class="meters">
-          <div class="meter"><div class="lab">Cost</div><div class="val cost" id="mCost">$0.0000</div></div>
+          <div class="meter big"><div class="lab">Cost this run</div><div class="val cost" id="mCost">$0.0000</div></div>
           <div class="meter"><div class="lab">Events</div><div class="val" id="mEvents">0</div></div>
+          <div class="meter"><div class="lab">Tokens</div><div class="val" id="mTok">0</div></div>
           <div class="meter"><div class="lab">Tokens in</div><div class="val" id="mTokIn">0</div></div>
           <div class="meter"><div class="lab">Tokens out</div><div class="val" id="mTokOut">0</div></div>
-          <div class="meter wide"><div class="lab">Last step</div><div class="val" id="mLast" style="font-size:15px">—</div></div>
+          <div class="meter big"><div class="lab">Last step</div><div class="val" id="mLast" style="font-size:16px">—</div></div>
         </div>
       </section>
     </aside>
@@ -123,6 +137,34 @@
   var TOKEN = "{{TOKEN}}";
   var $=function(id){return document.getElementById(id)};
   var feed=$("feed"), mode="story", n=0, cost=0, tin=0, tout=0;
+  var reduce=matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  // subsystem activity chips
+  var SUBS=[["llm","🧠","LLM"],["retrieval","🔍","Retrieval"],["tool","🔧","Tools"],["mcp","🔌","MCP"],
+            ["memory","🗃","Memory"],["graph","🕸","Graph"],["loader","📄","Loaders"],["embed","🧬","Embeddings"]];
+  var chips={};
+  SUBS.forEach(function(s){
+    var el=document.createElement("div"); el.className="chip"; el.dataset.k=s[0];
+    el.innerHTML='<div class="top"><span class="em">'+s[1]+'</span><span class="n" id="c_'+s[0]+'">0</span></div><div class="lab">'+s[2]+'</div>';
+    $("activity").appendChild(el); chips[s[0]]={el:el,c:0};
+  });
+  function subOf(ev){
+    var k=(ev.kind||ev.name||"").toLowerCase(); var a=ev.attributes||{};
+    if(k.indexOf("tool")>-1) return (String(a.tool||"").indexOf("mcp")===0)?"mcp":"tool";
+    if(k.indexOf("llm")>-1||a.model) return "llm";
+    if(k.indexOf("embed")>-1) return "embed";
+    if(k.indexOf("memory")>-1) return "memory";
+    if(k.indexOf("graph")>-1||k.indexOf("mesh")>-1) return "graph";
+    if(k.indexOf("loader")>-1) return "loader";
+    if(k.indexOf("retriev")>-1||k.indexOf("search")>-1||k.indexOf("vector")>-1) return "retrieval";
+    return null;
+  }
+  function bump(sub){
+    var c=chips[sub]; if(!c) return; c.c++; $("c_"+sub).textContent=c.c;
+    c.el.classList.add("lit"); c.el.classList.add("hot");
+    if(!reduce) setTimeout(function(){c.el.classList.remove("hot")},450);
+    else c.el.classList.remove("hot");
+  }
 
   $("mStory").onclick=function(){setMode("story")};
   $("mTrace").onclick=function(){setMode("trace")};
@@ -130,56 +172,54 @@
     feed.classList.toggle("trace",m==="trace");
     [].slice.call(feed.querySelectorAll(".ev")).forEach(function(el){el.querySelector(".t").innerHTML=m==="story"?el.dataset.story:el.dataset.trace;});}
 
-  var ICONS={span:"◆",llm:"🧠","llm.call":"🧠",retrieval:"🔍","retriever.search":"🔍",tool:"🔧","tool.call":"🔧",mcp:"🔌","memory.read":"🗃","memory.write":"🗃",memory:"🗃","db.query":"🗃","graph.query":"🕸","graph.ingest":"🕸",graph:"🕸","mesh.query":"🪢","mesh.ingest":"🪢",mesh:"🪢","loader.load":"📄",loader:"📄","embeddings.embed":"🧬",embeddings:"🧬",agent:"🤖",error:"⚠️","run.complete":"✅"};
-  function iconFor(ev){ var k=(ev.kind||ev.name||"").toLowerCase();
-    for(var key in ICONS){ if(k.indexOf(key)>-1) return ICONS[key]; } return "◆"; }
+  var ICONS={span:"◆","llm.call":"🧠",llm:"🧠","retriever.search":"🔍",retrieval:"🔍","tool.call":"🔧",tool:"🔧",mcp:"🔌",
+    "memory.read":"🗃","memory.write":"🗃",memory:"🗃","db.query":"🗃","graph.query":"🕸","graph.ingest":"🕸",graph:"🕸",
+    "mesh.query":"🪢","mesh.ingest":"🪢",mesh:"🪢","loader.load":"📄",loader:"📄","embeddings.embed":"🧬",embeddings:"🧬","run.complete":"✅"};
+  function iconFor(ev){var k=(ev.kind||ev.name||"").toLowerCase();for(var key in ICONS){if(k.indexOf(key)>-1)return ICONS[key];}
+    return (k.indexOf("search")>-1?"🔍":"◆");}
   function esc(s){return String(s==null?"":s).replace(/[&<>]/g,function(c){return{"&":"&amp;","<":"&lt;",">":"&gt;"}[c]});}
 
   function story(ev){
-    var a=ev.attributes||{};
-    var kind=(ev.kind||ev.name||"event")+"";
-    var name=ev.name||ev.kind||"event";
-    var k=kind.toLowerCase();
+    var a=ev.attributes||{}; var name=ev.name||ev.kind||"event"; var k=(ev.kind||name+"").toLowerCase();
     var dur=ev.duration_ms!=null?(" · "+Math.round(ev.duration_ms)+"ms"):"";
-    if(k.indexOf("retriev")>-1) return "Retrieved <b>"+(a.hits||a.k||"?")+"</b> passages"+dur;
-    if(k.indexOf("memory.write")>-1) return "Saved to memory"+dur;
-    if(k.indexOf("memory.read")>-1||k.indexOf("memory")>-1) return "Read from memory / DB"+dur;
-    if(k.indexOf("mesh.ingest")>-1) return "Ingested into the knowledge mesh"+dur;
-    if(k.indexOf("mesh")>-1) return "Queried the knowledge mesh"+dur;
+    if(k.indexOf("retriev")>-1||k.indexOf("search")>-1) return "Retrieved <b>"+(a.hits||a.k||"top")+"</b> passages"+dur;
+    if(k.indexOf("memory.write")>-1) return "Saved to memory / DB"+dur;
+    if(k.indexOf("memory")>-1) return "Read from memory / DB"+dur;
+    if(k.indexOf("mesh")>-1) return "Knowledge mesh"+dur;
+    if(k.indexOf("graph.ingest")>-1) return "Wrote to the knowledge graph"+dur;
+    if(k.indexOf("graph")>-1) return "Queried the knowledge graph"+dur;
+    if(k.indexOf("tool")>-1) return "Tool <code>"+esc(a.tool||name)+"</code>"+(a.operation?(" ("+esc(a.operation)+")"):"")+dur;
+    if(k.indexOf("llm")>-1||a.model) return "Thinking with <code>"+esc(a.model||"llm")+"</code>"+dur;
     if(k.indexOf("loader")>-1) return "Loaded documents with <code>"+esc(a.loader||"loader")+"</code>"+dur;
     if(k.indexOf("embed")>-1) return "Embedded text"+dur;
-    if(k.indexOf("graph.ingest")>-1) return "Wrote to the knowledge graph <code>"+esc(a.graph||a.backend||"")+"</code>"+dur;
-    if(k.indexOf("graph")>-1) return "Queried the knowledge graph <code>"+esc(a.graph||a.backend||"")+"</code>"+dur;
-    if(k.indexOf("tool")>-1) return "Tool <code>"+esc(a.tool||a.name||name)+"</code>"+(a.operation?(" ("+esc(a.operation)+")"):"")+dur;
-    if(k.indexOf("llm")>-1||a.model) return "Thinking with <code>"+esc(a.model||"llm")+"</code>"+dur;
     return "<b>"+esc(name)+"</b>"+dur+(ev.status&&ev.status!=="ok"?(" — "+esc(ev.status)):"");
   }
-  function trace(ev){ var a=ev.attributes||{}; var bits=[ev.name||ev.kind];
-    Object.keys(a).slice(0,6).forEach(function(k){bits.push(k+"="+JSON.stringify(a[k]));});
-    if(ev.duration_ms!=null)bits.push(Math.round(ev.duration_ms)+"ms");
-    return esc(bits.join(" ")); }
+  function trace(ev){var a=ev.attributes||{};var bits=[ev.name||ev.kind];
+    Object.keys(a).slice(0,6).forEach(function(kk){bits.push(kk+"="+JSON.stringify(a[kk]));});
+    if(ev.duration_ms!=null)bits.push(Math.round(ev.duration_ms)+"ms");return esc(bits.join(" "));}
 
   function render(ev){
     var e=$("empty"); if(e)e.remove();
     var a=ev.attributes||{};
-    var kind=(ev.status==="error"?"err":"");
-    var el=document.createElement("div"); el.className="ev "+kind;
+    var el=document.createElement("div"); el.className="ev "+(ev.status==="error"?"err":"");
     el.dataset.story=story(ev); el.dataset.trace=trace(ev);
     var meta=[];
     if(a.model)meta.push("<b>model</b> "+esc(a.model));
-    if(a.provider)meta.push("<b>provider</b> "+esc(a.provider));
+    if(a.tool)meta.push("<b>tool</b> "+esc(a.tool));
     if(ev.duration_ms!=null)meta.push("<b>took</b> "+Math.round(ev.duration_ms)+"ms");
     if(ev.status&&ev.status!=="ok")meta.push("<b>status</b> "+esc(ev.status));
     el.innerHTML='<div class="ic">'+iconFor(ev)+'</div><div><div class="t">'+
       (mode==="story"?el.dataset.story:el.dataset.trace)+'</div>'+
       (meta.length?'<div class="meta">'+meta.join('<span style="opacity:.4">·</span> ')+'</div>':'')+'</div>';
     feed.insertBefore(el,feed.firstChild);
-    n++; $("evCount").textContent=n+(n===1?" event":" events"); $("mEvents").textContent=n;
+    while(feed.children.length>60) feed.removeChild(feed.lastChild);
+    n++; $("evCount").textContent=n+(n===1?" event":" events"); $("mEvents").textContent=n.toLocaleString();
     $("mLast").textContent=(ev.name||ev.kind||"—");
-
+    var sub=subOf(ev); if(sub) bump(sub);
     var c=a.cost_usd||a.cost||0; if(c){cost+=Number(c);$("mCost").textContent="$"+cost.toFixed(4);}
     if(a.tokens_in||a.prompt_tokens){tin+=Number(a.tokens_in||a.prompt_tokens);$("mTokIn").textContent=tin.toLocaleString();}
     if(a.tokens_out||a.completion_tokens){tout+=Number(a.tokens_out||a.completion_tokens);$("mTokOut").textContent=tout.toLocaleString();}
+    $("mTok").textContent=(tin+tout).toLocaleString();
   }
 
   function setStatus(on,txt){var s=$("status");s.classList.toggle("on",on);$("statusText").textContent=txt;}


### PR DESCRIPTION
Upgrades the served SynapseKit Live dashboard from the basic P2 MVP so it's presentation/recording-ready:

- **Subsystem activity strip** — 8 chips (LLM, Retrieval, Tools, MCP, Memory, Graph, Loaders, Embeddings) that light up + count as their events stream. Everything-at-a-glance.
- Bigger cost + combined/in/out token meters, capped feed (last 60), general polish.
- Still one self-contained file, **0 dependencies**, wired to the real event stream (Story/Trace toggle intact).

17 live tests pass; served HTML verified (token injected, activity strip present).