### PR TITLE
fix(symbolic): verify() checks the answer against the solver result (#911)

### DIFF
--- a/src/synapsekit/symbolic/types.py
+++ b/src/synapsekit/symbolic/types.py
@@ -1,9 +1,36 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Any, Literal, Protocol, runtime_checkable
 
 ConstraintLanguage = Literal["smtlib", "prolog", "minizinc", "sympy", "text"]
+
+_NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?")
+
+
+def _first_number(text: object) -> float | None:
+    if text is None:
+        return None
+    match = _NUMBER_RE.search(str(text).replace(",", ""))
+    return float(match.group()) if match else None
+
+
+def _answer_consistent_with_result(answer: str, result: object) -> bool:
+    """True if a numeric solver result also appears (matching) in the answer.
+
+    Only enforced when the solver produced a numeric result (e.g. SymPy math): a
+    wrong rendered answer is rejected. For non-numeric results (Z3 models, Prolog,
+    MiniZinc) we can't do a cheap numeric check, so we stay lenient rather than
+    reject answers we cannot confidently disprove.
+    """
+    expected = _first_number(result)
+    if expected is None:
+        return True
+    got = _first_number(answer)
+    return got is not None and abs(got - expected) < 1e-6
+
+
 SolverStatus = Literal["sat", "unsat", "unknown", "error"]
 UnverifiedPolicy = Literal["retry", "reject", "flag"]
 
@@ -104,8 +131,15 @@ class BaseSymbolicBackend:
         *,
         timeout_seconds: float | None = None,
     ) -> ProofTrace:
-        del constraints, answer, timeout_seconds
-        if proof.status == "sat" and proof.verified:
+        del constraints, timeout_seconds
+        result = proof.model.get("result") if proof.model else None
+        if result is None:
+            result = proof.raw_output
+        if (
+            proof.status == "sat"
+            and proof.verified
+            and _answer_consistent_with_result(answer, result)
+        ):
             return ProofTrace(
                 status="sat",
                 model=dict(proof.model),
@@ -113,12 +147,17 @@ class BaseSymbolicBackend:
                 backend=self.name,
                 verified=True,
             )
+        if proof.status == "sat" and proof.verified:
+            # Solver found a model, but the rendered answer contradicts it.
+            error = f"Rendered answer {answer!r} is inconsistent with the solver result {result!r}."
+        else:
+            error = proof.error or "Solver did not produce a satisfiable model."
         return ProofTrace(
             status=proof.status,
             model=dict(proof.model),
             raw_output=proof.raw_output,
             backend=self.name,
-            error=proof.error or "Solver did not produce a satisfiable model.",
+            error=error,
             verified=False,
         )
 

--- a/tests/symbolic/test_symbolic_backends.py
+++ b/tests/symbolic/test_symbolic_backends.py
@@ -28,6 +28,24 @@ async def test_sympy_backend_solves_expression_when_available() -> None:
 
 
 @pytest.mark.asyncio
+async def test_verify_rejects_answer_that_contradicts_solver(monkeypatch) -> None:
+    # Regression for #911: verify() must compare the rendered answer to the
+    # solver's numeric result, not just check that the model is satisfiable.
+    pytest.importorskip("sympy")
+    backend = SympyBackend()
+    constraints = ConstraintSet(language="sympy", source="47*53")
+    proof = await backend.solve(constraints)
+    assert proof.model["result"] == "2491"
+
+    correct = await backend.verify(constraints, "2491", proof)
+    assert correct.is_verified is True
+
+    wrong = await backend.verify(constraints, "2481", proof)
+    assert wrong.is_verified is False
+    assert "inconsistent" in (wrong.error or "")
+
+
+@pytest.mark.asyncio
 async def test_prolog_backend_missing_executable_is_actionable() -> None:
     backend = PrologBackend(executable="definitely-missing-swipl")
 


### PR DESCRIPTION
`BaseSymbolicBackend.verify` did `del answer` and only checked `proof.status == "sat"`, so a wrong LLM answer passed as `verified=True`. Now it compares a numeric solver result against the rendered answer and returns `verified=False` (with an explanatory error) on mismatch — making the 'LLM proposes, solver verifies' guarantee real. Non-numeric results (Z3 models, Prolog, MiniZinc) stay lenient. Regression test added; 19 symbolic tests + the neuro-symbolic gate stay green. Closes #911.