### PR TITLE
test(agents): self-evolving acceptance benchmark + CI gate (#732)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,17 @@ jobs:
       - run: uv sync --group dev --group bench
       - run: uv run pytest benchmarks/test_agent_swarm_bench.py -v
 
+  # Enforces the #732 self-evolving acceptance targets: a SelfImprovingAgent must
+  # lift its own held-out accuracy from a fallible baseline (<=50%) to >=90% over 5
+  # evolution cycles, never regressing, with every decoy candidate blocked by the gate.
+  self-evolving-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --group dev --group bench
+      - run: uv run pytest benchmarks/test_self_evolving_bench.py -v
+
   # Neuro-symbolic acceptance gate (#733): routing arithmetic through the symbolic
   # solver beats answering directly by >=25pp. Needs the `symbolic` extra (sympy).
   neuro-symbolic-gate:

--- a/benchmarks/self_evolving_bench.py
+++ b/benchmarks/self_evolving_bench.py
@@ -1,0 +1,529 @@
+"""Self-evolving agent benchmark for #732.
+
+Quantifies the core claim — *a `SelfImprovingAgent` autonomously raises its own
+accuracy over repeated evolution cycles, and the eval gate stops it from
+regressing*. One agent is driven through 5 cycles of the real
+observe → diagnose → propose → validate → canary loop:
+
+* **the task suite** is synthetic and behavioural. Answer correctness is a pure
+  function of which *directives* ("state the unit", "cite the source", "ask when
+  ambiguous", ...) appear in the system prompt the model was handed. A scripted
+  :class:`BaseLLM` complies with a directive only when it is literally present in
+  its prompt, so a prompt with no directives is measurably bad and each directive
+  the agent discovers is worth a fixed, verifiable amount of accuracy;
+* **the gate is held out**. The :class:`EvalSuite` scores candidate prompts
+  against 8 tasks the proposer never observes — it only ever sees feedback from
+  the 15 proposer-visible tasks. The agent therefore cannot grade itself;
+* **the gate is load-bearing**. From cycle 2 on the proposer also emits a
+  deliberately bad decoy candidate that strips the directives learned so far.
+  Every decoy must be *blocked* by the eval gate, which is what proves the gate
+  is doing work rather than rubber-stamping.
+
+The proposer (:class:`DirectiveProposer`) is deterministic: it clusters negative
+:class:`FeedbackSample`s by the directive governing the failing task and proposes
+the single most-implicated directive still missing from the prompt. Deterministic,
+offline, no API keys, seeded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import tempfile
+from collections import Counter
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from synapsekit.agents import (
+    AgentConfig,
+    AgentConfigPatch,
+    AgentExecutor,
+    BaseTool,
+    SelfImprovingAgent,
+    ToolResult,
+)
+from synapsekit.agents.self_improving import AgentConfigSnapshot
+from synapsekit.evaluation import EvalSuite
+from synapsekit.llm.base import BaseLLM, LLMConfig
+from synapsekit.training import FeedbackCollector, RolloutPolicy
+from synapsekit.training.types import FeedbackSample
+
+SEED = 732
+N_CYCLES = 5
+DECOY_FROM_CYCLE = 2  # cycle 1 has no directives to strip, so a decoy can't regress yet
+
+BASELINE_PROMPT = "You are a helpful assistant. Answer the user's question."
+DECOY_PROMPT = BASELINE_PROMPT + "\nBe concise and skip unnecessary boilerplate."
+
+
+@dataclass(frozen=True)
+class Directive:
+    """A behavioural instruction whose presence in the prompt fixes a task class."""
+
+    key: str
+    text: str
+
+
+# Canonical order — also the deterministic tie-break when two directives are
+# implicated in the same number of negative samples.
+D_UNITS = Directive("show_units", "Always state the unit alongside every numeric answer.")
+D_CITE = Directive("cite_source", "Always cite the source document for every factual claim.")
+D_CLARIFY = Directive(
+    "refuse_ambiguous",
+    "Refuse to guess and ask a clarifying question when the request is ambiguous.",
+)
+D_STEPS = Directive("show_work", "Show the intermediate steps before stating the final answer.")
+D_UNKNOWN = Directive(
+    "admit_unknown", "Say you do not know rather than speculating beyond the provided context."
+)
+
+DIRECTIVES: tuple[Directive, ...] = (D_UNITS, D_CITE, D_CLARIFY, D_STEPS, D_UNKNOWN)
+
+
+@dataclass(frozen=True)
+class Task:
+    """One graded task.
+
+    ``answer`` is what the model always says; ``expected`` is the behavioural
+    artefact it only adds when ``directive`` is present in its prompt. Grading is
+    ``expected in answer`` — the grader never inspects the model's internals.
+    """
+
+    task_id: str
+    question: str
+    answer: str
+    expected: str
+    directive: Directive | None
+
+
+# Tasks whose failures the proposer is allowed to observe. Counts per directive
+# are distinct (5/4/3/2/1) so "the single most-implicated missing directive" is
+# unambiguous on every cycle.
+PROPOSER_TASKS: tuple[Task, ...] = (
+    Task("p01", "What is the mass of the shipping crate?", "The mass is 12", "kilograms", D_UNITS),
+    Task(
+        "p02",
+        "How far is the depot from the warehouse?",
+        "The distance is 340",
+        "kilometres",
+        D_UNITS,
+    ),
+    Task(
+        "p03", "How long does the nightly batch job take?", "The runtime is 45", "minutes", D_UNITS
+    ),
+    Task(
+        "p04",
+        "What is the storage footprint of the archive?",
+        "The footprint is 8",
+        "gigabytes",
+        D_UNITS,
+    ),
+    Task(
+        "p05",
+        "What is the operating temperature of the unit?",
+        "The temperature is 65",
+        "degrees Celsius",
+        D_UNITS,
+    ),
+    Task(
+        "p06",
+        "What was the revenue growth last year?",
+        "Revenue grew 14 percent",
+        "(source: fy24-report)",
+        D_CITE,
+    ),
+    Task(
+        "p07",
+        "How many active customers are there?",
+        "There are 4,200 active customers",
+        "(source: crm-export)",
+        D_CITE,
+    ),
+    Task(
+        "p08",
+        "What is the current churn rate?",
+        "Churn is 3.1 percent",
+        "(source: retention-memo)",
+        D_CITE,
+    ),
+    Task(
+        "p09", "Which region grew fastest?", "EMEA grew fastest", "(source: regional-brief)", D_CITE
+    ),
+    Task(
+        "p10",
+        "Can you fix the thing for me?",
+        "Here is one possible interpretation",
+        "could you clarify",
+        D_CLARIFY,
+    ),
+    Task("p11", "Make it better.", "Here is a generic improvement", "could you clarify", D_CLARIFY),
+    Task(
+        "p12",
+        "Update the report with the new number.",
+        "Here is an updated draft",
+        "could you clarify",
+        D_CLARIFY,
+    ),
+    Task("p13", "What is 47 times 53 minus 100?", "The result is 2391", "Step 1:", D_STEPS),
+    Task(
+        "p14",
+        "If a train covers 300 km in 4 hours, what is its average speed?",
+        "The result is 75",
+        "Step 1:",
+        D_STEPS,
+    ),
+    Task(
+        "p15",
+        "What is the CEO's home address?",
+        "Looking at what I was given",
+        "I do not know",
+        D_UNKNOWN,
+    ),
+)
+
+# The gate. Never shown to the proposer. Three tasks need no directive at all,
+# which is what makes the baseline non-zero but still fallible (3/8 = 37.5%);
+# the remaining five are unlocked one per directive, so each accepted patch is
+# worth exactly +1/8 held-out accuracy.
+HELDOUT_TASKS: tuple[Task, ...] = (
+    Task("h01", "What is the capital of France?", "The capital of France is", "Paris", None),
+    Task("h02", "How many days are in a leap year?", "A leap year has", "366 days", None),
+    Task(
+        "h03", "Who wrote the play Hamlet?", "The play was written by", "William Shakespeare", None
+    ),
+    Task(
+        "h04",
+        "What is the payload limit of the delivery drone?",
+        "The payload limit is 5",
+        "kilograms",
+        D_UNITS,
+    ),
+    Task(
+        "h05",
+        "What was the gross margin in Q3?",
+        "Gross margin was 62 percent",
+        "(source: q3-financials)",
+        D_CITE,
+    ),
+    Task(
+        "h06",
+        "Sort out the numbers, please.",
+        "Here is a plausible ordering",
+        "could you clarify",
+        D_CLARIFY,
+    ),
+    Task(
+        "h07",
+        "What is 18 percent of 250, rounded to the nearest whole number?",
+        "The result is 45",
+        "Step 1:",
+        D_STEPS,
+    ),
+    Task(
+        "h08",
+        "What is the internal codename of the unreleased product?",
+        "Checking what I was given",
+        "I do not know",
+        D_UNKNOWN,
+    ),
+)
+
+ALL_TASKS: tuple[Task, ...] = PROPOSER_TASKS + HELDOUT_TASKS
+
+
+def render(system_prompt: str, question: str) -> str:
+    """Flatten a system prompt and a question into the text the model receives."""
+    return f"{system_prompt}\n\nUser: {question}"
+
+
+def graded(task: Task, answer: str) -> bool:
+    """Whether *answer* exhibits the behaviour *task* is testing for."""
+    return task.expected in answer
+
+
+class ScriptedTaskLLM(BaseLLM):
+    """A model that complies with a directive only when it is in its prompt.
+
+    It resolves which task it is answering from the question text it was handed —
+    it is driven entirely by the prompt, never by out-of-band state — and appends
+    the task's behavioural artefact only when the governing directive is present.
+    """
+
+    def __init__(self, tasks: tuple[Task, ...] = ALL_TASKS) -> None:
+        super().__init__(
+            LLMConfig(
+                provider="bench", model="scripted-directive-follower", api_key="", max_retries=0
+            )
+        )
+        self._tasks = tasks
+
+    def answer_for(self, text: str) -> str:
+        task = self._resolve(text)
+        if task is None:
+            return "I have no answer for that."
+        complies = task.directive is None or task.directive.text in text
+        return f"{task.answer} {task.expected}" if complies else task.answer
+
+    def _resolve(self, text: str) -> Task | None:
+        for task in self._tasks:
+            if task.question in text:
+                return task
+        return None
+
+    async def stream(self, prompt: str, **kw: Any) -> AsyncGenerator[str]:
+        del kw
+        yield self.answer_for(prompt)
+
+    async def _call_with_tools_impl(
+        self, messages: list[dict[str, Any]], tools: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        del tools
+        text = "\n".join(str(m.get("content") or "") for m in messages)
+        return {"content": self.answer_for(text), "tool_calls": []}
+
+
+class EchoTool(BaseTool):
+    name = "echo"
+    description = "Echo input"
+    parameters = {"type": "object", "properties": {"input": {"type": "string"}}}
+
+    async def run(self, **kwargs: Any) -> ToolResult:
+        return ToolResult(output=str(kwargs.get("input", "")))
+
+
+class DirectiveProposer:
+    """Deterministic :class:`MetaAnalyzerProtocol` implementation.
+
+    Clusters negative feedback by the directive governing the failing task and
+    proposes a ``prompt_rewrite`` adding the single most-implicated directive
+    still missing from the prompt. From ``decoy_from_cycle`` onwards it *also*
+    emits — first, so the gate has to reject it before reaching the good one — a
+    decoy that strips every directive learned so far.
+    """
+
+    def __init__(
+        self,
+        tasks: tuple[Task, ...] = PROPOSER_TASKS,
+        *,
+        decoy_from_cycle: int = DECOY_FROM_CYCLE,
+    ) -> None:
+        # Only proposer-visible questions: the held-out slice is unmappable here.
+        self._by_question = {t.question: t.directive for t in tasks if t.directive is not None}
+        self._decoy_from_cycle = decoy_from_cycle
+        self.cycle = 0
+
+    async def propose(
+        self,
+        *,
+        samples: list[FeedbackSample],
+        snapshot: AgentConfigSnapshot,
+        improvement_targets: list[str],
+    ) -> list[AgentConfigPatch]:
+        self.cycle += 1
+        if "prompt" not in improvement_targets:
+            return []
+
+        prompt = snapshot.system_prompt
+        counts: Counter[str] = Counter()
+        for sample in samples:
+            if sample.feedback != "negative":
+                continue
+            directive = self._by_question.get(sample.query)
+            if directive is None or directive.text in prompt:
+                continue
+            counts[directive.key] += 1
+
+        patches: list[AgentConfigPatch] = []
+        if self.cycle >= self._decoy_from_cycle:
+            patches.append(self._decoy())
+
+        winner = self._most_implicated(counts)
+        if winner is not None:
+            patches.append(self._adopt(prompt, winner, counts[winner.key]))
+        return patches
+
+    def _most_implicated(self, counts: Counter[str]) -> Directive | None:
+        best: Directive | None = None
+        for directive in DIRECTIVES:  # canonical order breaks ties deterministically
+            if counts[directive.key] > (counts[best.key] if best else 0):
+                best = directive
+        return best
+
+    def _adopt(self, prompt: str, directive: Directive, implicated: int) -> AgentConfigPatch:
+        return AgentConfigPatch(
+            patch_type="prompt_rewrite",
+            description=(f"Adopt '{directive.key}' — implicated in {implicated} negative samples."),
+            changes={"system_prompt": f"{prompt.rstrip()}\n- {directive.text}"},
+            metadata={
+                "source": "directive-proposer",
+                "directive": directive.key,
+                "negative_samples": implicated,
+                "cycle": self.cycle,
+            },
+        )
+
+    def _decoy(self) -> AgentConfigPatch:
+        return AgentConfigPatch(
+            patch_type="prompt_rewrite",
+            description="Decoy: compress the prompt by dropping the accumulated directives.",
+            changes={"system_prompt": DECOY_PROMPT},
+            metadata={"source": "directive-proposer", "decoy": True, "cycle": self.cycle},
+        )
+
+
+def heldout_cases(
+    llm: ScriptedTaskLLM, tasks: tuple[Task, ...] = HELDOUT_TASKS
+) -> list[tuple[str, Any]]:
+    """Build ``EvalSuite`` cases that score a candidate prompt on the held-out slice."""
+
+    def make(task: Task) -> Any:
+        async def case(prompt: str = "") -> dict[str, float]:
+            answer = await llm.generate(render(prompt, task.question))
+            return {"score": 1.0 if graded(task, answer) else 0.0, "cost_usd": 0.0}
+
+        case.__name__ = f"heldout_{task.task_id}"
+        return case
+
+    return [(f"heldout_{task.task_id}", make(task)) for task in tasks]
+
+
+@dataclass
+class CycleRecord:
+    """What one evolution cycle did, snapshotted at the time it happened."""
+
+    cycle: int
+    eval_score: float
+    status: str
+    patch_id: str | None
+    directive: str | None
+    blocked_patch_ids: list[str] = field(default_factory=list)
+
+
+@dataclass
+class EvolutionBenchResult:
+    baseline_score: float
+    cycles: list[CycleRecord]
+    history: list[AgentConfigPatch]
+    agent: SelfImprovingAgent
+    eval_suite: EvalSuite
+    audit_path: Path
+    heldout_size: int
+
+    @property
+    def final_score(self) -> float:
+        return self.cycles[-1].eval_score if self.cycles else self.baseline_score
+
+    @property
+    def uplift(self) -> float:
+        return self.final_score - self.baseline_score
+
+    @property
+    def accepted(self) -> list[CycleRecord]:
+        return [c for c in self.cycles if c.patch_id is not None]
+
+    def score_current_prompt(self) -> float:
+        """Held-out accuracy of the agent's *current* system prompt."""
+        prompt = self.agent.base_agent.config.system_prompt
+        return asyncio.run(self.eval_suite.score_prompt(prompt)).score
+
+
+async def run_evolution(audit_path: str | Path) -> EvolutionBenchResult:
+    """Drive one agent through :data:`N_CYCLES` real evolution cycles.
+
+    *audit_path* must point somewhere disposable — the audit JSONL is written for
+    real so the signature round-trip can be verified, and must never land in the
+    repo.
+    """
+    audit_path = Path(audit_path)
+    llm = ScriptedTaskLLM()
+    executor = AgentExecutor(
+        AgentConfig(
+            llm=llm,
+            tools=[EchoTool()],
+            system_prompt=BASELINE_PROMPT,
+            agent_type="function_calling",
+        )
+    )
+    suite = EvalSuite.from_cases(heldout_cases(llm), threshold=None)
+    collector = FeedbackCollector()
+    collector.start()
+
+    agent = SelfImprovingAgent(
+        executor,
+        eval_suite=suite,
+        # min_eval_score=0.0 makes "must beat the current baseline" the binding
+        # gate, rather than an absolute floor the early cycles could never clear.
+        rollout=RolloutPolicy(
+            min_eval_score=0.0,
+            rollback_on_regression=True,
+            require_human_approval_for=[],
+        ),
+        feedback_collector=collector,
+        meta_analyzer=DirectiveProposer(),
+        improvement_targets=["prompt"],
+        agent_id="self-evolving-bench",
+        audit_path=audit_path,
+    )
+
+    # Seeded: task presentation order is shuffled but reproducible, so the result
+    # cannot depend on the order failures happen to arrive in.
+    order = list(PROPOSER_TASKS)
+    random.Random(SEED).shuffle(order)
+
+    baseline = (await suite.score_prompt(executor.config.system_prompt)).score
+    cycles: list[CycleRecord] = []
+
+    for cycle in range(1, N_CYCLES + 1):
+        for task in order:
+            answer = await agent.arun(task.question)
+            ok = graded(task, answer)
+            collector.record(
+                task.question,
+                answer,
+                "positive" if ok else "negative",
+                corrected_response=None if ok else f"{task.answer} {task.expected}",
+                metadata={"task_id": task.task_id, "cycle": cycle},
+            )
+        await collector.flush()
+
+        seen = len(agent.evolution_history())
+        outcome = await agent.evolve()
+        appended = agent.evolution_history()[: len(agent.evolution_history()) - seen]
+        score = (await suite.score_prompt(executor.config.system_prompt)).score
+
+        cycles.append(
+            CycleRecord(
+                cycle=cycle,
+                eval_score=score,
+                status=outcome.status,
+                patch_id=outcome.patch.patch_id if outcome.patch else None,
+                directive=(outcome.patch.metadata.get("directive") if outcome.patch else None),
+                blocked_patch_ids=[p.patch_id for p in appended if p.status == "blocked"],
+            )
+        )
+
+    await collector.stop()
+    return EvolutionBenchResult(
+        baseline_score=baseline,
+        cycles=cycles,
+        history=agent.evolution_history(),
+        agent=agent,
+        eval_suite=suite,
+        audit_path=audit_path,
+        heldout_size=len(HELDOUT_TASKS),
+    )
+
+
+if __name__ == "__main__":
+    with tempfile.TemporaryDirectory() as tmp:
+        res = asyncio.run(run_evolution(Path(tmp) / "evolution.jsonl"))
+    print(f"held-out slice: {res.heldout_size} tasks the proposer never sees")
+    print(f"{'baseline':>12}: {res.baseline_score:.0%}")
+    for c in res.cycles:
+        blocked = f"  (blocked {len(c.blocked_patch_ids)} decoy)" if c.blocked_patch_ids else ""
+        print(
+            f"{'cycle ' + str(c.cycle):>12}: {c.eval_score:.0%}  {c.status:<9} +{c.directive}{blocked}"
+        )
+    print(f"{'uplift':>12}: {res.uplift:+.0%}")

--- a/benchmarks/test_self_evolving_bench.py
+++ b/benchmarks/test_self_evolving_bench.py
@@ -1,0 +1,147 @@
+"""CI-enforced gate for the #732 self-evolving acceptance criterion.
+
+Runs one `SelfImprovingAgent` through 5 real evolution cycles and hard-enforces
+that it improves itself, and that the eval gate — not the agent — decides:
+
+* final held-out accuracy is near-perfect (>= 90%);
+* it beats its own starting accuracy by >= 35 percentage points;
+* held-out accuracy never regresses across the 5 cycles;
+* the baseline is genuinely fallible (<= 50%), so the uplift is real, not trivial;
+* the deliberately bad decoy candidates are *blocked* with a recorded reason;
+* every accepted patch is reversible — rolling the last one back restores the
+  previous held-out accuracy exactly — and every patch signature survives a
+  JSONL round-trip through the audit log.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from itertools import pairwise
+
+import pytest
+from self_evolving_bench import N_CYCLES, run_evolution
+
+from synapsekit.agents import AgentEvolutionAuditLog
+
+_MIN_FINAL_ACCURACY = 0.90
+_MIN_UPLIFT = 0.35
+_MAX_BASELINE_ACCURACY = 0.50
+_ACCEPTED_STATUSES = {"canary", "promoted"}
+
+
+@pytest.fixture(scope="module")
+def result(tmp_path_factory):
+    audit_path = tmp_path_factory.mktemp("self_evolving_bench") / "evolution.jsonl"
+    return asyncio.run(run_evolution(audit_path))
+
+
+def test_final_accuracy_is_near_perfect(result):
+    acc = result.final_score
+    assert acc >= _MIN_FINAL_ACCURACY, (
+        f"final held-out accuracy {acc:.0%} < {_MIN_FINAL_ACCURACY:.0%}"
+    )
+
+
+def test_uplift_over_baseline(result):
+    assert result.uplift >= _MIN_UPLIFT, (
+        f"baseline={result.baseline_score:.0%} vs final={result.final_score:.0%} → "
+        f"uplift {result.uplift:.0%} < {_MIN_UPLIFT:.0%}"
+    )
+
+
+def test_accuracy_never_regresses(result):
+    scores = [result.baseline_score] + [c.eval_score for c in result.cycles]
+    for prev, curr in pairwise(scores):
+        assert curr >= prev, (
+            f"held-out accuracy regressed {prev:.0%} → {curr:.0%} across "
+            f"{['baseline', *[f'cycle {c.cycle}' for c in result.cycles]]}"
+        )
+
+
+def test_baseline_is_actually_fallible(result):
+    # Guard against a trivially-easy suite: the un-evolved prompt must miss some.
+    acc = result.baseline_score
+    assert acc <= _MAX_BASELINE_ACCURACY, (
+        f"baseline too accurate ({acc:.0%} > {_MAX_BASELINE_ACCURACY:.0%}); "
+        "the suite isn't testing anything"
+    )
+
+
+def test_decoy_candidates_are_blocked_by_the_eval_gate(result):
+    blocked = [p for p in result.history if p.status == "blocked"]
+    assert blocked, (
+        f"0 blocked patches out of {len(result.history)}; the eval gate never "
+        "rejected anything, so it is rubber-stamping"
+    )
+    for patch in blocked:
+        reason = patch.metadata.get("block_reason")
+        assert reason, (
+            f"blocked patch {patch.patch_id} has block_reason={reason!r}, required a "
+            "non-empty reason"
+        )
+
+
+def test_accepted_patches_are_eval_approved_and_reversible(result):
+    accepted = result.accepted
+    assert len(accepted) == N_CYCLES, (
+        f"{len(accepted)} accepted patches, required {N_CYCLES} (one per cycle)"
+    )
+    for record in accepted:
+        assert record.status in _ACCEPTED_STATUSES, (
+            f"cycle {record.cycle} accepted with status {record.status!r}, "
+            f"required one of {sorted(_ACCEPTED_STATUSES)}"
+        )
+        patch = result.agent.audit_log.get(record.patch_id)
+        assert patch is not None, (
+            f"cycle {record.cycle} patch {record.patch_id} missing from audit log"
+        )
+        assert patch.before, (
+            f"cycle {record.cycle} patch {record.patch_id} has an empty `before` snapshot, "
+            "so it is not reversible"
+        )
+
+
+def test_history_covers_every_cycle_and_survives_jsonl_round_trip(result):
+    assert len(result.cycles) == N_CYCLES, (
+        f"{len(result.cycles)} cycles recorded, required {N_CYCLES}"
+    )
+    known = {p.patch_id for p in result.history}
+    for record in result.cycles:
+        expected = [pid for pid in [record.patch_id, *record.blocked_patch_ids] if pid]
+        assert expected, f"cycle {record.cycle} produced no audit entries at all"
+        missing = [pid for pid in expected if pid not in known]
+        assert not missing, (
+            f"cycle {record.cycle} patches missing from evolution_history(): {missing}"
+        )
+
+    reloaded = AgentEvolutionAuditLog(result.audit_path).list()
+    assert len(reloaded) == len(result.history), (
+        f"round-tripped {len(reloaded)} patches, required {len(result.history)}"
+    )
+    unverified = [p.patch_id for p in reloaded if not p.verify()]
+    assert not unverified, (
+        f"{len(unverified)} of {len(reloaded)} patch signatures failed to verify after a "
+        f"JSONL round-trip: {unverified}"
+    )
+
+
+def test_rollback_restores_the_previous_held_out_accuracy(result):
+    # Ordered last: rollback mutates the agent's live config on purpose.
+    last = result.accepted[-1]
+    previous = result.cycles[-2].eval_score
+
+    rollback = result.agent.rollback(last.patch_id, reason="bench rollback probe")
+    restored = result.score_current_prompt()
+
+    assert restored == pytest.approx(previous), (
+        f"rollback of {last.patch_id} left held-out accuracy at {restored:.3f}, "
+        f"required exactly the pre-patch {previous:.3f}"
+    )
+    assert rollback.status == "rolled_back", (
+        f"rollback entry status {rollback.status!r}, required 'rolled_back'"
+    )
+    assert rollback.rollback_of == last.patch_id, (
+        f"rollback entry points at {rollback.rollback_of!r}, required {last.patch_id!r}"
+    )
+    rolled_back = [p for p in result.agent.evolution_history() if p.status == "rolled_back"]
+    assert rolled_back, "no rolled_back entry was appended to the audit log"


### PR DESCRIPTION
Part of #732 — closes **acceptance-criterion #1**: an end-to-end benchmark proving a `SelfImprovingAgent` autonomously improves its accuracy over 5 evolution cycles, plus the CI gate that enforces it.

Nothing under `src/` is touched. The benchmark drives the real `SelfImprovingAgent` / `MetaAnalyzerProtocol` / `EvalSuite` / `RolloutPolicy` / `AgentEvolutionAuditLog` APIs — no reimplementation.

## Design

One agent is driven through 5 real observe → propose → validate → canary cycles.

**The task suite is behavioural.** 23 synthetic tasks where correctness is a pure function of which *directives* ("state the unit", "cite the source", "ask when ambiguous", "show your work", "admit what you don't know") appear in the system prompt. A scripted `BaseLLM` resolves which task it is answering from the question text it was handed, and emits the task's behavioural artefact only when the governing directive is **literally present in its prompt**. Grading is `expected in answer` — the grader never inspects the model's internals.

**The gate is held out.** The `EvalSuite` (built via `EvalSuite.from_cases`, `threshold=None`) scores candidate prompts against 8 tasks the proposer *never observes*; the proposer only ever sees feedback from the 15 proposer-visible tasks, and its question→directive map is constructed from those alone. The agent cannot grade itself.

**The gate is load-bearing.** `DirectiveProposer` clusters negative `FeedbackSample`s by the directive governing the failing task and proposes the single most-implicated directive still missing from the prompt (per-directive failure counts are distinct — 5/4/3/2/1 — so the argmax is unambiguous). From cycle 2 onward it *also* emits, **first in the candidate list**, a deliberately bad decoy that strips every directive learned so far. Every decoy must be rejected by `RolloutPolicy.check_eval_gate` before the good candidate is even reached — that is what proves the gate is doing work rather than rubber-stamping.

`RolloutPolicy(min_eval_score=0.0, rollback_on_regression=True, require_human_approval_for=[])` makes *"must beat the current baseline"* the binding gate, rather than an absolute floor the early cycles could never clear.

Fully offline and deterministic: no API keys, no network, seeded (`SEED = 732`). The audit log is written to a pytest `tmp_path_factory` directory, so no `.jsonl` is ever left in the repo.

## Measured result

| | held-out accuracy | patch |
|---|---|---|
| baseline | **37.5%** (3/8) | — |
| cycle 1 | 50.0% | `+show_units` (canary) |
| cycle 2 | 62.5% | `+cite_source` (canary), 1 decoy blocked |
| cycle 3 | 75.0% | `+refuse_ambiguous` (canary), 1 decoy blocked |
| cycle 4 | 87.5% | `+show_work` (canary), 1 decoy blocked |
| cycle 5 | **100.0%** | `+admit_unknown` (canary), 1 decoy blocked |

**37.5% → 100.0%, +62.5pp uplift**, monotonically non-decreasing, 4 decoys blocked by the eval gate.

## Thresholds enforced by `benchmarks/test_self_evolving_bench.py`

1. final held-out accuracy **>= 0.90** (measured 1.00)
2. final − baseline **>= 0.35** absolute uplift (measured 0.625)
3. eval score **monotonically non-decreasing** across all 5 cycles — no accepted patch ever regresses the held-out suite
4. baseline **<= 0.50**, so the uplift is not trivial (measured 0.375)
5. **at least one decoy reaches status `blocked`** with a populated `metadata["block_reason"]` (measured 4)
6. every accepted patch has status in `{canary, promoted}` **and a non-empty `before` snapshot** (i.e. is reversible)
7. `agent.rollback(patch_id)` on the last accepted patch restores the previous held-out accuracy **exactly** and appends a `rolled_back` audit entry
8. `evolution_history()` covers every cycle, and **every patch signature still verifies after a JSONL round-trip** through `AgentEvolutionAuditLog`

Each assertion prints actual vs required on failure, matching the existing benchmark tests.

## How to run

```bash
uv sync --group dev --group bench
uv run pytest benchmarks/test_self_evolving_bench.py -v   # 8 passed
uv run python benchmarks/self_evolving_bench.py           # prints the per-cycle table above
```

It is seeded — two consecutive runs are bit-identical. Verified locally, along with `uv run pytest tests/agents/test_self_improving_agent.py tests/training/ tests/cli/test_agent_cli.py -q` (192 passed), `ruff check` / `ruff format --check` on both new files, and `mypy src` (clean, 502 files).

## ⚠️ One thing to apply on merge

The `self-evolving-gate` CI job is **not in this push** — my token lacks the GitHub `workflow` OAuth scope, so it refuses to push commits touching `.github/workflows/`. The hunk goes immediately after `agent-swarm-market-gate` in `.github/workflows/ci.yml` and mirrors it exactly:

```yaml
  # Enforces the #732 self-evolving acceptance targets: a SelfImprovingAgent must
  # lift its own held-out accuracy from a fallible baseline (<=50%) to >=90% over 5
  # evolution cycles, never regressing, with every decoy candidate blocked by the gate.
  self-evolving-gate:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: astral-sh/setup-uv@v5
      - run: uv sync --group dev --group bench
      - run: uv run pytest benchmarks/test_self_evolving_bench.py -v
```

Happy to push it onto this branch instead if you'd rather it land in the same PR — say the word and I'll add it.

## Still open on #732

This closes acceptance-criterion #1 only. The **docs page / notebook** and the **rollout-policy branch-coverage** items remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
