### PR TITLE
feat(ambient): MVP ambient daemon — git+terminal sources, rule-based triggers (#743)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ voice-deepgram = ["deepgram-sdk>=3.0"]
 voice-silero = []
 training = ["openai>=1.0"]
 cron = ["croniter>=2.0", "tzdata>=2024.1; sys_platform == 'win32'"]
+ambient = ["plyer>=2.1"]
 excel = ["openpyxl>=3.1"]
 pptx = ["python-pptx>=0.6"]
 docx = ["python-docx>=1.0"]
@@ -215,6 +216,7 @@ all = [
     "asyncpg>=0.29",
     "groq>=0.9",
     "croniter>=2.0",
+    "plyer>=2.1",
     "erniebot>=0.5",
     "wolframalpha>=5.0",
     "discord.py>=2.0",

--- a/src/synapsekit/ambient/__init__.py
+++ b/src/synapsekit/ambient/__init__.py
@@ -1,0 +1,29 @@
+"""Ambient agent daemon — observes local activity and proactively notifies (MVP slice of #743)."""
+
+from __future__ import annotations
+
+from .daemon import AmbientDaemon, AmbientDaemonConfig
+from .events import AmbientEvent, AmbientState
+from .privacy import DEFAULT_AMBIENT_IGNORE, load_disabled_sources
+from .rules import DEFAULT_MIN_CONFIDENCE, Intervention, evaluate
+from .sources import AmbientSourcePlugin, GitSourcePlugin, TerminalSourcePlugin
+from .status import DEFAULT_STATUS_PATH, AmbientStatus, read_status, write_status
+
+__all__ = [
+    "DEFAULT_AMBIENT_IGNORE",
+    "DEFAULT_MIN_CONFIDENCE",
+    "DEFAULT_STATUS_PATH",
+    "AmbientDaemon",
+    "AmbientDaemonConfig",
+    "AmbientEvent",
+    "AmbientSourcePlugin",
+    "AmbientState",
+    "AmbientStatus",
+    "GitSourcePlugin",
+    "Intervention",
+    "TerminalSourcePlugin",
+    "evaluate",
+    "load_disabled_sources",
+    "read_status",
+    "write_status",
+]

--- a/src/synapsekit/ambient/daemon.py
+++ b/src/synapsekit/ambient/daemon.py
@@ -1,0 +1,204 @@
+"""Daemon for the synapsekit ambient system."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import getpass
+import logging
+import os
+import signal
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+from synapsekit.observability import AuditLog
+
+from .._compat import run_sync
+from .events import AmbientState
+from .notify import notify_windows_toast
+from .privacy import DEFAULT_AMBIENT_IGNORE, load_disabled_sources
+from .rules import DEFAULT_MIN_CONFIDENCE, Intervention, evaluate
+from .sources import GitSourcePlugin, TerminalSourcePlugin
+from .sources.base import AmbientSourcePlugin
+from .status import DEFAULT_STATUS_PATH, AmbientStatus, read_status, write_status
+
+logger = logging.getLogger(__name__)
+
+_STOP_SIGNALS: tuple[signal.Signals, ...] = (signal.SIGTERM, signal.SIGINT)
+_STOP_TIMEOUT_SECONDS = 5.0
+_STOP_POLL_SECONDS = 0.05
+
+
+@dataclass(frozen=True)
+class AmbientDaemonConfig:
+    """Runtime options for ``AmbientDaemon``."""
+
+    repo_root: Path = field(default_factory=Path.cwd)
+    poll_interval: float = 2.0
+    min_confidence: float = DEFAULT_MIN_CONFIDENCE
+    privacy_file: str | Path | None = DEFAULT_AMBIENT_IGNORE
+    status_path: str | Path = DEFAULT_STATUS_PATH
+    audit_path: str | Path = field(
+        default_factory=lambda: Path.home() / ".synapsekit" / "ambient_audit.jsonl"
+    )
+    terminal_history_path: str | Path | None = None
+
+
+class AmbientDaemon:
+    """Polls enabled ambient sources and fires notifications for risky commands."""
+
+    def __init__(
+        self,
+        *,
+        config: AmbientDaemonConfig | None = None,
+        sources: list[AmbientSourcePlugin] | None = None,
+    ) -> None:
+        self.config = config or AmbientDaemonConfig()
+        self._sources = sources if sources is not None else self._build_default_sources()
+        self._state = AmbientState()
+        self._stop_event = asyncio.Event()
+        self._signal_handlers_installed = False
+        self._audit_log: AuditLog | None = None
+
+    def _build_default_sources(self) -> list[AmbientSourcePlugin]:
+        disabled = load_disabled_sources(self.config.privacy_file)
+        sources: list[AmbientSourcePlugin] = []
+        if "git" not in disabled:
+            sources.append(GitSourcePlugin(self.config.repo_root))
+        if "terminal" not in disabled:
+            sources.append(TerminalSourcePlugin(self.config.terminal_history_path))
+        return sources
+
+    @property
+    def audit_log(self) -> AuditLog:
+        if self._audit_log is None:
+            audit_path = Path(self.config.audit_path)
+            audit_path.parent.mkdir(parents=True, exist_ok=True)
+            self._audit_log = AuditLog(backend="jsonl", path=str(audit_path))
+        return self._audit_log
+
+    async def start(self) -> AmbientStatus:
+        """Start the daemon: load sources, then poll until stopped."""
+
+        names = [source.name for source in self._sources]
+        print(f"synapsekit ambient: observing {', '.join(names) or '(no sources enabled)'}")
+        for source in self._sources:
+            await source.on_load()
+
+        write_status(
+            self.config.status_path,
+            state="running",
+            pid=os.getpid(),
+            started_at=datetime.now(UTC).isoformat(),
+        )
+        self._install_signal_handlers()
+        try:
+            await self._poll_loop()
+        finally:
+            self._remove_signal_handlers()
+            for source in self._sources:
+                await source.on_unload()
+        return read_status(self.config.status_path)
+
+    def start_sync(self) -> AmbientStatus:
+        """Sync wrapper for ``start``."""
+
+        return run_sync(self.start())
+
+    async def stop(self) -> AmbientStatus:
+        """Stop the daemon (in-process, or by signaling the running PID)."""
+
+        self._stop_event.set()
+
+        status = read_status(self.config.status_path)
+        if status.pid and status.pid != os.getpid() and self._signal_pid(status.pid):
+            await self._wait_for_stopped()
+
+        status = read_status(self.config.status_path)
+        if status.state != "stopped":
+            status = write_status(self.config.status_path, state="stopped", pid=None)
+        return status
+
+    def stop_sync(self) -> AmbientStatus:
+        """Sync wrapper for ``stop``."""
+
+        return run_sync(self.stop())
+
+    def status(self) -> AmbientStatus:
+        """Return current daemon status."""
+
+        return read_status(self.config.status_path)
+
+    async def _poll_loop(self) -> None:
+        while not self._stop_event.is_set():
+            await self._tick()
+            await asyncio.sleep(self.config.poll_interval)
+        write_status(self.config.status_path, state="stopped", pid=None)
+
+    async def _tick(self) -> None:
+        for source in self._sources:
+            for event in await source.poll():
+                if event.kind == "git_status":
+                    self._state.apply_git_status(event)
+                    continue
+                intervention = evaluate(event, self._state)
+                if intervention is not None and intervention.confidence >= self.config.min_confidence:
+                    self._fire(intervention)
+
+    def _fire(self, intervention: Intervention) -> None:
+        notify_windows_toast("SynapseKit ambient", intervention.message)
+        self.audit_log.record(
+            model=intervention.rule,
+            input_text=intervention.event.text,
+            output_text=intervention.message,
+            user=_current_user(),
+            metadata={"confidence": intervention.confidence, "source": intervention.event.source},
+        )
+
+    def _install_signal_handlers(self) -> None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        for sig in _STOP_SIGNALS:
+            with contextlib.suppress(NotImplementedError, ValueError):
+                loop.add_signal_handler(sig, self._stop_event.set)
+        self._signal_handlers_installed = True
+
+    def _remove_signal_handlers(self) -> None:
+        if not self._signal_handlers_installed:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        for sig in _STOP_SIGNALS:
+            with contextlib.suppress(NotImplementedError, ValueError):
+                loop.remove_signal_handler(sig)
+        self._signal_handlers_installed = False
+
+    @staticmethod
+    def _signal_pid(pid: int) -> bool:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return False
+        return True
+
+    async def _wait_for_stopped(self) -> None:
+        elapsed = 0.0
+        while elapsed < _STOP_TIMEOUT_SECONDS:
+            if read_status(self.config.status_path).state == "stopped":
+                return
+            await asyncio.sleep(_STOP_POLL_SECONDS)
+            elapsed += _STOP_POLL_SECONDS
+
+
+def _current_user() -> str:
+    try:
+        return getpass.getuser()
+    except Exception:
+        return "unknown"

--- a/src/synapsekit/ambient/daemon.py
+++ b/src/synapsekit/ambient/daemon.py
@@ -143,7 +143,10 @@ class AmbientDaemon:
                     self._state.apply_git_status(event)
                     continue
                 intervention = evaluate(event, self._state)
-                if intervention is not None and intervention.confidence >= self.config.min_confidence:
+                if (
+                    intervention is not None
+                    and intervention.confidence >= self.config.min_confidence
+                ):
                     self._fire(intervention)
 
     def _fire(self, intervention: Intervention) -> None:

--- a/src/synapsekit/ambient/events.py
+++ b/src/synapsekit/ambient/events.py
@@ -1,0 +1,34 @@
+"""Event and state types shared by ambient source plugins."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class AmbientEvent:
+    """A single observation reported by an ambient source plugin."""
+
+    source: str
+    kind: str
+    text: str
+    timestamp: datetime
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class AmbientState:
+    """Latest known signal from each source, updated in place each tick."""
+
+    git_dirty: bool = False
+    dirty_files: tuple[str, ...] = ()
+    branch: str | None = None
+    head: str | None = None
+
+    def apply_git_status(self, event: AmbientEvent) -> None:
+        self.git_dirty = bool(event.metadata.get("dirty", False))
+        self.dirty_files = tuple(event.metadata.get("dirty_files", ()))
+        self.branch = event.metadata.get("branch")
+        self.head = event.metadata.get("head")

--- a/src/synapsekit/ambient/notify.py
+++ b/src/synapsekit/ambient/notify.py
@@ -1,0 +1,24 @@
+"""Windows toast notification backend for ambient interventions."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def notify_windows_toast(title: str, message: str, *, timeout: int = 10) -> bool:
+    """Fire a Windows toast via ``plyer``.
+
+    Returns ``False`` (and logs) on any failure — a broken notification
+    backend must never take the daemon down.
+    """
+
+    try:
+        from plyer import notification
+
+        notification.notify(title=title, message=message, timeout=timeout)
+        return True
+    except Exception:
+        logger.warning("ambient: notification failed", exc_info=True)
+        return False

--- a/src/synapsekit/ambient/privacy.py
+++ b/src/synapsekit/ambient/privacy.py
@@ -1,0 +1,29 @@
+"""Per-source opt-out for the ambient daemon.
+
+Both sources are enabled by default; listing a source name in the ignore
+file disables it. Same tiny parsing shape as
+``synapsekit.mesh.privacy.MeshPrivacyFilter._read_ignore_file``, applied to
+source names instead of path globs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DEFAULT_AMBIENT_IGNORE = Path.home() / ".synapsekit" / "ambient.ignore"
+
+
+def load_disabled_sources(path: str | Path | None = DEFAULT_AMBIENT_IGNORE) -> set[str]:
+    if path is None:
+        return set()
+    ignore_path = Path(path).expanduser()
+    if not ignore_path.exists():
+        return set()
+
+    disabled: set[str] = set()
+    for raw in ignore_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        disabled.add(line)
+    return disabled

--- a/src/synapsekit/ambient/rules.py
+++ b/src/synapsekit/ambient/rules.py
@@ -1,0 +1,65 @@
+"""Rule-based trigger policy for ambient interventions.
+
+Deliberately not machine-learned: a small, auditable pattern table covering
+the issue's canonical trigger ("about to run something destructive against a
+dirty repo"). Add a rule by adding a tuple, not a new abstraction.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .events import AmbientEvent, AmbientState
+
+DEFAULT_MIN_CONFIDENCE = 0.6
+
+# (pattern, label, confidence)
+_RISKY_PATTERNS: tuple[tuple[re.Pattern[str], str, float], ...] = (
+    (
+        re.compile(r"\brm\s+-[a-z]*(rf|fr)[a-z]*\b", re.IGNORECASE),
+        "destructive-delete",
+        0.9,
+    ),
+    (
+        re.compile(r"\bRemove-Item\b.*(-Recurse\b.*-Force\b|-Force\b.*-Recurse\b)", re.IGNORECASE),
+        "destructive-delete",
+        0.9,
+    ),
+    (
+        re.compile(r"\bgit\s+reset\s+--hard\b", re.IGNORECASE),
+        "git-reset-hard",
+        0.85,
+    ),
+    (
+        re.compile(r"\bgit\s+(push\s+.*(--force\b|-f\b)|clean\s+-[a-z]*f)", re.IGNORECASE),
+        "git-force-push-or-clean",
+        0.8,
+    ),
+)
+
+
+@dataclass(frozen=True)
+class Intervention:
+    rule: str
+    confidence: float
+    message: str
+    event: AmbientEvent
+
+
+def evaluate(event: AmbientEvent, state: AmbientState) -> Intervention | None:
+    """Return an Intervention if ``event`` matches a risky pattern against dirty state."""
+
+    if event.source != "terminal" or not state.git_dirty:
+        return None
+
+    for pattern, label, confidence in _RISKY_PATTERNS:
+        if pattern.search(event.text):
+            branch = state.branch or "this repo"
+            message = (
+                f"'{event.text.strip()}' looks destructive and {branch} has "
+                f"{len(state.dirty_files)} uncommitted file(s). "
+                "Consider committing or stashing first."
+            )
+            return Intervention(rule=label, confidence=confidence, message=message, event=event)
+    return None

--- a/src/synapsekit/ambient/sources/__init__.py
+++ b/src/synapsekit/ambient/sources/__init__.py
@@ -1,0 +1,13 @@
+"""Ambient source plugins."""
+
+from __future__ import annotations
+
+from .base import AmbientSourcePlugin
+from .git import GitSourcePlugin
+from .terminal import TerminalSourcePlugin
+
+__all__ = [
+    "AmbientSourcePlugin",
+    "GitSourcePlugin",
+    "TerminalSourcePlugin",
+]

--- a/src/synapsekit/ambient/sources/base.py
+++ b/src/synapsekit/ambient/sources/base.py
@@ -1,0 +1,14 @@
+"""Base class for ambient source plugins."""
+
+from __future__ import annotations
+
+from synapsekit.plugins import BasePlugin
+
+from ..events import AmbientEvent
+
+
+class AmbientSourcePlugin(BasePlugin):
+    """A ``BasePlugin`` that can be polled for new ``AmbientEvent``s."""
+
+    async def poll(self) -> list[AmbientEvent]:
+        raise NotImplementedError

--- a/src/synapsekit/ambient/sources/git.py
+++ b/src/synapsekit/ambient/sources/git.py
@@ -1,0 +1,81 @@
+"""Ambient source plugin that polls local git status."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+from ..events import AmbientEvent
+from .base import AmbientSourcePlugin
+
+logger = logging.getLogger(__name__)
+
+
+class GitSourcePlugin(AmbientSourcePlugin):
+    """Polls ``git status --porcelain --branch`` for working-tree changes."""
+
+    name = "git"
+    version = "0.1.0"
+    description = "Observes local git branch and working-tree status."
+
+    def __init__(self, repo_root: str | Path = ".") -> None:
+        self.repo_root = Path(repo_root)
+        self._last_raw: str | None = None
+        self._unavailable = False
+
+    async def poll(self) -> list[AmbientEvent]:
+        if self._unavailable:
+            return []
+
+        raw = await asyncio.to_thread(self._run_status)
+        if raw is None:
+            self._unavailable = True
+            return []
+        if raw == self._last_raw:
+            return []
+        self._last_raw = raw
+
+        lines = raw.splitlines()
+        branch = None
+        if lines and lines[0].startswith("##"):
+            header = lines[0][2:].strip()
+            branch = header.split("...")[0].strip() or None
+            lines = lines[1:]
+        dirty_files = [line[3:].strip() for line in lines if line.strip()]
+
+        return [
+            AmbientEvent(
+                source=self.name,
+                kind="git_status",
+                text=f"{len(dirty_files)} file(s) changed on {branch or 'unknown branch'}",
+                timestamp=datetime.now(UTC),
+                metadata={
+                    "dirty": bool(dirty_files),
+                    "dirty_files": dirty_files,
+                    "branch": branch,
+                },
+            )
+        ]
+
+    def _run_status(self) -> str | None:
+        # ponytail: no retry/backoff after first failure (not-a-repo, git
+        # missing from PATH); add if this proves noisy in practice.
+        try:
+            result = subprocess.run(
+                ["git", "status", "--porcelain", "--branch"],
+                cwd=self.repo_root,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            logger.warning("ambient: git source unavailable, disabling", exc_info=True)
+            return None
+        if result.returncode != 0:
+            logger.warning("ambient: not a git repo at %s, disabling git source", self.repo_root)
+            return None
+        return result.stdout

--- a/src/synapsekit/ambient/sources/terminal.py
+++ b/src/synapsekit/ambient/sources/terminal.py
@@ -1,0 +1,76 @@
+"""Ambient source plugin that tails PowerShell's PSReadLine history file.
+
+Windows has no zsh/bash ``preexec`` hook, so this is a best-effort,
+after-the-fact source: it only sees a command once PSReadLine has flushed it
+to disk (i.e. after the user pressed Enter), not before execution. True
+pre-exec interception would require injecting a ``Set-PSReadLineKeyHandler``
+into the user's ``$PROFILE`` — out of scope for this source.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+from ..events import AmbientEvent
+from .base import AmbientSourcePlugin
+
+logger = logging.getLogger(__name__)
+
+_CANDIDATE_HISTORY_PATHS: tuple[str, ...] = (
+    "Microsoft.PowerShell_history.txt",  # PowerShell 7+ (pwsh)
+    "ConsoleHost_history.txt",  # Windows PowerShell 5.1
+)
+
+
+def _default_history_path() -> Path | None:
+    appdata = os.environ.get("APPDATA")
+    if not appdata:
+        return None
+    base = Path(appdata) / "Microsoft" / "Windows" / "PowerShell" / "PSReadLine"
+    for name in _CANDIDATE_HISTORY_PATHS:
+        candidate = base / name
+        if candidate.exists():
+            return candidate
+    return None
+
+
+class TerminalSourcePlugin(AmbientSourcePlugin):
+    """Tails the PSReadLine history file for newly-run commands."""
+
+    name = "terminal"
+    version = "0.1.0"
+    description = "Observes recently run PowerShell commands (best-effort, after-the-fact)."
+
+    def __init__(self, history_path: str | Path | None = None) -> None:
+        self._configured_path = Path(history_path) if history_path else None
+        self._offset: int | None = None
+        self._warned_unavailable = False
+
+    async def poll(self) -> list[AmbientEvent]:
+        path = self._configured_path or _default_history_path()
+        if path is None or not path.exists():
+            if not self._warned_unavailable:
+                logger.warning("ambient: no PSReadLine history file found, terminal source disabled")
+                self._warned_unavailable = True
+            return []
+
+        if self._offset is None:
+            # Baseline on first poll: don't replay history that predates the
+            # daemon starting, only react to commands run from here on.
+            self._offset = path.stat().st_size
+            return []
+
+        with open(path, encoding="utf-8", errors="replace") as f:
+            f.seek(self._offset)
+            new_text = f.read()
+            self._offset = f.tell()
+
+        lines = [line.strip() for line in new_text.splitlines() if line.strip()]
+        now = datetime.now(UTC)
+        return [
+            AmbientEvent(source=self.name, kind="command", text=line, timestamp=now)
+            for line in lines
+        ]

--- a/src/synapsekit/ambient/sources/terminal.py
+++ b/src/synapsekit/ambient/sources/terminal.py
@@ -9,6 +9,7 @@ into the user's ``$PROFILE`` — out of scope for this source.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from datetime import UTC, datetime
@@ -53,7 +54,9 @@ class TerminalSourcePlugin(AmbientSourcePlugin):
         path = self._configured_path or _default_history_path()
         if path is None or not path.exists():
             if not self._warned_unavailable:
-                logger.warning("ambient: no PSReadLine history file found, terminal source disabled")
+                logger.warning(
+                    "ambient: no PSReadLine history file found, terminal source disabled"
+                )
                 self._warned_unavailable = True
             return []
 
@@ -63,10 +66,7 @@ class TerminalSourcePlugin(AmbientSourcePlugin):
             self._offset = path.stat().st_size
             return []
 
-        with open(path, encoding="utf-8", errors="replace") as f:
-            f.seek(self._offset)
-            new_text = f.read()
-            self._offset = f.tell()
+        new_text, self._offset = await asyncio.to_thread(self._read_new_text, path, self._offset)
 
         lines = [line.strip() for line in new_text.splitlines() if line.strip()]
         now = datetime.now(UTC)
@@ -74,3 +74,10 @@ class TerminalSourcePlugin(AmbientSourcePlugin):
             AmbientEvent(source=self.name, kind="command", text=line, timestamp=now)
             for line in lines
         ]
+
+    @staticmethod
+    def _read_new_text(path: Path, offset: int) -> tuple[str, int]:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            f.seek(offset)
+            new_text = f.read()
+            return new_text, f.tell()

--- a/src/synapsekit/ambient/status.py
+++ b/src/synapsekit/ambient/status.py
@@ -1,0 +1,41 @@
+"""Tiny JSON status file for the ambient daemon (one row, no store needed)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+DEFAULT_STATUS_PATH = Path.home() / ".synapsekit" / "ambient.status.json"
+
+
+@dataclass
+class AmbientStatus:
+    state: str = "stopped"
+    pid: int | None = None
+    started_at: str | None = None
+
+
+def read_status(path: str | Path = DEFAULT_STATUS_PATH) -> AmbientStatus:
+    status_path = Path(path).expanduser()
+    if not status_path.exists():
+        return AmbientStatus()
+    try:
+        data = json.loads(status_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return AmbientStatus()
+    return AmbientStatus(
+        state=data.get("state", "stopped"),
+        pid=data.get("pid"),
+        started_at=data.get("started_at"),
+    )
+
+
+def write_status(path: str | Path = DEFAULT_STATUS_PATH, **values: object) -> AmbientStatus:
+    status_path = Path(path).expanduser()
+    status_path.parent.mkdir(parents=True, exist_ok=True)
+    status = read_status(status_path)
+    for key, value in values.items():
+        setattr(status, key, value)
+    status_path.write_text(json.dumps(asdict(status)), encoding="utf-8")
+    return status

--- a/src/synapsekit/cli/ambient.py
+++ b/src/synapsekit/cli/ambient.py
@@ -1,0 +1,85 @@
+"""``synapsekit ambient`` commands for the ambient agent daemon."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from synapsekit.ambient import AmbientDaemon, AmbientDaemonConfig
+from synapsekit.observability import AuditLog
+
+
+def _ambient_config(args: Any) -> AmbientDaemonConfig:
+    defaults = AmbientDaemonConfig()
+    return AmbientDaemonConfig(
+        repo_root=Path(getattr(args, "repo", None) or Path.cwd()),
+        poll_interval=float(getattr(args, "poll_interval", defaults.poll_interval)),
+        min_confidence=float(getattr(args, "min_confidence", defaults.min_confidence)),
+    )
+
+
+def _print_payload(payload: Any, *, output_json: bool = False) -> None:
+    if output_json:
+        print(json.dumps(payload, indent=2))
+        return
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            print(f"{key}: {value}")
+        return
+    print(payload)
+
+
+def run_ambient(args: Any) -> None:
+    """Dispatch ``synapsekit ambient`` subcommands."""
+
+    command = getattr(args, "ambient_command", None)
+    output_json = bool(getattr(args, "json", False))
+
+    if command == "start":
+        daemon = AmbientDaemon(config=_ambient_config(args))
+        status = daemon.start_sync()
+        _print_payload(asdict(status), output_json=output_json)
+        return
+
+    if command == "stop":
+        status = AmbientDaemon(config=_ambient_config(args)).stop_sync()
+        _print_payload(asdict(status), output_json=output_json)
+        return
+
+    if command == "status":
+        status = AmbientDaemon(config=_ambient_config(args)).status()
+        _print_payload(asdict(status), output_json=output_json)
+        return
+
+    if command == "log":
+        config = _ambient_config(args)
+        audit_log = AuditLog(backend="jsonl", path=str(config.audit_path))
+        entries = audit_log.query(limit=int(getattr(args, "limit", 20)))
+        payload = [asdict(entry) for entry in entries]
+        _print_payload(payload, output_json=output_json)
+        return
+
+    raise SystemExit("Missing ambient action. Use start, stop, status, or log.")
+
+
+def build_ambient_parser(subparsers: Any) -> None:
+    """Register the ``ambient`` parser with the top-level CLI."""
+
+    parser = subparsers.add_parser("ambient", help="Observe local activity and proactively notify")
+    parser.add_argument("--repo", default=None, help="Repo root to observe (default: cwd)")
+    parser.add_argument("--json", action="store_true", help="Emit JSON output")
+    ambient_sub = parser.add_subparsers(dest="ambient_command")
+
+    start_cmd = ambient_sub.add_parser("start", help="Start the ambient daemon")
+    start_cmd.add_argument("--poll-interval", type=float, default=2.0, help="Poll interval seconds")
+    start_cmd.add_argument(
+        "--min-confidence", type=float, default=0.6, help="Minimum confidence to notify"
+    )
+
+    ambient_sub.add_parser("stop", help="Stop the ambient daemon")
+    ambient_sub.add_parser("status", help="Show ambient daemon status")
+
+    log_cmd = ambient_sub.add_parser("log", help="Show recent interventions")
+    log_cmd.add_argument("--limit", type=int, default=20, help="Maximum entries to show")

--- a/src/synapsekit/cli/main.py
+++ b/src/synapsekit/cli/main.py
@@ -172,6 +172,12 @@ def _add_mesh_parser(subparsers: argparse._SubParsersAction) -> None:  # type: i
     build_mesh_parser(subparsers)
 
 
+def _add_ambient_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    from .ambient import build_ambient_parser
+
+    build_ambient_parser(subparsers)
+
+
 def _add_agent_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = subparsers.add_parser("agent", help="Inspect and manage SynapseKit agents")
     agent_sub = p.add_subparsers(dest="agent_command")
@@ -321,6 +327,7 @@ def main(argv: list[str] | None = None) -> None:
     _add_bench_parser(subparsers)
     _add_edge_parser(subparsers)
     _add_mesh_parser(subparsers)
+    _add_ambient_parser(subparsers)
     _add_agent_parser(subparsers)
     _add_memory_parser(subparsers)
     _add_ui_parser(subparsers)
@@ -371,6 +378,10 @@ def main(argv: list[str] | None = None) -> None:
         from .mesh import run_mesh
 
         run_mesh(args)
+    elif args.command == "ambient":
+        from .ambient import run_ambient
+
+        run_ambient(args)
     elif args.command == "agent":
         from .agent import run_agent
 

--- a/tests/ambient/test_daemon.py
+++ b/tests/ambient/test_daemon.py
@@ -1,0 +1,114 @@
+"""Tests for AmbientDaemon polling, notification, and lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from synapsekit.ambient.daemon import AmbientDaemon, AmbientDaemonConfig
+from synapsekit.ambient.events import AmbientEvent
+from synapsekit.ambient.sources.base import AmbientSourcePlugin
+
+
+class _FakeSource(AmbientSourcePlugin):
+    """Injectable source plugin that replays a fixed sequence of poll() batches."""
+
+    def __init__(self, name: str, batches: list[list[AmbientEvent]]) -> None:
+        self.name = name
+        self._batches = [list(batch) for batch in batches]
+
+    async def poll(self) -> list[AmbientEvent]:
+        if self._batches:
+            return self._batches.pop(0)
+        return []
+
+
+def _event(source: str, kind: str, text: str, **metadata: object) -> AmbientEvent:
+    return AmbientEvent(source=source, kind=kind, text=text, timestamp=datetime.now(UTC), metadata=metadata)
+
+
+@pytest.mark.asyncio
+async def test_tick_fires_notification_and_records_audit(tmp_path: Path, monkeypatch) -> None:
+    notified = []
+    monkeypatch.setattr(
+        "synapsekit.ambient.daemon.notify_windows_toast",
+        lambda title, message: notified.append((title, message)) or True,
+    )
+
+    dirty_event = _event(
+        "git", "git_status", "1 file changed", dirty=True, dirty_files=["foo.py"], branch="main"
+    )
+    risky_event = _event("terminal", "command", "rm -rf build")
+
+    git_source = _FakeSource("git", [[dirty_event]])
+    terminal_source = _FakeSource("terminal", [[], [risky_event]])
+
+    config = AmbientDaemonConfig(
+        status_path=tmp_path / "status.json",
+        audit_path=tmp_path / "audit.jsonl",
+    )
+    daemon = AmbientDaemon(config=config, sources=[git_source, terminal_source])
+
+    await daemon._tick()  # git reports dirty; terminal baseline (empty)
+    assert notified == []
+
+    await daemon._tick()  # terminal reports the risky command against dirty state
+    assert len(notified) == 1
+    assert "rm -rf build" in notified[0][1]
+
+    entries = daemon.audit_log.query()
+    assert len(entries) == 1
+    assert entries[0].model == "destructive-delete"
+    assert entries[0].input_text == "rm -rf build"
+
+
+@pytest.mark.asyncio
+async def test_low_confidence_intervention_is_suppressed(tmp_path: Path, monkeypatch) -> None:
+    notified = []
+    monkeypatch.setattr(
+        "synapsekit.ambient.daemon.notify_windows_toast",
+        lambda title, message: notified.append((title, message)) or True,
+    )
+
+    dirty_event = _event("git", "git_status", "1 file", dirty=True, dirty_files=["foo.py"], branch="main")
+    risky_event = _event("terminal", "command", "git clean -fd")
+
+    git_source = _FakeSource("git", [[dirty_event]])
+    terminal_source = _FakeSource("terminal", [[], [risky_event]])
+
+    config = AmbientDaemonConfig(
+        status_path=tmp_path / "status.json",
+        audit_path=tmp_path / "audit.jsonl",
+        min_confidence=0.95,  # above every rule's confidence
+    )
+    daemon = AmbientDaemon(config=config, sources=[git_source, terminal_source])
+
+    await daemon._tick()
+    await daemon._tick()
+    assert notified == []
+
+
+@pytest.mark.asyncio
+async def test_start_records_pid_and_stop_marks_stopped(tmp_path: Path) -> None:
+    config = AmbientDaemonConfig(
+        status_path=tmp_path / "status.json",
+        audit_path=tmp_path / "audit.jsonl",
+        poll_interval=0.05,
+    )
+    daemon = AmbientDaemon(config=config, sources=[])
+
+    task = asyncio.create_task(daemon.start())
+    try:
+        await asyncio.sleep(0.1)
+        status = daemon.status()
+        assert status.state == "running"
+        assert status.pid == os.getpid()
+    finally:
+        await daemon.stop()
+        await asyncio.wait_for(task, timeout=5)
+
+    assert daemon.status().state == "stopped"

--- a/tests/ambient/test_daemon.py
+++ b/tests/ambient/test_daemon.py
@@ -28,7 +28,9 @@ class _FakeSource(AmbientSourcePlugin):
 
 
 def _event(source: str, kind: str, text: str, **metadata: object) -> AmbientEvent:
-    return AmbientEvent(source=source, kind=kind, text=text, timestamp=datetime.now(UTC), metadata=metadata)
+    return AmbientEvent(
+        source=source, kind=kind, text=text, timestamp=datetime.now(UTC), metadata=metadata
+    )
 
 
 @pytest.mark.asyncio
@@ -74,7 +76,9 @@ async def test_low_confidence_intervention_is_suppressed(tmp_path: Path, monkeyp
         lambda title, message: notified.append((title, message)) or True,
     )
 
-    dirty_event = _event("git", "git_status", "1 file", dirty=True, dirty_files=["foo.py"], branch="main")
+    dirty_event = _event(
+        "git", "git_status", "1 file", dirty=True, dirty_files=["foo.py"], branch="main"
+    )
     risky_event = _event("terminal", "command", "git clean -fd")
 
     git_source = _FakeSource("git", [[dirty_event]])

--- a/tests/ambient/test_notify.py
+++ b/tests/ambient/test_notify.py
@@ -11,9 +11,7 @@ from synapsekit.ambient.notify import notify_windows_toast
 def test_notify_calls_plyer_with_expected_args(monkeypatch) -> None:
     calls = []
 
-    fake_notification = types.SimpleNamespace(
-        notify=lambda **kwargs: calls.append(kwargs)
-    )
+    fake_notification = types.SimpleNamespace(notify=lambda **kwargs: calls.append(kwargs))
     fake_plyer = types.ModuleType("plyer")
     fake_plyer.notification = fake_notification
     monkeypatch.setitem(sys.modules, "plyer", fake_plyer)

--- a/tests/ambient/test_notify.py
+++ b/tests/ambient/test_notify.py
@@ -1,0 +1,36 @@
+"""Tests for the Windows toast notifier wrapper."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+from synapsekit.ambient.notify import notify_windows_toast
+
+
+def test_notify_calls_plyer_with_expected_args(monkeypatch) -> None:
+    calls = []
+
+    fake_notification = types.SimpleNamespace(
+        notify=lambda **kwargs: calls.append(kwargs)
+    )
+    fake_plyer = types.ModuleType("plyer")
+    fake_plyer.notification = fake_notification
+    monkeypatch.setitem(sys.modules, "plyer", fake_plyer)
+
+    result = notify_windows_toast("Title", "Message", timeout=5)
+
+    assert result is True
+    assert calls == [{"title": "Title", "message": "Message", "timeout": 5}]
+
+
+def test_notify_swallows_failure_and_returns_false(monkeypatch) -> None:
+    def _raise(**kwargs):
+        raise RuntimeError("no notification backend")
+
+    fake_notification = types.SimpleNamespace(notify=_raise)
+    fake_plyer = types.ModuleType("plyer")
+    fake_plyer.notification = fake_notification
+    monkeypatch.setitem(sys.modules, "plyer", fake_plyer)
+
+    assert notify_windows_toast("Title", "Message") is False

--- a/tests/ambient/test_privacy.py
+++ b/tests/ambient/test_privacy.py
@@ -1,0 +1,29 @@
+"""Tests for the ambient source opt-out ignore file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from synapsekit.ambient.privacy import load_disabled_sources
+
+
+def test_missing_file_returns_empty_set(tmp_path: Path) -> None:
+    assert load_disabled_sources(tmp_path / "nonexistent.ignore") == set()
+
+
+def test_none_path_returns_empty_set() -> None:
+    assert load_disabled_sources(None) == set()
+
+
+def test_parses_source_names_and_skips_comments_and_blanks(tmp_path: Path) -> None:
+    ignore_file = tmp_path / "ambient.ignore"
+    ignore_file.write_text("# comment\n\nterminal\n\n# another comment\n", encoding="utf-8")
+
+    assert load_disabled_sources(ignore_file) == {"terminal"}
+
+
+def test_multiple_sources(tmp_path: Path) -> None:
+    ignore_file = tmp_path / "ambient.ignore"
+    ignore_file.write_text("terminal\ngit\n", encoding="utf-8")
+
+    assert load_disabled_sources(ignore_file) == {"terminal", "git"}

--- a/tests/ambient/test_rules.py
+++ b/tests/ambient/test_rules.py
@@ -1,0 +1,60 @@
+"""Tests for the ambient rule-based trigger policy."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from synapsekit.ambient.events import AmbientEvent, AmbientState
+from synapsekit.ambient.rules import evaluate
+
+
+def _event(text: str, source: str = "terminal") -> AmbientEvent:
+    return AmbientEvent(source=source, kind="command", text=text, timestamp=datetime.now(UTC))
+
+
+def _dirty_state() -> AmbientState:
+    return AmbientState(git_dirty=True, dirty_files=("foo.py",), branch="main")
+
+
+def _clean_state() -> AmbientState:
+    return AmbientState(git_dirty=False)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "rm -rf build",
+        "rm -fr build",
+        "Remove-Item -Recurse -Force somefile",
+        "Remove-Item -Force -Recurse somefile",
+        "git reset --hard",
+        "git push --force origin main",
+        "git push -f origin main",
+        "git clean -fd",
+    ],
+)
+def test_risky_command_fires_when_repo_dirty(command: str) -> None:
+    intervention = evaluate(_event(command), _dirty_state())
+    assert intervention is not None
+    assert intervention.confidence > 0
+    assert command.strip() in intervention.message
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["rm -rf build", "git reset --hard", "git push --force"],
+)
+def test_risky_command_does_not_fire_when_repo_clean(command: str) -> None:
+    assert evaluate(_event(command), _clean_state()) is None
+
+
+def test_unrelated_command_does_not_fire() -> None:
+    assert evaluate(_event("git status"), _dirty_state()) is None
+    assert evaluate(_event("ls -la"), _dirty_state()) is None
+
+
+def test_non_terminal_source_never_fires() -> None:
+    event = _event("rm -rf build", source="git")
+    assert evaluate(event, _dirty_state()) is None

--- a/tests/ambient/test_sources_git.py
+++ b/tests/ambient/test_sources_git.py
@@ -1,0 +1,71 @@
+"""Tests for GitSourcePlugin against a real git repo."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from synapsekit.ambient.sources.git import GitSourcePlugin
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git("init", "-b", "main", cwd=repo)
+    _git("config", "user.email", "test@example.com", cwd=repo)
+    _git("config", "user.name", "Test", cwd=repo)
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _git("add", ".", cwd=repo)
+    _git("commit", "-m", "initial", cwd=repo)
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_poll_reports_clean_repo_as_not_dirty(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    plugin = GitSourcePlugin(repo)
+    events = await plugin.poll()
+    assert len(events) == 1
+    assert events[0].metadata["dirty"] is False
+    assert events[0].metadata["branch"] == "main"
+
+
+@pytest.mark.asyncio
+async def test_poll_reports_dirty_repo(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    plugin = GitSourcePlugin(repo)
+    await plugin.poll()  # baseline clean-state event
+
+    (repo / "README.md").write_text("changed\n", encoding="utf-8")
+    events = await plugin.poll()
+
+    assert len(events) == 1
+    assert events[0].metadata["dirty"] is True
+    assert "README.md" in events[0].metadata["dirty_files"][0]
+
+
+@pytest.mark.asyncio
+async def test_poll_dedupes_unchanged_status(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    plugin = GitSourcePlugin(repo)
+    await plugin.poll()
+
+    events = await plugin.poll()
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_poll_on_non_repo_returns_empty_and_disables(tmp_path: Path) -> None:
+    not_a_repo = tmp_path / "not_a_repo"
+    not_a_repo.mkdir()
+    plugin = GitSourcePlugin(not_a_repo)
+
+    assert await plugin.poll() == []
+    assert plugin._unavailable is True
+    assert await plugin.poll() == []

--- a/tests/ambient/test_sources_terminal.py
+++ b/tests/ambient/test_sources_terminal.py
@@ -1,0 +1,53 @@
+"""Tests for TerminalSourcePlugin history-file tailing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from synapsekit.ambient.sources.terminal import TerminalSourcePlugin
+
+
+@pytest.mark.asyncio
+async def test_first_poll_establishes_baseline_without_emitting(tmp_path: Path) -> None:
+    history = tmp_path / "history.txt"
+    history.write_text("git status\nls -la\n", encoding="utf-8")
+
+    plugin = TerminalSourcePlugin(history_path=history)
+    events = await plugin.poll()
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_second_poll_only_returns_new_lines(tmp_path: Path) -> None:
+    history = tmp_path / "history.txt"
+    history.write_text("git status\n", encoding="utf-8")
+
+    plugin = TerminalSourcePlugin(history_path=history)
+    await plugin.poll()
+
+    with open(history, "a", encoding="utf-8") as f:
+        f.write("rm -rf build\n")
+
+    events = await plugin.poll()
+    assert [e.text for e in events] == ["rm -rf build"]
+    assert events[0].source == "terminal"
+    assert events[0].kind == "command"
+
+
+@pytest.mark.asyncio
+async def test_no_new_lines_returns_empty(tmp_path: Path) -> None:
+    history = tmp_path / "history.txt"
+    history.write_text("git status\n", encoding="utf-8")
+
+    plugin = TerminalSourcePlugin(history_path=history)
+    await plugin.poll()
+    assert await plugin.poll() == []
+
+
+@pytest.mark.asyncio
+async def test_missing_history_file_returns_empty(tmp_path: Path) -> None:
+    plugin = TerminalSourcePlugin(history_path=tmp_path / "nonexistent.txt")
+    assert await plugin.poll() == []
+    assert await plugin.poll() == []

--- a/tests/cli/test_ambient.py
+++ b/tests/cli/test_ambient.py
@@ -1,0 +1,62 @@
+"""Tests for ``synapsekit ambient`` CLI wiring."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from synapsekit.ambient import AmbientDaemonConfig
+from synapsekit.cli.ambient import run_ambient
+
+
+def _args(command: str, **extra) -> argparse.Namespace:
+    payload = {
+        "ambient_command": command,
+        "repo": None,
+        "json": True,
+        "poll_interval": 2.0,
+        "min_confidence": 0.6,
+        "limit": 20,
+    }
+    payload.update(extra)
+    return argparse.Namespace(**payload)
+
+
+def _patch_config(monkeypatch, tmp_path: Path, *, audit_path: Path | None = None) -> None:
+    config = AmbientDaemonConfig(
+        status_path=tmp_path / "status.json",
+        audit_path=audit_path or (tmp_path / "audit.jsonl"),
+    )
+    monkeypatch.setattr("synapsekit.cli.ambient._ambient_config", lambda args: config)
+
+
+def test_ambient_cli_status_when_never_started(tmp_path: Path, capsys, monkeypatch) -> None:
+    _patch_config(monkeypatch, tmp_path)
+
+    run_ambient(_args("status"))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["state"] == "stopped"
+
+
+def test_ambient_cli_missing_action_raises() -> None:
+    with pytest.raises(SystemExit):
+        run_ambient(_args(None))
+
+
+def test_ambient_cli_log_reads_audit_entries(tmp_path: Path, capsys, monkeypatch) -> None:
+    from synapsekit.observability import AuditLog
+
+    audit_path = tmp_path / "audit.jsonl"
+    AuditLog(backend="jsonl", path=str(audit_path)).record(
+        model="destructive-delete", input_text="rm -rf build", output_text="careful!"
+    )
+
+    _patch_config(monkeypatch, tmp_path, audit_path=audit_path)
+
+    run_ambient(_args("log"))
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload) == 1
+    assert payload[0]["model"] == "destructive-delete"


### PR DESCRIPTION
## Summary

Scopes down issue #743 ("v2.1: Ambient Agent — system daemon that proactively offers help based on observed activity") to a shippable MVP that proves the core mechanism end-to-end: **a background daemon that watches a git repo for dirty state and a terminal for risky commands, and fires a Windows notification when both line up.**

- `synapsekit.ambient` package: `AmbientDaemon` mirroring `MeshDaemon`'s start/stop/status lifecycle (signal handling, PID-based cross-process stop)
- Two source plugins: `git` (polls `git status --porcelain --branch`), `terminal` (tails PSReadLine history, best-effort — after-the-fact, not true pre-exec)
- Rule-based (non-ML) trigger policy: destructive delete / `git reset --hard` / force-push-or-clean, gated on the repo being dirty
- Windows Toast notifications via `plyer` (new optional extra: `pip install -e ".[ambient]"`)
- Audit trail reusing `AuditLog` (jsonl backend), privacy opt-out file (`~/.synapsekit/ambient.ignore`)
- New CLI: `synapsekit ambient start|stop|status|log`

## Explicitly out of scope (follow-ups, not oversights)

The full issue asks for 5 source plugins, an ML intent classifier + labeled false-positive-rate test set, 3-OS notification adapters, systemd/launchd units, and a privacy dashboard UI — a multi-week epic. This PR deliberately ships only the slice needed to demonstrate the issue's canonical example. Deferred:

- `editor`, `browser`, `screen` source plugins
- ML-based intent classifier / labeled FPR test set
- macOS/Linux notification adapters, systemd/launchd units
- Privacy dashboard UI (ignore-file + startup notice cover MVP consent needs)
- True pre-exec terminal interception (`$PROFILE` hook)

## Test plan

- [x] `pytest tests/ambient tests/cli/test_ambient.py -q` — 33 passed
- [x] `pytest tests/plugins tests/cli/test_mesh.py -q` — no regressions
- [x] `synapsekit ambient --help` / `start --help` — CLI wiring verified
- [ ] Manual: `pip install -e ".[ambient]"`, run `synapsekit ambient start` in a dirty repo, run a risky command in the same PowerShell session, confirm a real toast fires (needs an interactive Windows session — not run in this sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)