### PR TITLE
ci(benchmarks): install symbolic extra for make bench (#919)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -13,7 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
-      - run: uv sync --group dev --group bench
+      # --extra symbolic: benchmarks/ includes the neuro-symbolic gate, which
+      # imports SympyBackend. Mirrors the neuro-symbolic-gate job in ci.yml.
+      - run: uv sync --group dev --group bench --extra symbolic
 
       - name: Cache benchmark baselines
         uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ SynapseKit uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Benchmarks` workflow no longer fails on the `symbolic` extra** (#919) — `benchmarks.yml` ran `make bench` (the full `benchmarks/` suite, including the neuro-symbolic gate that imports `SympyBackend`) without installing the `symbolic` extra, so the nightly and `v*`-tag runs errored with `ImportError: sympy is required`. Added `--extra symbolic` to its `uv sync`, mirroring the `neuro-symbolic-gate` job in `ci.yml`.
+
 ## [2.0.1] - 2026-08-04
 
 ### Security


### PR DESCRIPTION
Fixes the failing `Benchmarks / bench` check (surfaced by the v2.0.1 tag; nightly `schedule` runs have been red since #912).

`benchmarks.yml` ran `make bench` (full `benchmarks/` suite, which includes `test_neuro_symbolic_bench.py` importing `SympyBackend`) without the `symbolic` extra → `ImportError: sympy is required`. Added `--extra symbolic`, mirroring the `neuro-symbolic-gate` job in `ci.yml`.

Verified locally: `make bench` → **35 passed**.

Closes #919