### PR TITLE
feat(live): Tier 2 — budget gauge, signed audit, swarm activity

### DIFF
--- a/src/synapsekit/live/dashboard.html
+++ b/src/synapsekit/live/dashboard.html
@@ -94,6 +94,9 @@
   .meter .val{font-family:var(--mono);font-size:22px;font-weight:700;margin-top:5px;font-variant-numeric:tabular-nums;letter-spacing:-.6px;color:var(--ink)}
   .meter.big{grid-column:1/-1}.meter.big .val{font-size:32px}
   .val.cost{color:var(--gold)}
+  .gauge{height:8px;border-radius:5px;background:#EAEEF4;margin-top:10px;overflow:hidden}
+  .gauge>i{display:block;height:100%;width:0;border-radius:5px;background:linear-gradient(90deg,#22C55E,#16A34A);transition:width .4s,background .4s}
+  .gauge>i.hi{background:linear-gradient(90deg,#F2B33D,#B54708)}.gauge>i.crit{background:linear-gradient(90deg,#F97066,#D92D20)}
   .chart{flex:1;min-height:110px;display:flex;flex-direction:column;padding:12px 16px 8px;border-top:1px solid var(--line)}
   .chart .lab{font-family:var(--mono);font-size:9.5px;text-transform:uppercase;letter-spacing:.8px;color:var(--faint);font-weight:600;display:flex;justify-content:space-between}
   .spark{flex:1;display:flex;align-items:flex-end;gap:3px;margin-top:10px;min-height:56px}
@@ -145,13 +148,14 @@
           <div class="meter"><div class="lab">Tokens</div><div class="val" id="mTok">0</div></div>
           <div class="meter"><div class="lab">Tokens in</div><div class="val" id="mTokIn">0</div></div>
           <div class="meter"><div class="lab">Tokens out</div><div class="val" id="mTokOut">0</div></div>
+          <div class="meter big" id="budgetMeter" style="display:none"><div class="lab">Daily budget <span id="mBudgetTxt" style="color:var(--muted)"></span></div><div class="gauge"><i id="mBudgetBar"></i></div></div>
         </div>
         <div class="chart"><div class="lab"><span>Latency per step</span><span id="mLatMax">0 ms</span></div><div class="spark" id="spark"></div></div>
         <div class="laststep">Last step: <b id="mLast">—</b></div>
       </section>
     </aside>
   </div>
-  <div class="foot">one event bus · stdlib <b>http.server</b> + SSE · single-file UI · <b>0 new dependencies</b></div>
+  <div class="foot">one event bus · stdlib <b>http.server</b> + SSE · single-file UI · <b>0 new dependencies</b> · the same events also export to <b>Prometheus / Grafana</b> via <code>synapsekit[observe]</code></div>
 </div>
 
 <script>
@@ -191,7 +195,8 @@
 
   var ICONS={span:"◆","llm.call":"🧠","llm.generate":"🧠",llm:"🧠","retriever.search":"🔍",retrieval:"🔍","tool.call":"🔧",tool:"🔧",mcp:"🔌",
     "memory.read":"🗃","memory.write":"🗃",memory:"🗃","graph.query":"🕸","graph.ingest":"🕸",graph:"🕸",
-    "mesh.query":"🪢","mesh.ingest":"🪢",mesh:"🪢","loader.load":"📄",loader:"📄","embeddings.embed":"🧬",embeddings:"🧬",log:"🪵","run.complete":"✅"};
+    "mesh.query":"🪢","mesh.ingest":"🪢",mesh:"🪢","loader.load":"📄",loader:"📄","embeddings.embed":"🧬",embeddings:"🧬",
+    budget:"💰",audit:"🔐",swarm:"🐝",log:"🪵","run.complete":"✅"};
   function iconFor(ev){if(ev.kind==="log")return ev.level==="error"?"⛔":ev.level==="warning"?"⚠️":"🪵";
     var k=(ev.kind||ev.name||"").toLowerCase();for(var key in ICONS){if(k.indexOf(key)>-1)return ICONS[key];}return (k.indexOf("search")>-1?"🔍":"◆");}
   function esc(s){return String(s==null?"":s).replace(/[&<>]/g,function(c){return{"&":"&amp;","<":"&lt;",">":"&gt;"}[c]});}
@@ -209,6 +214,9 @@
     if(k.indexOf("llm")>-1||model(a))return "Thinking with <code>"+esc(model(a)||"llm")+"</code>"+dur;
     if(k.indexOf("loader")>-1)return "Loaded documents with <code>"+esc(a.loader||"loader")+"</code>"+dur;
     if(k.indexOf("embed")>-1)return "Embedded text"+dur;
+    if(k.indexOf("budget")>-1)return "Recorded spend"+(a.limit?(" — $"+Number(a.spent||0).toFixed(4)+" of $"+a.limit+" daily"):"")+dur;
+    if(k.indexOf("audit")>-1)return "Signed audit entry"+(a.model?(" — <code>"+esc(a.model)+"</code>"):"")+dur;
+    if(k.indexOf("swarm")>-1)return "Agent swarm auction"+dur;
     return "<b>"+esc(name)+"</b>"+dur+(ev.status&&ev.status!=="ok"?(" — "+esc(ev.status)):"");}
   function trace(ev){var a=ev.attributes||{};var bits=[ev.name||ev.kind];
     Object.keys(a).slice(0,8).forEach(function(kk){if(kk!=="traceback"&&kk!=="llm.input"&&kk!=="llm.output")bits.push(kk+"="+JSON.stringify(a[kk]));});
@@ -262,6 +270,9 @@
     var ti=a.tokens_in||a.prompt_tokens||a["llm.prompt_tokens"];if(ti){tin+=Number(ti);$("mTokIn").textContent=tin.toLocaleString();}
     var to=a.tokens_out||a.completion_tokens||a["llm.completion_tokens"];if(to){tout+=Number(to);$("mTokOut").textContent=tout.toLocaleString();}
     $("mTok").textContent=(tin+tout).toLocaleString();
+    if(ev.kind==="budget"&&a.limit){var pct=Math.min(100,(Number(a.spent||0)/Number(a.limit))*100);
+      $("budgetMeter").style.display="";var bar=$("mBudgetBar");bar.style.width=pct.toFixed(1)+"%";
+      bar.className=pct>=90?"crit":pct>=70?"hi":"";$("mBudgetTxt").textContent="$"+Number(a.spent||0).toFixed(4)+" / $"+a.limit;}
   }
 
   function setStatus(on,txt){var s=$("status");s.classList.toggle("on",on);$("statusText").textContent=txt;}

--- a/src/synapsekit/live/instrument.py
+++ b/src/synapsekit/live/instrument.py
@@ -264,7 +264,15 @@ def instrument_all() -> None:
         _patch(PrometheusMetrics, "record_swarm_win", "swarm", _const(event="win"))
 
     for step in (
-        tools, memory, world_model, property_graph, mesh, loaders, embeddings,
-        budget, audit, swarm,
+        tools,
+        memory,
+        world_model,
+        property_graph,
+        mesh,
+        loaders,
+        embeddings,
+        budget,
+        audit,
+        swarm,
     ):
         _try(step)

--- a/src/synapsekit/live/instrument.py
+++ b/src/synapsekit/live/instrument.py
@@ -228,5 +228,43 @@ def instrument_all() -> None:
 
             _patch(ONNXEmbeddings, "embed", "embeddings.embed", _const(backend="onnx"))
 
-    for step in (tools, memory, world_model, property_graph, mesh, loaders, embeddings):
+    # -- Budget guard → live budget gauge --
+    def budget() -> None:
+        from ..observability.budget_guard import BudgetGuard
+
+        _patch(
+            BudgetGuard,
+            "record_spend",
+            "budget",
+            lambda self, a, k: {
+                "spent": round(getattr(self, "_daily_spend", 0.0), 6),
+                "limit": getattr(getattr(self, "_limits", None), "daily", None),
+                "cost": (a[0] if a else k.get("cost")),
+            },
+        )
+
+    # -- Signed audit log --
+    def audit() -> None:
+        from ..observability.audit_log import AuditLog
+
+        _patch(
+            AuditLog,
+            "record",
+            "audit",
+            lambda self, a, k: {
+                "model": (a[0] if a else k.get("model")),
+                "signed": True,
+            },
+        )
+
+    # -- Agent swarm auctions --
+    def swarm() -> None:
+        from ..observability.metrics import PrometheusMetrics
+
+        _patch(PrometheusMetrics, "record_swarm_win", "swarm", _const(event="win"))
+
+    for step in (
+        tools, memory, world_model, property_graph, mesh, loaders, embeddings,
+        budget, audit, swarm,
+    ):
         _try(step)

--- a/tests/live/test_instrument.py
+++ b/tests/live/test_instrument.py
@@ -100,6 +100,20 @@ async def test_noop_when_bus_disabled() -> None:
     assert bus.history() == []  # nothing published when Live is off
 
 
+def test_budget_and_audit_publish() -> None:
+    from synapsekit.observability.audit_log import AuditLog
+    from synapsekit.observability.budget_guard import BudgetGuard, BudgetLimit
+
+    BudgetGuard(BudgetLimit(daily=5.0)).record_spend(0.0043)
+    AuditLog().record(model="claude-haiku-4-5", input_text="hi", output_text="hello", user="u1")
+    kinds = [e["kind"] for e in bus.history()]
+    assert "budget" in kinds and "audit" in kinds
+    budget = [e for e in bus.history() if e["kind"] == "budget"][-1]
+    assert budget["attributes"]["limit"] == 5.0
+    audit = [e for e in bus.history() if e["kind"] == "audit"][-1]
+    assert audit["attributes"]["model"] == "claude-haiku-4-5"
+
+
 def test_sync_loader_publishes(tmp_path) -> None:
     # Loaders are sync and share no base class — the sync wrapper covers them.
     from synapsekit.loaders import TextLoader


### PR DESCRIPTION
Second Live UI tier: fold the existing observability recorders into the dashboard (no separate instrumentation — same bus).

- 💰 **Budget** — `BudgetGuard.record_spend` → a live daily-budget gauge (green→amber→red).
- 🔐 **Audit** — `AuditLog.record` → signed audit entries in the feed.
- 🐝 **Swarm** — `record_swarm_win` → auction events.
- Footer notes the same events also export to **Prometheus/Grafana** via `synapsekit[observe]`.

20 live tests pass.