### PR TITLE
feat(embeddings): first-class embeddings & reranker provider layer (#886)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,12 @@ vllm = ["openai>=1.0"]
 ai21 = ["ai21>=2.0"]
 cohere = ["cohere>=5.0"]
 mistral = ["mistralai>=1.0"]
-gemini = ["google-generativeai>=0.7"]
+gemini = ["google-generativeai>=0.7", "google-genai>=1.0"]
+# Hosted embeddings/rerankers over raw HTTP (OpenAI-compatible endpoints)
+voyage = ["httpx>=0.27"]
+jina = ["httpx>=0.27"]
+nomic = ["httpx>=0.27"]
+mixedbread = ["httpx>=0.27"]
 bedrock = ["boto3>=1.34"]
 gcal-tool = ["google-api-python-client>=2.0", "httplib2>=0.32.0"]
 aws-lambda = ["boto3>=1.34"]
@@ -109,7 +114,7 @@ okf = ["PyYAML>=6.0"]
 teams = ["httpx>=0.27"]
 http = ["aiohttp>=3.14.3"]
 search = ["duckduckgo-search>=6.0"]
-huggingface = ["huggingface-hub>=0.20"]
+huggingface = ["huggingface-hub>=0.20", "httpx>=0.27"]
 transformers = ["transformers>=4.0"]
 tiktoken = ["tiktoken>=0.12"]
 google-search = ["google-search-results>=2.4"]
@@ -197,6 +202,7 @@ all = [
     "cohere>=5.0",
     "mistralai>=1.0",
     "google-generativeai>=0.7",
+    "google-genai>=1.0",
     "boto3>=1.34",
     "duckduckgo-search>=6.0",
     "huggingface-hub>=0.20",
@@ -249,6 +255,7 @@ all = [
     "striprtf>=0.0.26",
     "ebooklib>=0.18",
     "gpt4all>=2.0",
+    "httpx>=0.27",
 ]
 
 [dependency-groups]
@@ -391,6 +398,17 @@ module = [
     "synapsekit.llm.providers.deepseek_r1",
     "synapsekit.llm.utils",
     "synapsekit.embeddings.backend",
+    "synapsekit.embeddings.base",
+    "synapsekit.embeddings.http",
+    "synapsekit.embeddings.openai",
+    "synapsekit.embeddings.cohere",
+    "synapsekit.embeddings.voyage",
+    "synapsekit.embeddings.jina",
+    "synapsekit.embeddings.gemini",
+    "synapsekit.embeddings.mistral",
+    "synapsekit.embeddings.nomic",
+    "synapsekit.embeddings.mixedbread",
+    "synapsekit.embeddings.huggingface",
     "synapsekit.retrieval.chroma",
     "synapsekit.retrieval.faiss",
     "synapsekit.retrieval.lancedb",
@@ -440,6 +458,12 @@ module = [
     "synapsekit.memory.readonly_shared_memory",
     "synapsekit.retrieval.vespa",
     "synapsekit.retrieval.raptor",
+    "synapsekit.retrieval.reranker",
+    "synapsekit.retrieval.voyage_reranker",
+    "synapsekit.retrieval.jina_reranker",
+    "synapsekit.retrieval.mixedbread_reranker",
+    "synapsekit.retrieval.cohere_reranker",
+    "synapsekit.retrieval.cross_encoder",
     "synapsekit.retrieval.document_augmentation",
     "synapsekit.retrieval.agentic_rag",
     "synapsekit.llm.replicate",
@@ -456,6 +480,7 @@ pep621_dev_dependency_groups = ["dev"]
 wikipedia-api = "wikipediaapi"
 z3-solver = "z3"
 google-generativeai = "google"
+google-genai = "google"
 google-cloud-storage = "google"
 google-cloud-bigquery = "google"
 google-api-python-client = "googleapiclient"
@@ -484,7 +509,7 @@ snowflake-connector-python = "snowflake"
 "piper-tts" = "piper"
 
 [tool.deptry.per_rule_ignores]
-DEP001 = ["sqlalchemy", "pydantic", "aiohttp", "opentelemetry", "whisper", "botocore", "aiomcache", "nest_asyncio", "huggingface_hub", "serpapi", "weaviate", "uvicorn", "starlette", "tomli", "pyttsx3", "faster_whisper", "sounddevice", "soundfile", "aiokafka", "kafka", "typesense", "prometheus_client", "sentence_transformers", "llama_cpp", "ragatouille", "torch"]
+DEP001 = ["sqlalchemy", "pydantic", "aiohttp", "opentelemetry", "whisper", "botocore", "aiomcache", "nest_asyncio", "huggingface_hub", "serpapi", "weaviate", "uvicorn", "starlette", "tomli", "pyttsx3", "faster_whisper", "sounddevice", "soundfile", "aiokafka", "kafka", "typesense", "prometheus_client", "sentence_transformers", "llama_cpp", "ragatouille", "torch", "httpx", "google-genai"]
 DEP002 = ["numpy", "rank-bm25", "beautifulsoup4", "lxml", "pillow", "pyasn1", "httplib2", "faiss-cpu", "google-generativeai", "tavily-python", "youtube-search-python", "psycopg", "google-search-results", "discord.py", "google-auth", "weaviate-client", "pymilvus", "lancedb", "pgvector", "slack-sdk", "supabase", "pymongo", "azure-storage-blob", "elasticsearch", "tzdata", "torchaudio", "python-multipart", "z3-solver", "pyautogui"]
 DEP003 = ["sqlalchemy", "botocore", "nest_asyncio", "opentelemetry", "starlette", "uvicorn", "tomli", "torch"]
 DEP004 = ["pydantic"]

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -390,6 +390,8 @@ from .retrieval.flare import FLARERetriever
 from .retrieval.graphrag import GraphRAGRetriever, KnowledgeGraph
 from .retrieval.hybrid_search import HybridSearchRetriever
 from .retrieval.hyde import HyDERetriever
+from .retrieval.jina_reranker import JinaReranker
+from .retrieval.mixedbread_reranker import MixedbreadReranker
 from .retrieval.mongodb_atlas import MongoDBAtlasVectorStore
 from .retrieval.multi_step import MultiStepRetriever
 from .retrieval.okf_graph import okf_to_world_model
@@ -413,6 +415,7 @@ from .retrieval.self_rag import SelfRAGRetriever
 from .retrieval.sentence_window import SentenceWindowRetriever
 from .retrieval.step_back import StepBackRetriever
 from .retrieval.vectorstore import InMemoryVectorStore
+from .retrieval.voyage_reranker import VoyageReranker
 from .retrieval.world_model import (
     CausalLinker,
     EntityMention,
@@ -582,6 +585,15 @@ __all__ = [
     # Embeddings
     "SynapsekitEmbeddings",
     "ONNXEmbeddings",
+    "OpenAIEmbeddings",
+    "CohereEmbeddings",
+    "VoyageEmbeddings",
+    "JinaEmbeddings",
+    "GeminiEmbeddings",
+    "MistralEmbeddings",
+    "NomicEmbeddings",
+    "MixedbreadEmbeddings",
+    "HuggingFaceEmbeddings",
     # Vector stores
     "VectorStore",
     "InMemoryVectorStore",
@@ -603,6 +615,8 @@ __all__ = [
     "AdaptiveRAGRetriever",
     "CohereReranker",
     "HybridSearchRetriever",
+    "JinaReranker",
+    "MixedbreadReranker",
     "MultiStepRetriever",
     "RAGFusionRetriever",
     "ContextualRetriever",
@@ -617,6 +631,7 @@ __all__ = [
     "SelfQueryRetriever",
     "SelfRAGRetriever",
     "SentenceWindowRetriever",
+    "VoyageReranker",
     "GraphRAGRetriever",
     "KnowledgeGraph",
     "KnowledgeGraphExtraction",
@@ -1177,6 +1192,15 @@ _LAZY_IMPORTS = {
     "WeaviateVectorStore": "retrieval.weaviate",
     "SQLiteVecStore": "retrieval.sqlite_vec",
     "ONNXEmbeddings": "embeddings.onnx",
+    "OpenAIEmbeddings": "embeddings.openai",
+    "CohereEmbeddings": "embeddings.cohere",
+    "VoyageEmbeddings": "embeddings.voyage",
+    "JinaEmbeddings": "embeddings.jina",
+    "GeminiEmbeddings": "embeddings.gemini",
+    "MistralEmbeddings": "embeddings.mistral",
+    "NomicEmbeddings": "embeddings.nomic",
+    "MixedbreadEmbeddings": "embeddings.mixedbread",
+    "HuggingFaceEmbeddings": "embeddings.huggingface",
     # LLM providers
     "AsyncLRUCache": "llm._cache",
     "DynamoDBCacheBackend": "llm._cache_dynamodb",

--- a/src/synapsekit/embeddings/__init__.py
+++ b/src/synapsekit/embeddings/__init__.py
@@ -1,9 +1,30 @@
 from .backend import SynapsekitEmbeddings
 
-__all__ = ["ONNXEmbeddings", "SynapsekitEmbeddings"]
+__all__ = [
+    "ONNXEmbeddings",
+    "SynapsekitEmbeddings",
+    "CohereEmbeddings",
+    "GeminiEmbeddings",
+    "HuggingFaceEmbeddings",
+    "JinaEmbeddings",
+    "MistralEmbeddings",
+    "MixedbreadEmbeddings",
+    "NomicEmbeddings",
+    "OpenAIEmbeddings",
+    "VoyageEmbeddings",
+]
 
 _BACKENDS = {
     "ONNXEmbeddings": ".onnx",
+    "OpenAIEmbeddings": ".openai",
+    "CohereEmbeddings": ".cohere",
+    "VoyageEmbeddings": ".voyage",
+    "JinaEmbeddings": ".jina",
+    "GeminiEmbeddings": ".gemini",
+    "MistralEmbeddings": ".mistral",
+    "NomicEmbeddings": ".nomic",
+    "MixedbreadEmbeddings": ".mixedbread",
+    "HuggingFaceEmbeddings": ".huggingface",
 }
 
 

--- a/src/synapsekit/embeddings/backend.py
+++ b/src/synapsekit/embeddings/backend.py
@@ -1,17 +1,34 @@
+"""Local sentence-transformers embeddings backend."""
+
 from __future__ import annotations
 
 import numpy as np
 
+from .base import BaseEmbeddings
 
-class SynapsekitEmbeddings:
+
+class SynapsekitEmbeddings(BaseEmbeddings):
     """
     Async embeddings using sentence-transformers.
     Lazy-loads the model on first use.
     """
 
-    def __init__(self, model: str = "all-MiniLM-L6-v2", use_gpu: bool = False) -> None:
+    dimensions: int | None = 384
+
+    def __init__(
+        self,
+        model: str = "all-MiniLM-L6-v2",
+        use_gpu: bool = False,
+        *,
+        batch_size: int = 64,
+        normalize: bool = True,
+        dimensions: int | None = None,
+    ) -> None:
+        super().__init__(batch_size=batch_size, normalize=normalize)
         self.model = model
         self.use_gpu = use_gpu
+        if dimensions is not None:
+            self.dimensions = dimensions
         self._backend = None
 
     def _get_backend(self):
@@ -26,8 +43,8 @@ class SynapsekitEmbeddings:
             self._backend = SentenceTransformer(self.model, device=device)
         return self._backend
 
-    async def embed(self, texts: list[str]) -> np.ndarray:
-        """Embed a list of texts, returns (N, D) float32 array."""
+    async def _embed_raw(self, texts: list[str]) -> np.ndarray:
+        """Run the sentence-transformer model on ``texts``."""
         import asyncio
 
         from ..observe.runtime import end_span, record_exception, start_span
@@ -44,10 +61,7 @@ class SynapsekitEmbeddings:
             backend = self._get_backend()
             loop = asyncio.get_event_loop()
             vecs = await loop.run_in_executor(None, backend.encode, texts)
-            arr = np.array(vecs, dtype=np.float32)
-            norms = np.linalg.norm(arr, axis=1, keepdims=True)
-            norms = np.where(norms == 0, 1.0, norms)
-            return arr / norms
+            return np.array(vecs, dtype=np.float32)
         except Exception as exc:
             record_exception(span, exc)
             raise

--- a/src/synapsekit/embeddings/base.py
+++ b/src/synapsekit/embeddings/base.py
@@ -1,0 +1,76 @@
+"""Base contract for all SynapseKit embedding backends.
+
+Every provider — local (sentence-transformers, ONNX) and hosted (OpenAI,
+Cohere, Voyage, Jina, Gemini, Mistral, Nomic, mixedbread, Hugging Face) —
+implements the same uniform async interface:
+
+- ``embed(texts)``  -> ``(N, D)`` float32, L2-normalized rows
+- ``embed_one(text)`` -> ``(D,)`` float32
+- ``embed_batch(texts, batch_size)`` -> chunked ``embed``, same semantics
+- ``dimensions``   -> the static output dimension of the default model
+
+The L2-normalization guarantee matters: ``InMemoryVectorStore`` and the other
+vector-store backends compute cosine similarity as a plain dot product and
+therefore assume unit-length rows.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class BaseEmbeddings:
+    """Uniform async embeddings contract implemented by all backends."""
+
+    #: Static output dimension of the provider's default model. ``None`` when
+    #: the dimension can only be derived at runtime from an ``embed()`` call.
+    dimensions: int | None = None
+
+    def __init__(self, *, batch_size: int = 64, normalize: bool = True) -> None:
+        self._batch_size = batch_size
+        self._normalize = normalize
+
+    async def _embed_raw(self, texts: list[str]) -> np.ndarray:
+        """Provider-specific embed implementation, returning ``(N, D)``.
+
+        Subclasses must implement this. Values may be unnormalized; the base
+        ``embed()`` applies L2 normalization when ``normalize=True``.
+        """
+        raise NotImplementedError
+
+    async def embed(self, texts: list[str]) -> np.ndarray:
+        """Embed a list of texts, returning an ``(N, D)`` float32 array.
+
+        Rows are L2-normalized by default. An empty input list returns an
+        empty ``(0, 0)`` float32 array.
+        """
+        if not texts:
+            return np.empty((0, 0), dtype=np.float32)
+        arr = np.asarray(await self._embed_raw(texts), dtype=np.float32)
+        if self._normalize:
+            norms = np.linalg.norm(arr, axis=1, keepdims=True)
+            norms = np.where(norms == 0, 1.0, norms)
+            arr = (arr / norms).astype(np.float32)
+        return arr
+
+    async def embed_one(self, text: str) -> np.ndarray:
+        """Embed a single string, returning a ``(D,)`` float32 array."""
+        arr = await self.embed([text])
+        return arr[0]
+
+    async def embed_batch(
+        self,
+        texts: list[str],
+        batch_size: int | None = None,
+    ) -> np.ndarray:
+        """Embed ``texts`` in chunks, returning the same result as ``embed``.
+
+        Useful for providers with per-request input limits. Chunking is
+        semantically transparent: results are concatenated in input order.
+        """
+        if not texts:
+            return np.empty((0, 0), dtype=np.float32)
+        size = self._batch_size if batch_size is None else batch_size
+        chunks = [texts[i : i + size] for i in range(0, len(texts), size)]
+        parts = [await self.embed(chunk) for chunk in chunks]
+        return np.concatenate(parts, axis=0)

--- a/src/synapsekit/embeddings/cohere.py
+++ b/src/synapsekit/embeddings/cohere.py
@@ -1,0 +1,86 @@
+"""Cohere embeddings provider (embed-v3, input-type aware)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import numpy as np
+
+from .base import BaseEmbeddings
+
+
+class CohereEmbeddings(BaseEmbeddings):
+    """Async embeddings backed by the Cohere Embed API.
+
+    Cohere's ``embed-v3`` models are input-type aware: documents and queries
+    should be embedded with ``input_type="search_document"`` and
+    ``input_type="search_query"`` respectively. ``embed()`` uses the document
+    type; ``embed_one()`` switches to the query type so the same instance can
+    serve both ingestion and retrieval.
+
+    Usage::
+
+        emb = CohereEmbeddings(api_key="...")               # or CO_API_KEY
+        doc_vecs = await emb.embed(["doc1", "doc2"])
+        query_vec = await emb.embed_one("a question")       # search_query
+
+    Requires ``cohere``: ``pip install synapsekit[cohere]``
+    """
+
+    dimensions: int | None = 1024
+
+    def __init__(
+        self,
+        model: str = "embed-v3",
+        *,
+        api_key: str | None = None,
+        input_type: str = "search_document",
+        query_input_type: str = "search_query",
+        batch_size: int = 64,
+        normalize: bool = True,
+    ) -> None:
+        super().__init__(batch_size=batch_size, normalize=normalize)
+        self.model = model
+        self._api_key = api_key
+        self._input_type = input_type
+        self._query_input_type = query_input_type
+        self._client: Any = None
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            try:
+                from cohere import AsyncClientV2
+            except ImportError:
+                raise ImportError("cohere required: pip install synapsekit[cohere]") from None
+            key = self._api_key or os.environ.get("CO_API_KEY")
+            if not key:
+                raise ValueError("CO_API_KEY is not set")
+            self._client = AsyncClientV2(api_key=key)
+        return self._client
+
+    async def _embed_raw(self, texts: list[str]) -> np.ndarray:
+        client = self._get_client()
+        resp = await client.embed(
+            model=self.model,
+            texts=texts,
+            input_type=self._input_type,
+            embedding_types=["float"],
+        )
+        return np.asarray(resp.embeddings.float_, dtype=np.float32)
+
+    async def embed_one(self, text: str) -> np.ndarray:
+        """Embed a single string using the query input type."""
+        client = self._get_client()
+        resp = await client.embed(
+            model=self.model,
+            texts=[text],
+            input_type=self._query_input_type,
+            embedding_types=["float"],
+        )
+        vec = np.asarray(resp.embeddings.float_[0], dtype=np.float32)
+        if self._normalize:
+            norm = np.linalg.norm(vec)
+            if norm != 0:
+                vec = vec / norm
+        return vec

--- a/src/synapsekit/embeddings/gemini.py
+++ b/src/synapsekit/embeddings/gemini.py
@@ -1,0 +1,60 @@
+"""Google Gemini embeddings provider (text-embedding-004)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import numpy as np
+
+from .base import BaseEmbeddings
+
+
+class GeminiEmbeddings(BaseEmbeddings):
+    """Async embeddings backed by the Google Gemini Embeddings API.
+
+    Usage::
+
+        emb = GeminiEmbeddings(api_key="AIza...")           # or GEMINI_API_KEY
+        vecs = await emb.embed(["hello", "world"])          # (2, 768) float32
+
+    Requires ``google-genai``: ``pip install synapsekit[gemini]``
+    """
+
+    dimensions: int | None = 768
+
+    def __init__(
+        self,
+        model: str = "text-embedding-004",
+        *,
+        api_key: str | None = None,
+        batch_size: int = 64,
+        normalize: bool = True,
+    ) -> None:
+        super().__init__(batch_size=batch_size, normalize=normalize)
+        self.model = model
+        self._api_key = api_key
+        self._client: Any = None
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            try:
+                from google import genai
+            except ImportError:
+                raise ImportError("google-genai required: pip install synapsekit[gemini]") from None
+            key = self._api_key or os.environ.get("GEMINI_API_KEY")
+            if not key:
+                raise ValueError("GEMINI_API_KEY is not set")
+            self._client = genai.Client(api_key=key)
+        return self._client
+
+    async def _embed_raw(self, texts: list[str]) -> np.ndarray:
+        client = self._get_client()
+        resp = await client.models.embed_content(
+            model=self.model,
+            contents=texts,
+        )
+        return np.asarray(
+            [item.values for item in resp.embeddings],
+            dtype=np.float32,
+        )

--- a/src/synapsekit/embeddings/http.py
+++ b/src/synapsekit/embeddings/http.py
@@ -1,0 +1,105 @@
+"""Shared HTTP transport for OpenAI-compatible embeddings providers.
+
+Used by Voyage, Jina, Nomic, mixedbread, and Hugging Face (Inference API /
+TEI). All of them accept ``POST <base_url>/embeddings`` with an
+``{"model": ..., "input": [...]}`` body and return
+``{"data": [{"index": ..., "embedding": [...]}]}``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import numpy as np
+
+from .base import BaseEmbeddings
+
+
+class HTTPEmbeddings(BaseEmbeddings):
+    """Async embeddings over a generic ``/embeddings`` HTTP endpoint.
+
+    Constructor arguments:
+
+    - ``model``: model name sent in the request body.
+    - ``api_key``: explicit API key; falls back to ``os.environ[env_key]``.
+      When neither is available, a ``ValueError`` is raised on first use.
+    - ``base_url``: provider base URL; the endpoint is ``{base_url}/embeddings``.
+    - ``env_key``: environment variable holding the API key.
+    - ``batch_size`` / ``normalize``: inherited from ``BaseEmbeddings``.
+    - ``request_extra``: extra static JSON fields merged into every request
+      body (e.g. ``task=...`` for Jina, ``task_type=...`` for Nomic).
+    """
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        api_key: str | None = None,
+        base_url: str,
+        env_key: str,
+        batch_size: int = 64,
+        normalize: bool = True,
+        timeout: float = 60.0,
+        **request_extra: Any,
+    ) -> None:
+        super().__init__(batch_size=batch_size, normalize=normalize)
+        self.model = model
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._env_key = env_key
+        self._timeout = timeout
+        self._request_extra = request_extra
+        self._client: Any = None
+
+    def _get_key(self) -> str:
+        key = self._api_key or os.environ.get(self._env_key)
+        if not key:
+            raise ValueError(f"{self._env_key} is not set")
+        return key
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            try:
+                import httpx
+            except ImportError:
+                raise ImportError("httpx required: pip install synapsekit[web]") from None
+            self._get_key()  # fail fast on a missing key
+            self._client = httpx.Client(timeout=self._timeout)
+        return self._client
+
+    async def _embed_raw(self, texts: list[str]) -> np.ndarray:
+        """POST to ``{base_url}/embeddings`` and parse the response."""
+        import asyncio
+        import json
+
+        client = self._get_client()
+        payload: dict[str, Any] = {"model": self.model, "input": texts}
+        payload.update(self._request_extra)
+
+        def _request() -> dict[str, Any]:
+            resp = client.post(
+                f"{self._base_url}/embeddings",
+                headers={"Authorization": f"Bearer {self._get_key()}"},
+                json=payload,
+            )
+            if resp.status_code != 200:
+                raise RuntimeError(
+                    f"Embedding request failed: HTTP {resp.status_code} {resp.text[:200]}"
+                )
+            return json.loads(resp.content)
+
+        try:
+            data = await asyncio.to_thread(_request)
+        except RuntimeError:
+            raise
+        except Exception as exc:
+            raise RuntimeError(f"Embedding request failed: {exc}") from exc
+
+        items = data.get("data")
+        if not isinstance(items, list):
+            raise RuntimeError(f"Unexpected embedding response: {data!r}")
+
+        ordered = sorted(items, key=lambda item: item["index"])
+        vecs = np.asarray([item["embedding"] for item in ordered], dtype=np.float32)
+        return vecs

--- a/src/synapsekit/embeddings/huggingface.py
+++ b/src/synapsekit/embeddings/huggingface.py
@@ -1,0 +1,108 @@
+"""Hugging Face embeddings provider (Inference API / TEI)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import numpy as np
+
+from .base import BaseEmbeddings
+
+
+class HuggingFaceEmbeddings(BaseEmbeddings):
+    """Async embeddings backed by Hugging Face.
+
+    Two endpoints are supported:
+
+    - **Inference API** (default): ``POST https://api-inference.huggingface.co/
+      models/{model}`` with ``{"inputs": texts}`` — returns a JSON list of
+      vectors. Default model ``BAAI/bge-base-en-v1.5`` (768 dims).
+    - **TEI** (Text Embeddings Inference, self-hosted): pass ``base_url``,
+      e.g. ``base_url="http://localhost:8080"`` — posts ``{"inputs": texts}``
+      to ``{base_url}/embed``.
+
+    Usage::
+
+        emb = HuggingFaceEmbeddings()                        # BAAI/bge-base-en-v1.5
+        emb = HuggingFaceEmbeddings(model="sentence-transformers/all-MiniLM-L6-v2")
+        emb = HuggingFaceEmbeddings(base_url="http://localhost:8080")
+        vecs = await emb.embed(["hello", "world"])
+
+    Requires ``httpx``: ``pip install synapsekit[huggingface]``
+    """
+
+    dimensions: int | None = 768
+
+    def __init__(
+        self,
+        model: str = "BAAI/bge-base-en-v1.5",
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        batch_size: int = 64,
+        normalize: bool = True,
+        timeout: float = 60.0,
+    ) -> None:
+        super().__init__(batch_size=batch_size, normalize=normalize)
+        self.model = model
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/") if base_url else None
+        self._timeout = timeout
+        self._client: Any = None
+
+    def _get_key(self) -> str:
+        key = self._api_key or os.environ.get("HF_TOKEN") or os.environ.get("HF_API_KEY")
+        if not key:
+            raise ValueError("HF_TOKEN is not set")
+        return key
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            try:
+                import httpx
+            except ImportError:
+                raise ImportError("httpx required: pip install synapsekit[huggingface]") from None
+            self._get_key()  # fail fast on a missing key
+            self._client = httpx.Client(timeout=self._timeout)
+        return self._client
+
+    def _url(self) -> str:
+        if self._base_url is not None:
+            return f"{self._base_url}/embed"
+        return f"https://api-inference.huggingface.co/models/{self.model}"
+
+    async def _embed_raw(self, texts: list[str]) -> np.ndarray:
+        import asyncio
+        import json
+
+        client = self._get_client()
+        url = self._url()
+
+        def _request() -> Any:
+            resp = client.post(
+                url,
+                headers={"Authorization": f"Bearer {self._get_key()}"},
+                json={"inputs": texts},
+            )
+            if resp.status_code != 200:
+                raise RuntimeError(
+                    f"Hugging Face embedding request failed: HTTP {resp.status_code} "
+                    f"{resp.text[:200]}"
+                )
+            return json.loads(resp.content)
+
+        try:
+            data = await asyncio.to_thread(_request)
+        except RuntimeError:
+            raise
+        except Exception as exc:
+            raise RuntimeError(f"Hugging Face embedding request failed: {exc}") from exc
+
+        if isinstance(data, dict) and isinstance(data.get("data"), list):
+            # Some TEI versions return OpenAI-style objects.
+            ordered = sorted(data["data"], key=lambda item: item["index"])
+            return np.asarray([item["embedding"] for item in ordered], dtype=np.float32)
+        if isinstance(data, list):
+            return np.asarray(data, dtype=np.float32)
+        raise RuntimeError(f"Unexpected Hugging Face embedding response: {data!r}")

--- a/src/synapsekit/embeddings/jina.py
+++ b/src/synapsekit/embeddings/jina.py
@@ -1,0 +1,52 @@
+"""Jina AI embeddings provider (jina-embeddings-v3, long-context, task LoRA)."""
+
+from __future__ import annotations
+
+from .http import HTTPEmbeddings
+
+
+class JinaEmbeddings(HTTPEmbeddings):
+    """Async embeddings backed by the Jina AI Embeddings API.
+
+    ``jina-embeddings-v3`` supports long contexts (8k tokens) and task LoRA
+    via the ``task`` field — e.g. ``"retrieval.passage"`` for ingestion and
+    ``"retrieval.query"`` for queries.
+
+    Usage::
+
+        emb = JinaEmbeddings(api_key="jina_...")            # or JINA_API_KEY
+        emb = JinaEmbeddings(task="retrieval.passage", dimensions=1024)
+        vecs = await emb.embed(["hello", "world"])
+
+    Requires ``httpx``: ``pip install synapsekit[jina]``
+    """
+
+    dimensions: int | None = 1024
+
+    def __init__(
+        self,
+        model: str = "jina-embeddings-v3",
+        *,
+        api_key: str | None = None,
+        task: str | None = None,
+        dimensions: int | None = None,
+        batch_size: int = 64,
+        normalize: bool = True,
+        timeout: float = 60.0,
+    ) -> None:
+        request_extra: dict[str, str | int] = {}
+        if task is not None:
+            request_extra["task"] = task
+        if dimensions is not None:
+            request_extra["dimensions"] = dimensions
+            self.dimensions = dimensions
+        super().__init__(
+            model,
+            api_key=api_key,
+            base_url="https://api.jina.ai/v1",
+            env_key="JINA_API_KEY",
+            batch_size=batch_size,
+            normalize=normalize,
+            timeout=timeout,
+            **request_extra,
+        )

--- a/src/synapsekit/embeddings/mistral.py
+++ b/src/synapsekit/embeddings/mistral.py
@@ -1,0 +1,55 @@
+"""Mistral embeddings provider (mistral-embed)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import numpy as np
+
+from .base import BaseEmbeddings
+
+
+class MistralEmbeddings(BaseEmbeddings):
+    """Async embeddings backed by the Mistral Embeddings API.
+
+    Usage::
+
+        emb = MistralEmbeddings(api_key="...")              # or MISTRAL_API_KEY
+        vecs = await emb.embed(["hello", "world"])          # (2, 1024) float32
+
+    Requires ``mistralai``: ``pip install synapsekit[mistral]``
+    """
+
+    dimensions: int | None = 1024
+
+    def __init__(
+        self,
+        model: str = "mistral-embed",
+        *,
+        api_key: str | None = None,
+        batch_size: int = 64,
+        normalize: bool = True,
+    ) -> None:
+        super().__init__(batch_size=batch_size, normalize=normalize)
+        self.model = model
+        self._api_key = api_key
+        self._client: Any = None
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            try:
+                from mistralai import Mistral
+            except ImportError:
+                raise ImportError("mistralai required: pip install synapsekit[mistral]") from None
+            key = self._api_key or os.environ.get("MISTRAL_API_KEY")
+            if not key:
+                raise ValueError("MISTRAL_API_KEY is not set")
+            self._client = Mistral(api_key=key)
+        return self._client
+
+    async def _embed_raw(self, texts: list[str]) -> np.ndarray:
+        client = self._get_client()
+        resp = await client.embeddings_async(model=self.model, inputs=texts)
+        ordered = sorted(resp.data, key=lambda item: item.index)
+        return np.asarray([item.embedding for item in ordered], dtype=np.float32)

--- a/src/synapsekit/embeddings/mixedbread.py
+++ b/src/synapsekit/embeddings/mixedbread.py
@@ -1,0 +1,38 @@
+"""mixedbread embeddings provider (mxbai-embed-large)."""
+
+from __future__ import annotations
+
+from .http import HTTPEmbeddings
+
+
+class MixedbreadEmbeddings(HTTPEmbeddings):
+    """Async embeddings backed by the mixedbread.ai Embeddings API.
+
+    Usage::
+
+        emb = MixedbreadEmbeddings(api_key="mxb_...")       # or MXBAI_API_KEY
+        vecs = await emb.embed(["hello", "world"])          # (2, 1024) float32
+
+    Requires ``httpx``: ``pip install synapsekit[mixedbread]``
+    """
+
+    dimensions: int | None = 1024
+
+    def __init__(
+        self,
+        model: str = "mxbai-embed-large",
+        *,
+        api_key: str | None = None,
+        batch_size: int = 64,
+        normalize: bool = True,
+        timeout: float = 60.0,
+    ) -> None:
+        super().__init__(
+            model,
+            api_key=api_key,
+            base_url="https://api.mixedbread.ai/v1",
+            env_key="MXBAI_API_KEY",
+            batch_size=batch_size,
+            normalize=normalize,
+            timeout=timeout,
+        )

--- a/src/synapsekit/embeddings/nomic.py
+++ b/src/synapsekit/embeddings/nomic.py
@@ -1,0 +1,61 @@
+"""Nomic embeddings provider (nomic-embed-text, open + Atlas)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .http import HTTPEmbeddings
+
+
+class NomicEmbeddings(HTTPEmbeddings):
+    """Async embeddings backed by the Nomic Embeddings API.
+
+    ``nomic-embed-text`` supports a ``task_type`` field; ingestion should use
+    ``search_document`` and queries ``search_query``. ``embed()`` sends the
+    document type, ``embed_one()`` the query type, matching the Cohere
+    input-type pattern.
+
+    Usage::
+
+        emb = NomicEmbeddings(api_key="nomic_...")          # or NOMIC_API_KEY
+        vecs = await emb.embed(["hello", "world"])
+        query_vec = await emb.embed_one("a question")       # search_query
+
+    Requires ``httpx``: ``pip install synapsekit[nomic]``
+    """
+
+    dimensions: int | None = 768
+
+    def __init__(
+        self,
+        model: str = "nomic-embed-text",
+        *,
+        api_key: str | None = None,
+        task_type: str = "search_document",
+        query_task_type: str = "search_query",
+        batch_size: int = 64,
+        normalize: bool = True,
+        timeout: float = 60.0,
+    ) -> None:
+        self._task_type = task_type
+        self._query_task_type = query_task_type
+        super().__init__(
+            model,
+            api_key=api_key,
+            base_url="https://api.nomic.ai/v1",
+            env_key="NOMIC_API_KEY",
+            batch_size=batch_size,
+            normalize=normalize,
+            timeout=timeout,
+            task_type=task_type,
+        )
+
+    async def embed_one(self, text: str) -> np.ndarray:
+        """Embed a single string using the query task type."""
+        old = self._request_extra.get("task_type")
+        self._request_extra["task_type"] = self._query_task_type
+        try:
+            arr = await self.embed([text])
+            return arr[0]
+        finally:
+            self._request_extra["task_type"] = old

--- a/src/synapsekit/embeddings/openai.py
+++ b/src/synapsekit/embeddings/openai.py
@@ -1,0 +1,63 @@
+"""OpenAI embeddings provider (text-embedding-3-small/large)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import numpy as np
+
+from .base import BaseEmbeddings
+
+
+class OpenAIEmbeddings(BaseEmbeddings):
+    """Async embeddings backed by the OpenAI Embeddings API.
+
+    Usage::
+
+        emb = OpenAIEmbeddings(api_key="sk-...")            # or OPENAI_API_KEY
+        vecs = await emb.embed(["hello", "world"])          # (2, 1536) float32
+
+    Requires ``openai``: ``pip install synapsekit[openai]``
+    """
+
+    dimensions: int | None = 1536
+
+    def __init__(
+        self,
+        model: str = "text-embedding-3-small",
+        *,
+        api_key: str | None = None,
+        dimensions: int | None = None,
+        batch_size: int = 64,
+        normalize: bool = True,
+    ) -> None:
+        super().__init__(batch_size=batch_size, normalize=normalize)
+        self.model = model
+        self._api_key = api_key
+        if dimensions is not None:
+            self.dimensions = dimensions
+        self._client: Any = None
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            try:
+                from openai import AsyncOpenAI
+            except ImportError:
+                raise ImportError(
+                    "openai package required: pip install synapsekit[openai]"
+                ) from None
+            key = self._api_key or os.environ.get("OPENAI_API_KEY")
+            if not key:
+                raise ValueError("OPENAI_API_KEY is not set")
+            self._client = AsyncOpenAI(api_key=key)
+        return self._client
+
+    async def _embed_raw(self, texts: list[str]) -> np.ndarray:
+        client = self._get_client()
+        kwargs: dict[str, Any] = {"model": self.model, "input": texts}
+        if self.dimensions is not None:
+            kwargs["dimensions"] = self.dimensions
+        resp = await client.embeddings.create(**kwargs)
+        ordered = sorted(resp.data, key=lambda item: item.index)
+        return np.asarray([item.embedding for item in ordered], dtype=np.float32)

--- a/src/synapsekit/embeddings/voyage.py
+++ b/src/synapsekit/embeddings/voyage.py
@@ -1,0 +1,40 @@
+"""Voyage AI embeddings provider (voyage-3)."""
+
+from __future__ import annotations
+
+from .http import HTTPEmbeddings
+
+
+class VoyageEmbeddings(HTTPEmbeddings):
+    """Async embeddings backed by the Voyage AI Embeddings API.
+
+    Voyage models are retrieval-optimized and strong on code/finance domains.
+
+    Usage::
+
+        emb = VoyageEmbeddings(api_key="pa-...")            # or VOYAGE_API_KEY
+        vecs = await emb.embed(["hello", "world"])          # (2, 1024) float32
+
+    Requires ``httpx``: ``pip install synapsekit[voyage]``
+    """
+
+    dimensions: int | None = 1024
+
+    def __init__(
+        self,
+        model: str = "voyage-3",
+        *,
+        api_key: str | None = None,
+        batch_size: int = 64,
+        normalize: bool = True,
+        timeout: float = 60.0,
+    ) -> None:
+        super().__init__(
+            model,
+            api_key=api_key,
+            base_url="https://api.voyageai.com/v1",
+            env_key="VOYAGE_API_KEY",
+            batch_size=batch_size,
+            normalize=normalize,
+            timeout=timeout,
+        )

--- a/src/synapsekit/retrieval/__init__.py
+++ b/src/synapsekit/retrieval/__init__.py
@@ -14,7 +14,9 @@ from .full_context import FullContextRetriever
 from .graphrag import GraphRAGRetriever, KnowledgeGraph
 from .hybrid_search import HybridSearchRetriever
 from .hyde import HyDERetriever
+from .jina_reranker import JinaReranker
 from .late_chunking import LateChunkingRetriever
+from .mixedbread_reranker import MixedbreadReranker
 from .mongodb_atlas import MongoDBAtlasVectorStore
 from .multi_step import MultiStepRetriever
 from .parent_document import ParentDocumentRetriever
@@ -31,6 +33,7 @@ from .property_graph import (
 )
 from .query_decomposition import QueryDecompositionRetriever
 from .raptor import RAPTORRetriever
+from .reranker import Reranker
 from .retriever import Retriever
 from .self_query import SelfQueryRetriever
 from .self_rag import SelfRAGRetriever
@@ -38,6 +41,7 @@ from .step_back import StepBackRetriever
 from .strategies.colbert import ColBERTRetriever
 from .token_counting import TokenCounter
 from .vectorstore import InMemoryVectorStore
+from .voyage_reranker import VoyageReranker
 from .world_model import (
     CausalLinker,
     EntityMention,
@@ -86,6 +90,7 @@ __all__ = [
     "HybridSearchRetriever",
     "HyDERetriever",
     "InMemoryVectorStore",
+    "JinaReranker",
     "KnowledgeGraph",
     "KnowledgeGraphExtraction",
     "KnowledgeGraphExtractor",
@@ -93,6 +98,7 @@ __all__ = [
     "MarqoVectorStore",
     "MilvusVectorStore",
     "MongoDBAtlasVectorStore",
+    "MixedbreadReranker",
     "MultiStepRetriever",
     "Neo4jPropertyGraphBackend",
     "NetworkXPropertyGraphBackend",
@@ -105,6 +111,7 @@ __all__ = [
     "QdrantVectorStore",
     "QueryDecompositionRetriever",
     "RedisVectorStore",
+    "Reranker",
     "Retriever",
     "SelfQueryRetriever",
     "SelfRAGRetriever",
@@ -115,6 +122,7 @@ __all__ = [
     "TypesenseVectorStore",
     "VectorStore",
     "VespaVectorStore",
+    "VoyageReranker",
     "WeaviateVectorStore",
     "CausalLinker",
     "EntityMention",

--- a/src/synapsekit/retrieval/cohere_reranker.py
+++ b/src/synapsekit/retrieval/cohere_reranker.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from .reranker import Reranker
 from .retriever import Retriever
 
 
-class CohereReranker:
+class CohereReranker(Reranker):
     """Rerank retrieval results using Cohere's rerank models.
 
     Usage::
@@ -26,10 +27,7 @@ class CohereReranker:
         api_key: str | None = None,
         fetch_k: int = 20,
     ) -> None:
-        self._retriever = retriever
-        self._model = model
-        self._api_key = api_key
-        self._fetch_k = fetch_k
+        super().__init__(retriever, model, api_key=api_key, fetch_k=fetch_k)
         self._client: Any = None
 
     def _get_client(self):

--- a/src/synapsekit/retrieval/cross_encoder.py
+++ b/src/synapsekit/retrieval/cross_encoder.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from .reranker import Reranker
 from .retriever import Retriever
 
 
-class CrossEncoderReranker:
+class CrossEncoderReranker(Reranker):
     """Rerank retrieval results using a cross-encoder model for higher precision.
 
     Cross-encoders score query-document pairs jointly, giving much more
@@ -28,9 +29,9 @@ class CrossEncoderReranker:
         model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2",
         fetch_k: int = 20,
     ) -> None:
-        self._retriever = retriever
+        super().__init__(retriever, model, fetch_k=fetch_k)
+        # Backwards-compatible alias used by `_get_cross_encoder`.
         self._model_name = model
-        self._fetch_k = fetch_k
         self._cross_encoder = None
 
     def _get_cross_encoder(self):

--- a/src/synapsekit/retrieval/jina_reranker.py
+++ b/src/synapsekit/retrieval/jina_reranker.py
@@ -1,0 +1,108 @@
+"""Jina AI reranker (jina-reranker-v2)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from .reranker import Reranker
+
+
+class JinaReranker(Reranker):
+    """Rerank retrieval results using the Jina AI Rerank API.
+
+    Usage::
+
+        reranker = JinaReranker(retriever=retriever, model="jina-reranker-v2-base-multilingual")
+        results = await reranker.retrieve("What is RAG?", top_k=5)
+
+    Requires ``httpx``: ``pip install synapsekit[jina]``
+    """
+
+    def __init__(
+        self,
+        retriever,
+        model: str = "jina-reranker-v2-base-multilingual",
+        api_key: str | None = None,
+        fetch_k: int = 20,
+    ) -> None:
+        super().__init__(retriever, model, api_key=api_key, fetch_k=fetch_k)
+        self._client: Any = None
+
+    def _get_key(self) -> str:
+        key = self._api_key or os.environ.get("JINA_API_KEY")
+        if not key:
+            raise ValueError("JINA_API_KEY is not set")
+        return key
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            try:
+                import httpx
+            except ImportError:
+                raise ImportError(
+                    "httpx required for JinaReranker: pip install synapsekit[jina]"
+                ) from None
+            self._client = httpx.Client(timeout=60.0)
+        return self._client
+
+    def _call(self, query: str, documents: list[str], top_n: int) -> list[dict]:
+        import json
+
+        client = self._get_client()
+        resp = client.post(
+            "https://api.jina.ai/v1/rerank",
+            headers={"Authorization": f"Bearer {self._get_key()}"},
+            json={
+                "model": self._model,
+                "query": query,
+                "documents": documents,
+            },
+        )
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"Jina rerank request failed: HTTP {resp.status_code} {resp.text[:200]}"
+            )
+        data = json.loads(resp.content)
+        scored = sorted(
+            (
+                {"text": documents[item["index"]], "relevance_score": item["relevance_score"]}
+                for item in data["results"]
+            ),
+            key=lambda r: r["relevance_score"],
+            reverse=True,
+        )
+        return scored[:top_n]
+
+    async def retrieve(
+        self,
+        query: str,
+        top_k: int = 5,
+        metadata_filter: dict | None = None,
+    ) -> list[str]:
+        """Retrieve candidates then rerank with the Jina Rerank API."""
+        import asyncio
+
+        results = await self._retriever.retrieve(
+            query, top_k=self._fetch_k, metadata_filter=metadata_filter
+        )
+        if not results:
+            return []
+        scored = await asyncio.to_thread(self._call, query, results, top_k)
+        return [r["text"] for r in scored]
+
+    async def retrieve_with_scores(
+        self,
+        query: str,
+        top_k: int = 5,
+        metadata_filter: dict | None = None,
+    ) -> list[dict]:
+        """Retrieve and return results with Jina relevance scores."""
+        import asyncio
+
+        results = await self._retriever.retrieve(
+            query, top_k=self._fetch_k, metadata_filter=metadata_filter
+        )
+        if not results:
+            return []
+        return await asyncio.to_thread(self._call, query, results, top_k)

--- a/src/synapsekit/retrieval/mixedbread_reranker.py
+++ b/src/synapsekit/retrieval/mixedbread_reranker.py
@@ -1,0 +1,108 @@
+"""mixedbread reranker (mxbai-rerank)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from .reranker import Reranker
+
+
+class MixedbreadReranker(Reranker):
+    """Rerank retrieval results using the mixedbread.ai Rerank API.
+
+    Usage::
+
+        reranker = MixedbreadReranker(retriever=retriever, model="mxbai-rerank-base-v2")
+        results = await reranker.retrieve("What is RAG?", top_k=5)
+
+    Requires ``httpx``: ``pip install synapsekit[mixedbread]``
+    """
+
+    def __init__(
+        self,
+        retriever,
+        model: str = "mxbai-rerank-base-v2",
+        api_key: str | None = None,
+        fetch_k: int = 20,
+    ) -> None:
+        super().__init__(retriever, model, api_key=api_key, fetch_k=fetch_k)
+        self._client: Any = None
+
+    def _get_key(self) -> str:
+        key = self._api_key or os.environ.get("MXBAI_API_KEY")
+        if not key:
+            raise ValueError("MXBAI_API_KEY is not set")
+        return key
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            try:
+                import httpx
+            except ImportError:
+                raise ImportError(
+                    "httpx required for MixedbreadReranker: pip install synapsekit[mixedbread]"
+                ) from None
+            self._client = httpx.Client(timeout=60.0)
+        return self._client
+
+    def _call(self, query: str, documents: list[str], top_n: int) -> list[dict]:
+        import json
+
+        client = self._get_client()
+        resp = client.post(
+            "https://api.mixedbread.ai/v1/rerank",
+            headers={"Authorization": f"Bearer {self._get_key()}"},
+            json={
+                "model": self._model,
+                "query": query,
+                "documents": documents,
+            },
+        )
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"Mixedbread rerank request failed: HTTP {resp.status_code} {resp.text[:200]}"
+            )
+        data = json.loads(resp.content)
+        scored = sorted(
+            (
+                {"text": documents[item["index"]], "relevance_score": item["relevance_score"]}
+                for item in data["data"]
+            ),
+            key=lambda r: r["relevance_score"],
+            reverse=True,
+        )
+        return scored[:top_n]
+
+    async def retrieve(
+        self,
+        query: str,
+        top_k: int = 5,
+        metadata_filter: dict | None = None,
+    ) -> list[str]:
+        """Retrieve candidates then rerank with the mixedbread Rerank API."""
+        import asyncio
+
+        results = await self._retriever.retrieve(
+            query, top_k=self._fetch_k, metadata_filter=metadata_filter
+        )
+        if not results:
+            return []
+        scored = await asyncio.to_thread(self._call, query, results, top_k)
+        return [r["text"] for r in scored]
+
+    async def retrieve_with_scores(
+        self,
+        query: str,
+        top_k: int = 5,
+        metadata_filter: dict | None = None,
+    ) -> list[dict]:
+        """Retrieve and return results with mixedbread relevance scores."""
+        import asyncio
+
+        results = await self._retriever.retrieve(
+            query, top_k=self._fetch_k, metadata_filter=metadata_filter
+        )
+        if not results:
+            return []
+        return await asyncio.to_thread(self._call, query, results, top_k)

--- a/src/synapsekit/retrieval/reranker.py
+++ b/src/synapsekit/retrieval/reranker.py
@@ -1,0 +1,56 @@
+"""Base contract for all SynapseKit rerankers.
+
+Every reranker — hosted (Cohere, Voyage, Jina, mixedbread) and local
+(cross-encoder) — implements the same uniform async interface:
+
+- ``retrieve(query, top_k)`` -> ``list[str]``
+- ``retrieve_with_scores(query, top_k)`` -> ``list[dict]``
+  with ``{"text": ..., "relevance_score": ...}``
+
+Rerankers wrap a ``Retriever`` (or anything exposing the same
+``retrieve``/``retrieve_with_scores`` async methods): they fetch ``fetch_k``
+candidates, score them with the provider model, and return the top ``top_k``
+in relevance order.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from .retriever import Retriever
+
+
+class Reranker(ABC):
+    """Abstract base class for all reranker implementations."""
+
+    def __init__(
+        self,
+        retriever: Retriever,
+        model: str,
+        api_key: str | None = None,
+        fetch_k: int = 20,
+    ) -> None:
+        self._retriever = retriever
+        self._model = model
+        self._api_key = api_key
+        self._fetch_k = fetch_k
+
+    @abstractmethod
+    async def retrieve(
+        self,
+        query: str,
+        top_k: int = 5,
+        metadata_filter: dict | None = None,
+    ) -> list[str]:
+        """Return the top-``top_k`` reranked document texts."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def retrieve_with_scores(
+        self,
+        query: str,
+        top_k: int = 5,
+        metadata_filter: dict | None = None,
+    ) -> list[dict]:
+        """Return the top-``top_k`` reranked results with scores."""
+        raise NotImplementedError

--- a/src/synapsekit/retrieval/voyage_reranker.py
+++ b/src/synapsekit/retrieval/voyage_reranker.py
@@ -1,0 +1,108 @@
+"""Voyage AI reranker (rerank-2)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from .reranker import Reranker
+
+
+class VoyageReranker(Reranker):
+    """Rerank retrieval results using the Voyage AI Rerank API.
+
+    Usage::
+
+        reranker = VoyageReranker(retriever=retriever, model="rerank-2")
+        results = await reranker.retrieve("What is RAG?", top_k=5)
+
+    Requires ``httpx``: ``pip install synapsekit[voyage]``
+    """
+
+    def __init__(
+        self,
+        retriever,
+        model: str = "rerank-2",
+        api_key: str | None = None,
+        fetch_k: int = 20,
+    ) -> None:
+        super().__init__(retriever, model, api_key=api_key, fetch_k=fetch_k)
+        self._client: Any = None
+
+    def _get_key(self) -> str:
+        key = self._api_key or os.environ.get("VOYAGE_API_KEY")
+        if not key:
+            raise ValueError("VOYAGE_API_KEY is not set")
+        return key
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            try:
+                import httpx
+            except ImportError:
+                raise ImportError(
+                    "httpx required for VoyageReranker: pip install synapsekit[voyage]"
+                ) from None
+            self._client = httpx.Client(timeout=60.0)
+        return self._client
+
+    def _call(self, query: str, documents: list[str], top_n: int) -> list[dict]:
+        import json
+
+        client = self._get_client()
+        resp = client.post(
+            "https://api.voyageai.com/v1/rerank",
+            headers={"Authorization": f"Bearer {self._get_key()}"},
+            json={
+                "model": self._model,
+                "query": query,
+                "documents": documents,
+            },
+        )
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"Voyage rerank request failed: HTTP {resp.status_code} {resp.text[:200]}"
+            )
+        data = json.loads(resp.content)
+        scored = sorted(
+            (
+                {"text": documents[item["index"]], "relevance_score": item["relevance_score"]}
+                for item in data["data"]
+            ),
+            key=lambda r: r["relevance_score"],
+            reverse=True,
+        )
+        return scored[:top_n]
+
+    async def retrieve(
+        self,
+        query: str,
+        top_k: int = 5,
+        metadata_filter: dict | None = None,
+    ) -> list[str]:
+        """Retrieve candidates then rerank with the Voyage Rerank API."""
+        import asyncio
+
+        results = await self._retriever.retrieve(
+            query, top_k=self._fetch_k, metadata_filter=metadata_filter
+        )
+        if not results:
+            return []
+        scored = await asyncio.to_thread(self._call, query, results, top_k)
+        return [r["text"] for r in scored]
+
+    async def retrieve_with_scores(
+        self,
+        query: str,
+        top_k: int = 5,
+        metadata_filter: dict | None = None,
+    ) -> list[dict]:
+        """Retrieve and return results with Voyage relevance scores."""
+        import asyncio
+
+        results = await self._retriever.retrieve(
+            query, top_k=self._fetch_k, metadata_filter=metadata_filter
+        )
+        if not results:
+            return []
+        return await asyncio.to_thread(self._call, query, results, top_k)

--- a/tests/embeddings/conftest.py
+++ b/tests/embeddings/conftest.py
@@ -1,0 +1,15 @@
+"""Shared fixtures for embeddings tests."""
+
+from __future__ import annotations
+
+
+def embed_payload(model: str, dim: int, texts: list[str]) -> dict:
+    """Build an OpenAI-style embedding API response body."""
+    return {
+        "object": "list",
+        "data": [
+            {"object": "embedding", "index": i, "embedding": [0.1] * dim} for i in range(len(texts))
+        ],
+        "model": model,
+        "usage": {"prompt_tokens": 4, "total_tokens": 4},
+    }

--- a/tests/embeddings/test_cohere_embeddings.py
+++ b/tests/embeddings/test_cohere_embeddings.py
@@ -1,0 +1,69 @@
+"""HTTP-contract tests for CohereEmbeddings (respx)."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import numpy as np
+import pytest
+
+respx = pytest.importorskip("respx")
+pytest.importorskip("cohere")
+
+from synapsekit.embeddings.cohere import CohereEmbeddings  # noqa: E402
+
+_URL = "https://api.cohere.com/v2/embed"
+
+
+def _payload() -> dict:
+    return {
+        "embeddings": {"float": [[0.1] * 4, [0.2] * 4]},
+        "texts": ["a", "b"],
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_sends_document_input_type():
+    route = respx.post(_URL).mock(return_value=httpx.Response(200, json=_payload()))
+    emb = CohereEmbeddings(api_key="test-key")
+    vecs = await emb.embed(["a", "b"])
+    assert vecs.shape == (2, 4)
+    body = json.loads(route.calls[0].request.content)
+    assert body["input_type"] == "search_document"
+    assert body["model"] == "embed-v3"
+    assert body["texts"] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_one_sends_query_input_type():
+    route = respx.post(_URL).mock(return_value=httpx.Response(200, json=_payload()))
+    emb = CohereEmbeddings(api_key="test-key")
+    vec = await emb.embed_one("a")
+    assert vec.shape == (4,)
+    body = json.loads(route.calls[0].request.content)
+    assert body["input_type"] == "search_query"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_custom_input_types_respected():
+    route = respx.post(_URL).mock(return_value=httpx.Response(200, json=_payload()))
+    emb = CohereEmbeddings(
+        api_key="test-key", input_type="classification", query_input_type="clustering"
+    )
+    await emb.embed(["a"])
+    await emb.embed_one("a")
+    assert json.loads(route.calls[0].request.content)["input_type"] == "classification"
+    assert json.loads(route.calls[1].request.content)["input_type"] == "clustering"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_normalizes():
+    respx.post(_URL).mock(return_value=httpx.Response(200, json=_payload()))
+    emb = CohereEmbeddings(api_key="test-key")
+    vecs = await emb.embed(["a", "b"])
+    np.testing.assert_allclose(np.linalg.norm(vecs, axis=1), 1.0)

--- a/tests/embeddings/test_embeddings_contract.py
+++ b/tests/embeddings/test_embeddings_contract.py
@@ -1,0 +1,99 @@
+"""Generic contract tests for the hosted embedding providers.
+
+Each provider class is exercised through the uniform async interface
+(``embed`` / ``embed_one`` / ``embed_batch`` / ``dimensions``) with the SDK
+or HTTP layer mocked — no live API keys or network access.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "cls_name",
+    [
+        "VoyageEmbeddings",
+        "JinaEmbeddings",
+        "NomicEmbeddings",
+        "MixedbreadEmbeddings",
+    ],
+)
+def test_http_providers_are_importable_from_top_level(cls_name):
+    import synapsekit
+
+    cls = getattr(synapsekit, cls_name)
+    assert cls.dimensions is not None
+
+
+@pytest.mark.parametrize(
+    "cls_name, module_name",
+    [
+        ("OpenAIEmbeddings", "openai"),
+        ("CohereEmbeddings", "cohere"),
+        ("GeminiEmbeddings", "gemini"),
+        ("MistralEmbeddings", "mistral"),
+    ],
+)
+def test_lazy_import_error_message(cls_name, module_name):
+    """SDK-backed providers raise ImportError with a pip hint when SDK missing."""
+    import importlib
+    from unittest.mock import patch
+
+    with patch.dict("sys.modules", {module_name: None}):
+        mod = importlib.import_module(f"synapsekit.embeddings.{module_name}")
+        cls = getattr(mod, cls_name)
+        obj = cls(api_key="test-key")
+        with pytest.raises(ImportError, match="pip install"):
+            obj._get_client()
+
+
+@pytest.mark.parametrize(
+    "cls_name, module_name, env_key, sdk_module",
+    [
+        ("OpenAIEmbeddings", "openai", "OPENAI_API_KEY", "openai"),
+        ("CohereEmbeddings", "cohere", "CO_API_KEY", "cohere"),
+        ("GeminiEmbeddings", "gemini", "GEMINI_API_KEY", "google.genai"),
+        ("MistralEmbeddings", "mistral", "MISTRAL_API_KEY", "mistralai"),
+        ("VoyageEmbeddings", "voyage", "VOYAGE_API_KEY", None),
+        ("JinaEmbeddings", "jina", "JINA_API_KEY", None),
+        ("NomicEmbeddings", "nomic", "NOMIC_API_KEY", None),
+        ("MixedbreadEmbeddings", "mixedbread", "MXBAI_API_KEY", None),
+        ("HuggingFaceEmbeddings", "huggingface", "HF_TOKEN", None),
+    ],
+)
+def test_missing_key_raises_value_error(cls_name, module_name, env_key, sdk_module):
+    """Missing API key raises a clear ValueError naming the env var."""
+    import importlib
+    import os
+    from unittest.mock import MagicMock, patch
+
+    with patch.dict(os.environ, {}, clear=True):
+        if sdk_module:
+            fake_sdks = {sdk_module: MagicMock()}
+            if sdk_module == "google.genai":
+                fake_sdks["google"] = MagicMock()
+            with patch.dict("sys.modules", fake_sdks):
+                mod = importlib.import_module(f"synapsekit.embeddings.{module_name}")
+                cls = getattr(mod, cls_name)
+                obj = cls(api_key=None)
+                with pytest.raises(ValueError, match=env_key):
+                    obj._get_client()
+        else:
+            mod = importlib.import_module(f"synapsekit.embeddings.{module_name}")
+            cls = getattr(mod, cls_name)
+            obj = cls(api_key=None)
+            with pytest.raises(ValueError, match=env_key):
+                obj._get_client()
+
+
+def test_openai_missing_key_raises():
+    import os
+    from unittest.mock import patch
+
+    from synapsekit.embeddings.openai import OpenAIEmbeddings
+
+    emb = OpenAIEmbeddings(api_key=None)
+    with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+        with patch.dict(os.environ, {}, clear=True):
+            emb._get_client()

--- a/tests/embeddings/test_gemini_embeddings.py
+++ b/tests/embeddings/test_gemini_embeddings.py
@@ -1,0 +1,82 @@
+"""HTTP-contract tests for GeminiEmbeddings (mocked client)."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+class _FakeGenAI(ModuleType):
+    """Fake ``google.genai`` module exposing ``Client``."""
+
+    Client = MagicMock()
+
+
+class _Embedding:
+    def __init__(self, values: list[float]) -> None:
+        self.values = values
+
+
+@pytest.fixture
+def fake_genai():
+    """Install a fake ``google.genai`` module for the duration of a test."""
+    fake = _FakeGenAI("google.genai")
+    fake.Client = MagicMock()
+    with patch.dict(
+        "sys.modules",
+        {"google.genai": fake, "google": sys.modules.get("google", ModuleType("google"))},
+    ):
+        yield fake
+
+
+def _make_client(resp) -> MagicMock:
+    client = MagicMock()
+    client.models.embed_content = AsyncMock(return_value=resp)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_embed_parses_values(fake_genai):
+    resp = MagicMock()
+    resp.embeddings = [_Embedding([0.1] * 4), _Embedding([0.2] * 4)]
+    mock_client = _make_client(resp)
+    fake_genai.Client.return_value = mock_client
+
+    from synapsekit.embeddings.gemini import GeminiEmbeddings
+
+    emb = GeminiEmbeddings(api_key="test-key")
+    vecs = await emb.embed(["a", "b"])
+
+    assert vecs.shape == (2, 4)
+    np.testing.assert_allclose(np.linalg.norm(vecs, axis=1), 1.0)
+    kwargs = mock_client.models.embed_content.call_args.kwargs
+    assert kwargs["model"] == "text-embedding-004"
+    assert kwargs["contents"] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_embed_one_returns_first_row(fake_genai):
+    resp = MagicMock()
+    resp.embeddings = [_Embedding([0.3] * 4)]
+    mock_client = _make_client(resp)
+    fake_genai.Client.return_value = mock_client
+
+    from synapsekit.embeddings.gemini import GeminiEmbeddings
+
+    emb = GeminiEmbeddings(api_key="test-key")
+    vec = await emb.embed_one("a")
+
+    assert vec.shape == (4,)
+
+
+def test_missing_key_raises(fake_genai):
+    from synapsekit.embeddings.gemini import GeminiEmbeddings
+
+    emb = GeminiEmbeddings(api_key=None)
+    with pytest.raises(ValueError, match="GEMINI_API_KEY"):
+        with patch.dict("synapsekit.embeddings.gemini.os.environ", {}, clear=True):
+            emb._get_client()

--- a/tests/embeddings/test_huggingface_embeddings.py
+++ b/tests/embeddings/test_huggingface_embeddings.py
@@ -1,0 +1,70 @@
+"""HTTP-contract tests for HuggingFaceEmbeddings (respx)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+respx = pytest.importorskip("respx")
+
+from synapsekit.embeddings.huggingface import HuggingFaceEmbeddings  # noqa: E402
+
+_INFERENCE_URL = "https://api-inference.huggingface.co/models/BAAI/bge-base-en-v1.5"
+
+
+def _list_payload() -> list[list[float]]:
+    return [[0.1] * 4, [0.2] * 4]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_inference_api_sends_inputs_and_parses_list():
+    route = respx.post(_INFERENCE_URL).mock(return_value=httpx.Response(200, json=_list_payload()))
+    emb = HuggingFaceEmbeddings(api_key="test-key")
+    vecs = await emb.embed(["a", "b"])
+    assert vecs.shape == (2, 4)
+    assert route.calls[0].request.headers["authorization"] == "Bearer test-key"
+    assert route.calls[0].request.url.path.endswith("/models/BAAI/bge-base-en-v1.5")
+    assert "inputs" in route.calls[0].request.content.decode()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_tei_base_url_posts_to_embed():
+    route = respx.post("http://localhost:8080/embed").mock(
+        return_value=httpx.Response(200, json=_list_payload())
+    )
+    emb = HuggingFaceEmbeddings(api_key="test-key", base_url="http://localhost:8080")
+    vecs = await emb.embed(["a", "b"])
+    assert vecs.shape == (2, 4)
+    assert route.calls[0].request.url.path == "/embed"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_openai_style_response_supported():
+    payload = {
+        "data": [
+            {"index": 0, "embedding": [0.1] * 4},
+            {"index": 1, "embedding": [0.2] * 4},
+        ]
+    }
+    respx.post(_INFERENCE_URL).mock(return_value=httpx.Response(200, json=payload))
+    emb = HuggingFaceEmbeddings(api_key="test-key")
+    vecs = await emb.embed(["a", "b"])
+    assert vecs.shape == (2, 4)
+
+
+def test_hf_token_takes_precedence_over_hf_api_key(monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", "token-val")
+    monkeypatch.setenv("HF_API_KEY", "key-val")
+    emb = HuggingFaceEmbeddings()
+    assert emb._get_key() == "token-val"
+
+
+def test_missing_key_raises(monkeypatch):
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HF_API_KEY", raising=False)
+    emb = HuggingFaceEmbeddings(api_key=None)
+    with pytest.raises(ValueError, match="HF_TOKEN"):
+        emb._get_key()

--- a/tests/embeddings/test_jina_embeddings.py
+++ b/tests/embeddings/test_jina_embeddings.py
@@ -1,0 +1,49 @@
+"""HTTP-contract tests for JinaEmbeddings (respx)."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+respx = pytest.importorskip("respx")
+
+from synapsekit.embeddings.jina import JinaEmbeddings  # noqa: E402
+
+_URL = "https://api.jina.ai/v1/embeddings"
+
+
+def _payload() -> dict:
+    return {
+        "object": "list",
+        "data": [
+            {"object": "embedding", "index": 0, "embedding": [0.1] * 4},
+            {"object": "embedding", "index": 1, "embedding": [0.2] * 4},
+        ],
+        "model": "jina-embeddings-v3",
+        "usage": {"prompt_tokens": 4, "total_tokens": 4},
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_sends_task_and_dimensions():
+    route = respx.post(_URL).mock(return_value=httpx.Response(200, json=_payload()))
+    emb = JinaEmbeddings(api_key="test-key", task="retrieval.passage", dimensions=4)
+    vecs = await emb.embed(["a", "b"])
+    assert vecs.shape == (2, 4)
+    body = json.loads(route.calls[0].request.content)
+    assert body["task"] == "retrieval.passage"
+    assert body["dimensions"] == 4
+    assert body["model"] == "jina-embeddings-v3"
+    assert body["input"] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_one_returns_first_row():
+    respx.post(_URL).mock(return_value=httpx.Response(200, json=_payload()))
+    emb = JinaEmbeddings(api_key="test-key")
+    vec = await emb.embed_one("a")
+    assert vec.shape == (4,)

--- a/tests/embeddings/test_mistral_embeddings.py
+++ b/tests/embeddings/test_mistral_embeddings.py
@@ -1,0 +1,49 @@
+"""HTTP-contract tests for MistralEmbeddings (respx)."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+respx = pytest.importorskip("respx")
+pytest.importorskip("mistralai")
+
+from synapsekit.embeddings.mistral import MistralEmbeddings  # noqa: E402
+
+_URL = "https://api.mistral.ai/v1/embeddings"
+
+
+def _payload() -> dict:
+    return {
+        "id": "emb-1",
+        "object": "list",
+        "data": [
+            {"object": "embedding", "index": 0, "embedding": [0.1] * 4},
+            {"object": "embedding", "index": 1, "embedding": [0.2] * 4},
+        ],
+        "model": "mistral-embed",
+        "usage": {"prompt_tokens": 4, "total_tokens": 4},
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_parses_response():
+    route = respx.post(_URL).mock(return_value=httpx.Response(200, json=_payload()))
+    emb = MistralEmbeddings(api_key="test-key")
+    vecs = await emb.embed(["a", "b"])
+    assert vecs.shape == (2, 4)
+    body = json.loads(route.calls[0].request.content)
+    assert body["model"] == "mistral-embed"
+    assert body["inputs"] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_one_returns_first_row():
+    respx.post(_URL).mock(return_value=httpx.Response(200, json=_payload()))
+    emb = MistralEmbeddings(api_key="test-key")
+    vec = await emb.embed_one("a")
+    assert vec.shape == (4,)

--- a/tests/embeddings/test_mixedbread_embeddings.py
+++ b/tests/embeddings/test_mixedbread_embeddings.py
@@ -1,0 +1,47 @@
+"""HTTP-contract tests for MixedbreadEmbeddings (respx)."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+respx = pytest.importorskip("respx")
+
+from synapsekit.embeddings.mixedbread import MixedbreadEmbeddings  # noqa: E402
+
+_URL = "https://api.mixedbread.ai/v1/embeddings"
+
+
+def _payload() -> dict:
+    return {
+        "object": "list",
+        "data": [
+            {"object": "embedding", "index": 0, "embedding": [0.1] * 4},
+            {"object": "embedding", "index": 1, "embedding": [0.2] * 4},
+        ],
+        "model": "mxbai-embed-large",
+        "usage": {"prompt_tokens": 4, "total_tokens": 4},
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_parses_response():
+    route = respx.post(_URL).mock(return_value=httpx.Response(200, json=_payload()))
+    emb = MixedbreadEmbeddings(api_key="test-key")
+    vecs = await emb.embed(["a", "b"])
+    assert vecs.shape == (2, 4)
+    body = json.loads(route.calls[0].request.content)
+    assert body["model"] == "mxbai-embed-large"
+    assert body["input"] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_one_returns_first_row():
+    respx.post(_URL).mock(return_value=httpx.Response(200, json=_payload()))
+    emb = MixedbreadEmbeddings(api_key="test-key")
+    vec = await emb.embed_one("a")
+    assert vec.shape == (4,)

--- a/tests/embeddings/test_nomic_embeddings.py
+++ b/tests/embeddings/test_nomic_embeddings.py
@@ -1,0 +1,58 @@
+"""HTTP-contract tests for NomicEmbeddings (respx)."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+respx = pytest.importorskip("respx")
+
+from synapsekit.embeddings.nomic import NomicEmbeddings  # noqa: E402
+
+_URL = "https://api.nomic.ai/v1/embeddings"
+
+
+def _payload() -> dict:
+    return {
+        "object": "list",
+        "data": [
+            {"object": "embedding", "index": 0, "embedding": [0.1] * 4},
+            {"object": "embedding", "index": 1, "embedding": [0.2] * 4},
+        ],
+        "model": "nomic-embed-text",
+        "usage": {"prompt_tokens": 4, "total_tokens": 4},
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_sends_document_task_type():
+    route = respx.post(_URL).mock(return_value=httpx.Response(200, json=_payload()))
+    emb = NomicEmbeddings(api_key="test-key")
+    vecs = await emb.embed(["a", "b"])
+    assert vecs.shape == (2, 4)
+    body = json.loads(route.calls[0].request.content)
+    assert body["task_type"] == "search_document"
+    assert body["model"] == "nomic-embed-text"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_one_sends_query_task_type():
+    route = respx.post(_URL).mock(return_value=httpx.Response(200, json=_payload()))
+    emb = NomicEmbeddings(api_key="test-key")
+    vec = await emb.embed_one("a")
+    assert vec.shape == (4,)
+    body = json.loads(route.calls[0].request.content)
+    assert body["task_type"] == "search_query"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_one_restores_task_type_after_call():
+    respx.post(_URL).mock(return_value=httpx.Response(200, json=_payload()))
+    emb = NomicEmbeddings(api_key="test-key")
+    await emb.embed_one("a")
+    assert emb._request_extra["task_type"] == "search_document"

--- a/tests/embeddings/test_openai_embeddings.py
+++ b/tests/embeddings/test_openai_embeddings.py
@@ -1,0 +1,74 @@
+"""HTTP-contract tests for OpenAIEmbeddings (respx)."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import numpy as np
+import pytest
+
+respx = pytest.importorskip("respx")
+pytest.importorskip("openai")
+
+from tests.embeddings.conftest import embed_payload  # noqa: E402
+
+from synapsekit.embeddings.openai import OpenAIEmbeddings  # noqa: E402
+
+_URL = "https://api.openai.com/v1/embeddings"
+
+
+def _emb() -> OpenAIEmbeddings:
+    return OpenAIEmbeddings(api_key="test-key")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_parses_response_and_sends_bearer():
+    route = respx.post(_URL).mock(
+        return_value=httpx.Response(
+            200, json=embed_payload("text-embedding-3-small", 8, ["a", "b"])
+        )
+    )
+    emb = _emb()
+    vecs = await emb.embed(["a", "b"])
+    assert vecs.shape == (2, 8)
+    np.testing.assert_allclose(np.linalg.norm(vecs, axis=1), 1.0)
+    assert route.calls[0].request.headers["authorization"] == "Bearer test-key"
+    body = json.loads(route.calls[0].request.content)
+    assert body["model"] == "text-embedding-3-small"
+    assert body["input"] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_dimensions_param_forwarded_when_set():
+    route = respx.post(_URL).mock(
+        return_value=httpx.Response(200, json=embed_payload("text-embedding-3-small", 8, ["a"]))
+    )
+    emb = OpenAIEmbeddings(api_key="test-key", dimensions=8)
+    await emb.embed(["a"])
+    body = json.loads(route.calls[0].request.content)
+    assert body["dimensions"] == 8
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_one_matches_first_row():
+    respx.post(_URL).mock(
+        return_value=httpx.Response(200, json=embed_payload("text-embedding-3-small", 8, ["a"]))
+    )
+    emb = _emb()
+    vec = await emb.embed_one("a")
+    assert vec.shape == (8,)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_reorders_by_index():
+    payload = embed_payload("text-embedding-3-small", 4, ["a", "b"])
+    payload["data"] = [payload["data"][1], payload["data"][0]]
+    respx.post(_URL).mock(return_value=httpx.Response(200, json=payload))
+    emb = _emb()
+    vecs = await emb.embed(["a", "b"])
+    assert vecs.shape == (2, 4)

--- a/tests/embeddings/test_voyage_embeddings.py
+++ b/tests/embeddings/test_voyage_embeddings.py
@@ -1,0 +1,57 @@
+"""HTTP-contract tests for VoyageEmbeddings (respx)."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+respx = pytest.importorskip("respx")
+
+from synapsekit.embeddings.voyage import VoyageEmbeddings  # noqa: E402
+
+_URL = "https://api.voyageai.com/v1/embeddings"
+
+
+def _payload() -> dict:
+    return {
+        "object": "list",
+        "data": [
+            {"object": "embedding", "index": 0, "embedding": [0.1] * 4},
+            {"object": "embedding", "index": 1, "embedding": [0.2] * 4},
+        ],
+        "model": "voyage-3",
+        "usage": {"prompt_tokens": 4, "total_tokens": 4},
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_parses_response():
+    route = respx.post(_URL).mock(return_value=httpx.Response(200, json=_payload()))
+    emb = VoyageEmbeddings(api_key="test-key")
+    vecs = await emb.embed(["a", "b"])
+    assert vecs.shape == (2, 4)
+    assert route.calls[0].request.headers["authorization"] == "Bearer test-key"
+    body = json.loads(route.calls[0].request.content)
+    assert body["model"] == "voyage-3"
+    assert body["input"] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_one_returns_first_row():
+    respx.post(_URL).mock(return_value=httpx.Response(200, json=_payload()))
+    emb = VoyageEmbeddings(api_key="test-key")
+    vec = await emb.embed_one("a")
+    assert vec.shape == (4,)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_non_200_raises_runtime_error():
+    respx.post(_URL).mock(return_value=httpx.Response(401, json={"error": "bad key"}))
+    emb = VoyageEmbeddings(api_key="test-key")
+    with pytest.raises(RuntimeError, match="401"):
+        await emb.embed(["a"])

--- a/tests/retrieval/test_rerankers.py
+++ b/tests/retrieval/test_rerankers.py
@@ -1,0 +1,199 @@
+"""Tests for the Reranker ABC and the Voyage/Jina/mixedbread rerankers."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+respx = pytest.importorskip("respx")
+
+
+def _mock_retriever(texts: list[str]) -> AsyncMock:
+    retriever = AsyncMock()
+    retriever.retrieve.return_value = texts
+    return retriever
+
+
+def _sorted_payload(items: list[tuple[int, float]]) -> dict:
+    return {"data": [{"index": i, "relevance_score": s} for i, s in items]}
+
+
+# --------------------------------------------------------------------------- #
+# Reranker ABC
+# --------------------------------------------------------------------------- #
+
+
+def test_reranker_abc_requires_retrieve_and_retrieve_with_scores():
+    from synapsekit.retrieval.reranker import Reranker
+
+    assert Reranker.__abstractmethods__ == frozenset({"retrieve", "retrieve_with_scores"})
+
+
+def test_cohere_and_cross_encoder_subclass_reranker():
+    from synapsekit import CohereReranker, CrossEncoderReranker
+    from synapsekit.retrieval.reranker import Reranker
+
+    assert issubclass(CohereReranker, Reranker)
+    assert issubclass(CrossEncoderReranker, Reranker)
+
+
+# --------------------------------------------------------------------------- #
+# VoyageReranker
+# --------------------------------------------------------------------------- #
+
+
+@respx.mock
+def test_voyage_reranker_request_and_reorder():
+    retriever = _mock_retriever(["doc1", "doc2", "doc3"])
+    respx.post("https://api.voyageai.com/v1/rerank").mock(
+        return_value=httpx.Response(200, json=_sorted_payload([(2, 0.9), (0, 0.7)]))
+    )
+    from synapsekit.retrieval.voyage_reranker import VoyageReranker
+
+    reranker = VoyageReranker(retriever=retriever, api_key="test-key")
+    results = reranker._call("query", ["doc1", "doc2", "doc3"], top_n=2)
+    assert results == [
+        {"text": "doc3", "relevance_score": 0.9},
+        {"text": "doc1", "relevance_score": 0.7},
+    ]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_voyage_retrieve_async():
+    retriever = _mock_retriever(["doc1", "doc2", "doc3"])
+    respx.post("https://api.voyageai.com/v1/rerank").mock(
+        return_value=httpx.Response(200, json=_sorted_payload([(2, 0.9), (0, 0.7)]))
+    )
+    from synapsekit.retrieval.voyage_reranker import VoyageReranker
+
+    reranker = VoyageReranker(retriever=retriever, api_key="test-key")
+    out = await reranker.retrieve("query", top_k=2)
+    assert out == ["doc3", "doc1"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_voyage_retrieve_with_scores_async():
+    retriever = _mock_retriever(["doc1", "doc2"])
+    respx.post("https://api.voyageai.com/v1/rerank").mock(
+        return_value=httpx.Response(200, json=_sorted_payload([(1, 0.8)]))
+    )
+    from synapsekit.retrieval.voyage_reranker import VoyageReranker
+
+    reranker = VoyageReranker(retriever=retriever, api_key="test-key")
+    out = await reranker.retrieve_with_scores("query", top_k=1)
+    assert out == [{"text": "doc2", "relevance_score": 0.8}]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_voyage_empty_candidates_short_circuits():
+    retriever = _mock_retriever([])
+    from synapsekit.retrieval.voyage_reranker import VoyageReranker
+
+    reranker = VoyageReranker(retriever=retriever, api_key="test-key")
+    assert await reranker.retrieve("query") == []
+    assert await reranker.retrieve_with_scores("query") == []
+
+
+def test_voyage_missing_key_raises():
+    from synapsekit.retrieval.voyage_reranker import VoyageReranker
+
+    reranker = VoyageReranker(retriever=_mock_retriever(["a"]))
+    with pytest.raises(ValueError, match="VOYAGE_API_KEY"):
+        reranker._get_key()
+
+
+# --------------------------------------------------------------------------- #
+# JinaReranker
+# --------------------------------------------------------------------------- #
+
+
+@respx.mock
+def test_jina_reranker_request_and_reorder():
+    retriever = _mock_retriever(["doc1", "doc2", "doc3"])
+    respx.post("https://api.jina.ai/v1/rerank").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"index": 2, "relevance_score": 0.9},
+                    {"index": 0, "relevance_score": 0.7},
+                ]
+            },
+        )
+    )
+    from synapsekit.retrieval.jina_reranker import JinaReranker
+
+    reranker = JinaReranker(retriever=retriever, api_key="test-key")
+    results = reranker._call("query", ["doc1", "doc2", "doc3"], top_n=2)
+    assert results == [
+        {"text": "doc3", "relevance_score": 0.9},
+        {"text": "doc1", "relevance_score": 0.7},
+    ]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_jina_retrieve_async():
+    retriever = _mock_retriever(["doc1", "doc2"])
+    respx.post("https://api.jina.ai/v1/rerank").mock(
+        return_value=httpx.Response(200, json={"results": [{"index": 1, "relevance_score": 0.8}]})
+    )
+    from synapsekit.retrieval.jina_reranker import JinaReranker
+
+    reranker = JinaReranker(retriever=retriever, api_key="test-key")
+    assert await reranker.retrieve("query", top_k=1) == ["doc2"]
+
+
+def test_jina_missing_key_raises():
+    from synapsekit.retrieval.jina_reranker import JinaReranker
+
+    reranker = JinaReranker(retriever=_mock_retriever(["a"]))
+    with pytest.raises(ValueError, match="JINA_API_KEY"):
+        reranker._get_key()
+
+
+# --------------------------------------------------------------------------- #
+# MixedbreadReranker
+# --------------------------------------------------------------------------- #
+
+
+@respx.mock
+def test_mixedbread_reranker_request_and_reorder():
+    retriever = _mock_retriever(["doc1", "doc2", "doc3"])
+    respx.post("https://api.mixedbread.ai/v1/rerank").mock(
+        return_value=httpx.Response(200, json=_sorted_payload([(2, 0.9), (0, 0.7)]))
+    )
+    from synapsekit.retrieval.mixedbread_reranker import MixedbreadReranker
+
+    reranker = MixedbreadReranker(retriever=retriever, api_key="test-key")
+    results = reranker._call("query", ["doc1", "doc2", "doc3"], top_n=2)
+    assert results == [
+        {"text": "doc3", "relevance_score": 0.9},
+        {"text": "doc1", "relevance_score": 0.7},
+    ]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_mixedbread_retrieve_async():
+    retriever = _mock_retriever(["doc1", "doc2"])
+    respx.post("https://api.mixedbread.ai/v1/rerank").mock(
+        return_value=httpx.Response(200, json=_sorted_payload([(1, 0.8)]))
+    )
+    from synapsekit.retrieval.mixedbread_reranker import MixedbreadReranker
+
+    reranker = MixedbreadReranker(retriever=retriever, api_key="test-key")
+    assert await reranker.retrieve("query", top_k=1) == ["doc2"]
+
+
+def test_mixedbread_missing_key_raises():
+    from synapsekit.retrieval.mixedbread_reranker import MixedbreadReranker
+
+    reranker = MixedbreadReranker(retriever=_mock_retriever(["a"]))
+    with pytest.raises(ValueError, match="MXBAI_API_KEY"):
+        reranker._get_key()


### PR DESCRIPTION
Closes #886

## Summary

Adds a first-class embeddings & reranker provider layer: a uniform async embeddings contract implemented by 9 hosted providers, plus a shared `Reranker` ABC with 3 new hosted rerankers.

### Embeddings (`BaseEmbeddings` contract)

- `embed(texts)` -> `(N, D)` float32, L2-normalized rows (required by every vector-store backend)
- `embed_one(text)` -> `(D,)` float32
- `embed_batch(texts, batch_size)` -> chunked, identical semantics
- `dimensions` -> static output dim of the default model, no network call

| Provider | Class | Default model | Dims | Extra |
|---|---|---|---|---|
| OpenAI | `OpenAIEmbeddings` | `text-embedding-3-small` | 1536 | `openai` |
| Cohere | `CohereEmbeddings` | `embed-v3` (input-type aware) | 1024 | `cohere` |
| Voyage AI | `VoyageEmbeddings` | `voyage-3` | 1024 | `voyage` |
| Jina AI | `JinaEmbeddings` | `jina-embeddings-v3` (task LoRA) | 1024 | `jina` |
| Google Gemini | `GeminiEmbeddings` | `text-embedding-004` | 768 | `gemini` |
| Mistral | `MistralEmbeddings` | `mistral-embed` | 1024 | `mistral` |
| Nomic | `NomicEmbeddings` | `nomic-embed-text` | 768 | `nomic` |
| mixedbread | `MixedbreadEmbeddings` | `mxbai-embed-large` | 1024 | `mixedbread` |
| Hugging Face | `HuggingFaceEmbeddings` | `BAAI/bge-base-en-v1.5` (Inference API / TEI) | 768 | `huggingface` |

All providers are lazy-imported behind optional extras (`pip install synapsekit[<provider>]`); the core import guard stays green. `SynapsekitEmbeddings` and `ONNXEmbeddings` are unchanged in behavior.

### Rerankers (`Reranker` ABC)

- `retrieve(query, top_k)` / `retrieve_with_scores(query, top_k)` async contract over a wrapped `Retriever`
- New: `VoyageReranker` (rerank-2), `JinaReranker` (jina-reranker-v2), `MixedbreadReranker` (mxbai-rerank)
- `CohereReranker` / `CrossEncoderReranker` now subclass `Reranker` with unchanged constructors/behavior

### Tests & CI

- Generic contract suite (dimensions, lazy-import errors, missing-key `ValueError`s) for every provider
- Per-provider respx HTTP-contract tests (request body/headers, parsing, reordering) — no live keys, no network
- Reranker request/reorder/empty/missing-key tests
- CI (`ci.yml`) needs no changes; `respx` is already a dev dep

## Verification

- `pytest tests/embeddings tests/retrieval/test_rerankers.py` — 56 passed, 2 skipped
- `pytest tests/` — passes (pre-existing env-only failures on this machine: shell-tool `WinError 2` tests, flaky mesh daemon PID test, `nbformat`-missing examples collection)
- `ruff check` + `ruff format --check` — clean
- `mypy` — clean (521 files)
- `deptry src/` — clean
