### PR TITLE
feat(live): equal-height dashboard layout + latency sparkline

### DIFF
--- a/src/synapsekit/live/dashboard.html
+++ b/src/synapsekit/live/dashboard.html
@@ -5,79 +5,86 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>SynapseKit Live</title>
 <style>
-  :root {
-    --bg:#F4F7FA; --panel:#fff; --panel-2:#FBFCFE; --line:#E8ECF2; --line-2:#DBE1EA;
-    --ink:#101828; --ink-2:#364152; --muted:#667085; --faint:#98A2B3;
-    --brand:#16A34A; --brand-2:#22C55E; --brand-ink:#05603A; --brand-soft:#E9F9EF;
-    --warn:#B54708; --warn-soft:#FEF0E6; --crit:#D92D20; --gold:#B54708;
-    --shadow:0 1px 2px rgba(16,24,40,.04),0 8px 24px rgba(16,24,40,.06);
+  :root{
+    --bg:#EEF2F7;--panel:#fff;--panel-2:#FBFCFE;--line:#E6EAF1;--line-2:#DBE1EA;
+    --ink:#0F1728;--ink-2:#364152;--muted:#667085;--faint:#98A2B3;
+    --brand:#16A34A;--brand-2:#22C55E;--brand-ink:#05603A;--brand-soft:#E9F9EF;
+    --warn:#B54708;--crit:#D92D20;--gold:#B54708;
+    --shadow:0 1px 2px rgba(16,24,40,.05),0 10px 30px rgba(16,24,40,.07);
     --sans:ui-sans-serif,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
     --mono:ui-monospace,"SF Mono","JetBrains Mono",Menlo,Consolas,monospace;
   }
   *{box-sizing:border-box}
-  body{margin:0;min-height:100vh;font-family:var(--sans);color:var(--ink);line-height:1.5;
-    -webkit-font-smoothing:antialiased;
-    background:radial-gradient(820px 480px at 88% -8%,#E9F9EF88,transparent 70%),
-      radial-gradient(720px 480px at -4% 108%,#EAF1FB88,transparent 70%),var(--bg);}
-  .wrap{max-width:1200px;margin:0 auto;padding:20px 22px 40px}
-  header{display:flex;align-items:center;gap:16px;padding:10px 4px 16px;flex-wrap:wrap}
-  .brand{display:flex;align-items:center;gap:11px}
-  .brand svg{width:32px;height:32px;display:block}
-  .brand b{font-weight:680;font-size:17px;letter-spacing:.2px}
-  .live-tag{font-family:var(--mono);font-size:10.5px;color:var(--muted);text-transform:uppercase;letter-spacing:1.4px;padding-top:2px;display:flex;align-items:center;gap:6px;font-weight:600}
+  html,body{height:100%}
+  body{margin:0;font-family:var(--sans);color:var(--ink);line-height:1.5;-webkit-font-smoothing:antialiased;
+    background:radial-gradient(900px 520px at 90% -12%,#E4F7EC,transparent 68%),
+      radial-gradient(760px 520px at -6% 112%,#E7EEFA,transparent 68%),var(--bg);}
+  .wrap{max-width:1220px;margin:0 auto;padding:20px 22px 34px;min-height:100%;display:flex;flex-direction:column}
+  header{display:flex;align-items:center;gap:16px;padding:8px 4px 16px;flex-wrap:wrap}
+  .brand{display:flex;align-items:center;gap:12px}
+  .brand svg{width:34px;height:34px;display:block}
+  .brand b{font-weight:700;font-size:18px;letter-spacing:-.1px}
+  .live-tag{font-family:var(--mono);font-size:10.5px;color:var(--muted);text-transform:uppercase;letter-spacing:1.4px;padding-top:3px;display:flex;align-items:center;gap:6px;font-weight:600}
   .live-tag.on{color:var(--brand)}
   .pulse{width:7px;height:7px;border-radius:50%;background:var(--faint)}
   .live-tag.on .pulse{background:var(--brand);animation:pulse 2.2s infinite}
   @keyframes pulse{0%{box-shadow:0 0 0 0 #16A34A44}70%{box-shadow:0 0 0 7px #16A34A00}100%{box-shadow:0 0 0 0 #16A34A00}}
-  .runmeta{margin-left:auto;display:flex;align-items:center;gap:14px;font-family:var(--mono);font-size:11.5px;color:var(--muted);flex-wrap:wrap}
-  .dep-badge{font-family:var(--mono);font-size:10.5px;font-weight:600;color:var(--brand-ink);border:1px solid #ABE5C3;background:var(--brand-soft);padding:5px 10px;border-radius:999px;white-space:nowrap}
-  .seg{display:inline-flex;border:1px solid var(--line-2);border-radius:999px;padding:3px;background:var(--panel-2)}
-  .seg button{font:inherit;font-size:12.5px;font-weight:550;color:var(--muted);background:none;border:0;cursor:pointer;padding:5px 14px;border-radius:999px;transition:.18s}
-  .seg button[aria-pressed="true"]{background:var(--brand);color:#fff;box-shadow:0 1px 2px #05603a33}
+  .runmeta{margin-left:auto;display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .dep-badge{font-family:var(--mono);font-size:10.5px;font-weight:600;color:var(--brand-ink);border:1px solid #ABE5C3;background:var(--brand-soft);padding:6px 11px;border-radius:999px;white-space:nowrap}
+  .seg{display:inline-flex;border:1px solid var(--line-2);border-radius:999px;padding:3px;background:var(--panel);box-shadow:var(--shadow)}
+  .seg button{font:inherit;font-size:12.5px;font-weight:600;color:var(--muted);background:none;border:0;cursor:pointer;padding:6px 15px;border-radius:999px;transition:.18s}
+  .seg button[aria-pressed="true"]{background:var(--brand);color:#fff;box-shadow:0 1px 3px #05603a44}
   .seg button:focus-visible{outline:2px solid var(--brand);outline-offset:2px}
 
-  /* subsystem activity strip */
-  .activity{display:grid;grid-template-columns:repeat(8,1fr);gap:10px;margin:6px 0 16px}
-  @media(max-width:820px){.activity{grid-template-columns:repeat(4,1fr)}}
-  .chip{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:11px 12px;box-shadow:var(--shadow);transition:border-color .3s,transform .12s,box-shadow .3s}
+  .activity{display:grid;grid-template-columns:repeat(8,1fr);gap:11px;margin:2px 0 16px}
+  @media(max-width:860px){.activity{grid-template-columns:repeat(4,1fr)}}
+  .chip{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:12px 13px;box-shadow:var(--shadow);transition:border-color .3s,transform .12s,box-shadow .3s}
   .chip .top{display:flex;align-items:center;justify-content:space-between}
-  .chip .em{font-size:16px;filter:grayscale(.5);opacity:.7;transition:.3s}
-  .chip .n{font-family:var(--mono);font-size:16px;font-weight:680;font-variant-numeric:tabular-nums;color:var(--ink)}
-  .chip .lab{font-family:var(--mono);font-size:9.5px;text-transform:uppercase;letter-spacing:.6px;color:var(--faint);margin-top:5px;font-weight:600}
-  .chip.lit{border-color:#ABE5C3}
-  .chip.lit .em{filter:none;opacity:1}
-  .chip.lit .lab{color:var(--brand-ink)}
-  .chip.hot{border-color:var(--brand);box-shadow:0 0 0 3px #16A34A1f,var(--shadow);transform:translateY(-2px)}
+  .chip .em{font-size:17px;filter:grayscale(.55);opacity:.65;transition:.3s}
+  .chip .n{font-family:var(--mono);font-size:17px;font-weight:700;font-variant-numeric:tabular-nums;color:var(--ink)}
+  .chip .lab{font-family:var(--mono);font-size:9.5px;text-transform:uppercase;letter-spacing:.7px;color:var(--faint);margin-top:6px;font-weight:600}
+  .chip.lit{border-color:#ABE5C3}.chip.lit .em{filter:none;opacity:1}.chip.lit .lab{color:var(--brand-ink)}
+  .chip.hot{border-color:var(--brand);box-shadow:0 0 0 3px #16A34A22,var(--shadow);transform:translateY(-3px)}
 
-  .grid{display:grid;gap:16px;grid-template-columns:1.7fr .95fr}
-  @media(max-width:820px){.grid{grid-template-columns:1fr}}
-  .panel{background:var(--panel);border:1px solid var(--line);border-radius:14px;box-shadow:var(--shadow)}
-  .panel>h2{margin:0;padding:13px 16px;font-size:11px;font-weight:680;text-transform:uppercase;letter-spacing:1.5px;color:var(--muted);border-bottom:1px solid var(--line);display:flex;align-items:center;gap:9px}
+  .grid{display:grid;gap:16px;grid-template-columns:1.7fr .92fr;align-items:stretch;flex:1;min-height:520px}
+  @media(max-width:860px){.grid{grid-template-columns:1fr}.side,.feedpanel{height:auto!important}.feedpanel{height:60vh!important}}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:16px;box-shadow:var(--shadow)}
+  .panel>h2{margin:0;padding:14px 17px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:1.6px;color:var(--muted);border-bottom:1px solid var(--line);display:flex;align-items:center;gap:9px}
   .panel>h2 .count{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--faint);font-weight:500}
-  .feed{max-height:560px;overflow-y:auto;padding:6px 6px 10px}
-  .empty{padding:52px 20px;text-align:center;color:var(--faint);font-size:13.5px}
-  .empty .big{font-size:30px;margin-bottom:10px;opacity:.6}
-  .ev{display:grid;grid-template-columns:26px 1fr;gap:12px;padding:12px 12px;border-radius:11px;margin:2px 4px;animation:slidein .35s cubic-bezier(.2,.7,.3,1)}
+
+  .feedpanel{display:flex;flex-direction:column;min-height:0}
+  .feed{flex:1;min-height:0;overflow-y:auto;padding:6px 6px 10px}
+  .empty{padding:60px 20px;text-align:center;color:var(--faint);font-size:13.5px}
+  .empty .big{font-size:34px;margin-bottom:12px;opacity:.55}
+  .ev{display:grid;grid-template-columns:28px 1fr;gap:12px;padding:12px 13px;border-radius:12px;margin:2px 5px;animation:slidein .35s cubic-bezier(.2,.7,.3,1)}
   @keyframes slidein{from{opacity:0;transform:translateY(-7px)}to{opacity:1;transform:none}}
-  .ev:hover{background:#F5F8FB}
-  .ev .ic{width:26px;height:26px;border-radius:8px;display:grid;place-items:center;font-size:13px;margin-top:1px;background:var(--brand-soft);border:1px solid #C7EED6}
+  .ev:hover{background:#F4F8FB}
+  .ev .ic{width:28px;height:28px;border-radius:9px;display:grid;place-items:center;font-size:14px;margin-top:1px;background:var(--brand-soft);border:1px solid #C7EED6}
   .ev.err .ic{background:#FEECEB;border-color:#F5B5B0}
   .ev .t{font-size:14px;color:var(--ink-2);line-height:1.45}
-  .ev .t b{color:var(--ink);font-weight:680}
-  .ev .t code{font-family:var(--mono);font-size:12px;background:#EEF2F7;padding:1px 5px;border-radius:5px;color:#344054}
+  .ev .t b{color:var(--ink);font-weight:700}
+  .ev .t code{font-family:var(--mono);font-size:12px;background:#EEF2F7;padding:1px 6px;border-radius:6px;color:#344054}
   .ev .meta{font-family:var(--mono);font-size:10.5px;color:var(--faint);margin-top:5px;display:flex;gap:10px;flex-wrap:wrap}
   .ev .meta b{color:var(--muted);font-weight:600}
   .feed.trace .ev .t{font-family:var(--mono);font-size:12px;color:#475467;word-break:break-word}
-  .col-c{display:flex;flex-direction:column;gap:16px}
-  .meters{display:grid;grid-template-columns:1fr 1fr;gap:12px;padding:14px}
-  .meter{background:var(--panel-2);border:1px solid var(--line);border-radius:11px;padding:13px 14px}
+
+  .side{display:flex;flex-direction:column;min-height:0}
+  .side .panel{flex:1;display:flex;flex-direction:column;min-height:0}
+  .meters{display:grid;grid-template-columns:1fr 1fr;gap:11px;padding:14px}
+  .meter{background:var(--panel-2);border:1px solid var(--line);border-radius:12px;padding:13px 14px}
   .meter .lab{font-family:var(--mono);font-size:9.5px;text-transform:uppercase;letter-spacing:.8px;color:var(--faint);font-weight:600}
-  .meter .val{font-family:var(--mono);font-size:23px;font-weight:680;margin-top:5px;font-variant-numeric:tabular-nums;letter-spacing:-.5px}
-  .meter.big{grid-column:1/-1}
-  .meter.big .val{font-size:30px}
+  .meter .val{font-family:var(--mono);font-size:22px;font-weight:700;margin-top:5px;font-variant-numeric:tabular-nums;letter-spacing:-.6px;color:var(--ink)}
+  .meter.big{grid-column:1/-1}.meter.big .val{font-size:32px}
   .val.cost{color:var(--gold)}
-  .val.live{color:var(--brand)}
-  .foot{margin-top:22px;text-align:center;font-family:var(--mono);font-size:11px;color:var(--faint)}
+  .chart{flex:1;min-height:120px;display:flex;flex-direction:column;padding:12px 16px 8px;border-top:1px solid var(--line)}
+  .chart .lab{font-family:var(--mono);font-size:9.5px;text-transform:uppercase;letter-spacing:.8px;color:var(--faint);font-weight:600;display:flex;justify-content:space-between}
+  .spark{flex:1;display:flex;align-items:flex-end;gap:3px;margin-top:10px;min-height:60px}
+  .spark > i{flex:1;min-width:2px;background:linear-gradient(180deg,var(--brand-2),#16A34A22);border-radius:3px 3px 0 0;min-height:3px;transition:height .3s}
+  .spark > i.slow{background:linear-gradient(180deg,#F2B33D,#F2B33D22)}
+  .laststep{padding:11px 16px;border-top:1px solid var(--line);font-family:var(--mono);font-size:11.5px;color:var(--muted);display:flex;gap:8px;align-items:center}
+  .laststep b{color:var(--ink);font-weight:600}
+
+  .foot{margin-top:18px;text-align:center;font-family:var(--mono);font-size:11px;color:var(--faint)}
   .foot b{color:var(--brand);font-weight:600}
   @media(prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
 </style>
@@ -108,13 +115,13 @@
   <div class="activity" id="activity"></div>
 
   <div class="grid">
-    <section class="panel">
+    <section class="panel feedpanel">
       <h2>Live activity <span class="count" id="evCount">0 events</span></h2>
       <div class="feed" id="feed" aria-live="polite">
-        <div class="empty" id="empty"><div class="big">◇</div>Waiting for a SynapseKit run…<br>Execute an agent, RAG query, tool, or graph and it appears here live.</div>
+        <div class="empty" id="empty"><div class="big">◇</div>Waiting for a SynapseKit run…<br>Execute an agent, RAG query, tool, or graph and it streams here live.</div>
       </div>
     </section>
-    <aside class="col-c">
+    <aside class="side">
       <section class="panel">
         <h2>Telemetry</h2>
         <div class="meters">
@@ -123,8 +130,12 @@
           <div class="meter"><div class="lab">Tokens</div><div class="val" id="mTok">0</div></div>
           <div class="meter"><div class="lab">Tokens in</div><div class="val" id="mTokIn">0</div></div>
           <div class="meter"><div class="lab">Tokens out</div><div class="val" id="mTokOut">0</div></div>
-          <div class="meter big"><div class="lab">Last step</div><div class="val" id="mLast" style="font-size:16px">—</div></div>
         </div>
+        <div class="chart">
+          <div class="lab"><span>Latency per step</span><span id="mLatMax">0 ms</span></div>
+          <div class="spark" id="spark"></div>
+        </div>
+        <div class="laststep">Last step: <b id="mLast">—</b></div>
       </section>
     </aside>
   </div>
@@ -136,38 +147,26 @@
   "use strict";
   var TOKEN = "{{TOKEN}}";
   var $=function(id){return document.getElementById(id)};
-  var feed=$("feed"), mode="story", n=0, cost=0, tin=0, tout=0;
+  var feed=$("feed"), spark=$("spark"), mode="story", n=0, cost=0, tin=0, tout=0, latMax=1;
   var reduce=matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-  // subsystem activity chips
   var SUBS=[["llm","🧠","LLM"],["retrieval","🔍","Retrieval"],["tool","🔧","Tools"],["mcp","🔌","MCP"],
             ["memory","🗃","Memory"],["graph","🕸","Graph"],["loader","📄","Loaders"],["embed","🧬","Embeddings"]];
   var chips={};
   SUBS.forEach(function(s){
-    var el=document.createElement("div"); el.className="chip"; el.dataset.k=s[0];
+    var el=document.createElement("div"); el.className="chip";
     el.innerHTML='<div class="top"><span class="em">'+s[1]+'</span><span class="n" id="c_'+s[0]+'">0</span></div><div class="lab">'+s[2]+'</div>';
     $("activity").appendChild(el); chips[s[0]]={el:el,c:0};
   });
-  function subOf(ev){
-    var k=(ev.kind||ev.name||"").toLowerCase(); var a=ev.attributes||{};
-    if(k.indexOf("tool")>-1) return (String(a.tool||"").indexOf("mcp")===0)?"mcp":"tool";
-    if(k.indexOf("llm")>-1||a.model) return "llm";
-    if(k.indexOf("embed")>-1) return "embed";
-    if(k.indexOf("memory")>-1) return "memory";
-    if(k.indexOf("graph")>-1||k.indexOf("mesh")>-1) return "graph";
-    if(k.indexOf("loader")>-1) return "loader";
-    if(k.indexOf("retriev")>-1||k.indexOf("search")>-1||k.indexOf("vector")>-1) return "retrieval";
-    return null;
-  }
-  function bump(sub){
-    var c=chips[sub]; if(!c) return; c.c++; $("c_"+sub).textContent=c.c;
-    c.el.classList.add("lit"); c.el.classList.add("hot");
-    if(!reduce) setTimeout(function(){c.el.classList.remove("hot")},450);
-    else c.el.classList.remove("hot");
-  }
+  function subOf(ev){var k=(ev.kind||ev.name||"").toLowerCase();var a=ev.attributes||{};
+    if(k.indexOf("tool")>-1)return String(a.tool||"").indexOf("mcp")===0?"mcp":"tool";
+    if(k.indexOf("llm")>-1||a.model)return "llm";if(k.indexOf("embed")>-1)return "embed";if(k.indexOf("memory")>-1)return "memory";
+    if(k.indexOf("graph")>-1||k.indexOf("mesh")>-1)return "graph";if(k.indexOf("loader")>-1)return "loader";
+    if(k.indexOf("retriev")>-1||k.indexOf("search")>-1||k.indexOf("vector")>-1)return "retrieval";return null;}
+  function bump(sub){var c=chips[sub];if(!c)return;c.c++;$("c_"+sub).textContent=c.c;
+    c.el.classList.add("lit");c.el.classList.add("hot");if(!reduce)setTimeout(function(){c.el.classList.remove("hot")},450);else c.el.classList.remove("hot");}
 
-  $("mStory").onclick=function(){setMode("story")};
-  $("mTrace").onclick=function(){setMode("trace")};
+  $("mStory").onclick=function(){setMode("story")};$("mTrace").onclick=function(){setMode("trace")};
   function setMode(m){mode=m;$("mStory").setAttribute("aria-pressed",m==="story");$("mTrace").setAttribute("aria-pressed",m==="trace");
     feed.classList.toggle("trace",m==="trace");
     [].slice.call(feed.querySelectorAll(".ev")).forEach(function(el){el.querySelector(".t").innerHTML=m==="story"?el.dataset.story:el.dataset.trace;});}
@@ -175,28 +174,33 @@
   var ICONS={span:"◆","llm.call":"🧠",llm:"🧠","retriever.search":"🔍",retrieval:"🔍","tool.call":"🔧",tool:"🔧",mcp:"🔌",
     "memory.read":"🗃","memory.write":"🗃",memory:"🗃","db.query":"🗃","graph.query":"🕸","graph.ingest":"🕸",graph:"🕸",
     "mesh.query":"🪢","mesh.ingest":"🪢",mesh:"🪢","loader.load":"📄",loader:"📄","embeddings.embed":"🧬",embeddings:"🧬","run.complete":"✅"};
-  function iconFor(ev){var k=(ev.kind||ev.name||"").toLowerCase();for(var key in ICONS){if(k.indexOf(key)>-1)return ICONS[key];}
-    return (k.indexOf("search")>-1?"🔍":"◆");}
+  function iconFor(ev){var k=(ev.kind||ev.name||"").toLowerCase();for(var key in ICONS){if(k.indexOf(key)>-1)return ICONS[key];}return (k.indexOf("search")>-1?"🔍":"◆");}
   function esc(s){return String(s==null?"":s).replace(/[&<>]/g,function(c){return{"&":"&amp;","<":"&lt;",">":"&gt;"}[c]});}
 
-  function story(ev){
-    var a=ev.attributes||{}; var name=ev.name||ev.kind||"event"; var k=(ev.kind||name+"").toLowerCase();
+  function story(ev){var a=ev.attributes||{};var name=ev.name||ev.kind||"event";var k=(ev.kind||name+"").toLowerCase();
     var dur=ev.duration_ms!=null?(" · "+Math.round(ev.duration_ms)+"ms"):"";
-    if(k.indexOf("retriev")>-1||k.indexOf("search")>-1) return "Retrieved <b>"+(a.hits||a.k||"top")+"</b> passages"+dur;
-    if(k.indexOf("memory.write")>-1) return "Saved to memory / DB"+dur;
-    if(k.indexOf("memory")>-1) return "Read from memory / DB"+dur;
-    if(k.indexOf("mesh")>-1) return "Knowledge mesh"+dur;
-    if(k.indexOf("graph.ingest")>-1) return "Wrote to the knowledge graph"+dur;
-    if(k.indexOf("graph")>-1) return "Queried the knowledge graph"+dur;
-    if(k.indexOf("tool")>-1) return "Tool <code>"+esc(a.tool||name)+"</code>"+(a.operation?(" ("+esc(a.operation)+")"):"")+dur;
-    if(k.indexOf("llm")>-1||a.model) return "Thinking with <code>"+esc(a.model||"llm")+"</code>"+dur;
-    if(k.indexOf("loader")>-1) return "Loaded documents with <code>"+esc(a.loader||"loader")+"</code>"+dur;
-    if(k.indexOf("embed")>-1) return "Embedded text"+dur;
-    return "<b>"+esc(name)+"</b>"+dur+(ev.status&&ev.status!=="ok"?(" — "+esc(ev.status)):"");
-  }
+    if(k.indexOf("retriev")>-1||k.indexOf("search")>-1)return "Retrieved <b>"+(a.hits||a.k||"top")+"</b> passages"+dur;
+    if(k.indexOf("memory.write")>-1)return "Saved to memory / DB"+dur;
+    if(k.indexOf("memory")>-1)return "Read from memory / DB"+dur;
+    if(k.indexOf("mesh")>-1)return "Knowledge mesh"+dur;
+    if(k.indexOf("graph.ingest")>-1)return "Wrote to the knowledge graph"+dur;
+    if(k.indexOf("graph")>-1)return "Queried the knowledge graph"+dur;
+    if(k.indexOf("tool")>-1)return "Tool <code>"+esc(a.tool||name)+"</code>"+(a.operation?(" ("+esc(a.operation)+")"):"")+dur;
+    if(k.indexOf("llm")>-1||a.model)return "Thinking with <code>"+esc(a.model||"llm")+"</code>"+dur;
+    if(k.indexOf("loader")>-1)return "Loaded documents with <code>"+esc(a.loader||"loader")+"</code>"+dur;
+    if(k.indexOf("embed")>-1)return "Embedded text"+dur;
+    return "<b>"+esc(name)+"</b>"+dur+(ev.status&&ev.status!=="ok"?(" — "+esc(ev.status)):"");}
   function trace(ev){var a=ev.attributes||{};var bits=[ev.name||ev.kind];
     Object.keys(a).slice(0,6).forEach(function(kk){bits.push(kk+"="+JSON.stringify(a[kk]));});
     if(ev.duration_ms!=null)bits.push(Math.round(ev.duration_ms)+"ms");return esc(bits.join(" "));}
+
+  function addSpark(ms){
+    var b=document.createElement("i"); var v=Math.max(1,Math.round(ms||0));
+    latMax=Math.max(latMax,v); b.dataset.v=v; if(v>300)b.className="slow";
+    spark.appendChild(b); while(spark.children.length>36) spark.removeChild(spark.firstChild);
+    $("mLatMax").textContent=latMax+" ms";
+    [].slice.call(spark.children).forEach(function(x){x.style.height=(6+Math.round(Math.log10(1+ (+x.dataset.v))/Math.log10(1+latMax)*54))+"px";});
+  }
 
   function render(ev){
     var e=$("empty"); if(e)e.remove();
@@ -216,6 +220,7 @@
     n++; $("evCount").textContent=n+(n===1?" event":" events"); $("mEvents").textContent=n.toLocaleString();
     $("mLast").textContent=(ev.name||ev.kind||"—");
     var sub=subOf(ev); if(sub) bump(sub);
+    addSpark(ev.duration_ms);
     var c=a.cost_usd||a.cost||0; if(c){cost+=Number(c);$("mCost").textContent="$"+cost.toFixed(4);}
     if(a.tokens_in||a.prompt_tokens){tin+=Number(a.tokens_in||a.prompt_tokens);$("mTokIn").textContent=tin.toLocaleString();}
     if(a.tokens_out||a.completion_tokens){tout+=Number(a.tokens_out||a.completion_tokens);$("mTokOut").textContent=tout.toLocaleString();}


### PR DESCRIPTION
Addresses the layout feedback (RHS shorter than LHS) and enhances the look:

- **Equal-height columns** — the grid stretches both sides; the feed scrolls inside a flex panel and the telemetry panel fills the same height.
- **Live latency sparkline** — a log-scaled bar per step (slow steps in amber) so the RHS earns its height, plus a last-step readout.
- Larger radii, softer shadows, cleaner spacing. Still one self-contained file, 0 deps, Story/Trace + activity strip intact.

17 live tests pass; served HTML verified.