### PR TITLE
feat: add Agent OS Shell for issue #750

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,14 @@ SynapseKit uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Agent OS Shell** (#750) — a local-first hybrid shell that mixes ordinary shell syntax with quoted natural-language requests (`git status && "why did that fail?"`). Commands run **argv-only** (never `shell=True`), a **fail-closed** safety gate blocks destructive commands unless they carry an Ed25519 signature, and every run writes a signed, verifiable audit receipt. Ships with an LLM planner, a rule planner, bounded subprocess execution, and a `synapsekit shell` / `synshell` entry point. **Wired into SynapseKit Live** — each `plan` and `run` publishes `shell.plan` / `shell.run` events (with the input), so shell activity streams to the glass-box dashboard. Contributed by [@DhruvGarg111](https://github.com/DhruvGarg111).
+
 ### Fixed
 
+- **Agent OS Shell no longer OOMs or hangs on unbounded output** (#929) — the executor buffered a child's entire stdout/stderr via `communicate()` before `max_output_bytes` was applied, so `cat /dev/zero`/`yes` could exhaust RAM and `yes | head -1` hung (the producer never got SIGPIPE). Output is now streamed under a hard byte cap that terminates the child at the cap; a capped producer still feeds the next pipeline stage. Regression tests cover bounded output and a non-hanging pipeline.
+- **Agent OS Shell no longer drops quoted args that start with a cue word** (#930) — `git commit -m "find and fix the bug"` and `grep "search term" file` silently lost the quoted argument because the lexer treated any quoted span beginning with a cue word (find/run/search/…) as natural language regardless of position. The cue-word/bare-phrase heuristics are now gated on the quote opening a command; only the explicit `nl:`/`ask:` sentinels stay unconditional. Regression tests cover both cases.
 - **`Benchmarks` workflow no longer fails on the `symbolic` extra** (#919) — `benchmarks.yml` ran `make bench` (the full `benchmarks/` suite, including the neuro-symbolic gate that imports `SympyBackend`) without installing the `symbolic` extra, so the nightly and `v*`-tag runs errored with `ImportError: sympy is required`. Added `--extra symbolic` to its `uv sync`, mirroring the `neuro-symbolic-gate` job in `ci.yml`.
 
 ## [2.0.1] - 2026-08-04

--- a/docs/agent-os-shell.md
+++ b/docs/agent-os-shell.md
@@ -1,0 +1,93 @@
+# Agent OS Shell
+
+`synapsekit shell` is a local-first hybrid shell wrapper. Keep ordinary shell
+syntax as-is and quote a natural-language request when you want SynapseKit to
+plan it with project context.
+
+```console
+synapsekit shell run 'git status && "find me the relevant test and rerun it"'
+synshell '"why is this directory so large?"'
+```
+
+The default planner is deliberately deterministic and offline. Applications
+can inject an `LLMShellPlanner` backed by an `EdgeRuntime` or another
+`BaseLLM`; planning output is strict JSON and always passes through the same
+safety policy before execution.
+
+## Safety model
+
+Commands are parsed into argv vectors and launched with direct subprocess
+execution; no user or model text is passed through `shell=True`. `&&`, `||`,
+`;`, and `|` are parsed by SynapseKit and executed with bounded output and a
+timeout.
+
+Destructive operations—such as `rm`, `Remove-Item`, `git reset`, `git clean`,
+force pushes, Docker prune, Kubernetes deletes, and Terraform destroy—are
+previewed and require confirmation. They also require an Ed25519 signing key:
+the shell exports a signed pre-execution audit receipt before launching the
+command and a final bundle with the captured result and post-command Git diff.
+
+```console
+synapsekit shell keygen ~/.synapsekit/shell/key
+synapsekit shell run --signing-key ~/.synapsekit/shell/key 'git clean -fd'
+```
+
+`--yes` only skips the interactive answer after a signing key is supplied; it
+does not permit unsigned destructive execution. Use `--dry-run` to inspect a
+plan without launching any command.
+
+## Context and privacy
+
+The session collects the current directory, shell dialect, bounded Git state,
+a small allowlist of non-secret environment metadata, optional KnowledgeMesh
+hits, optional Ambient Agent status JSON, and relevant local history.
+
+History lives at `~/.synapsekit/shell/history.sqlite3`. Common secret-shaped
+`api_key`, `token`, `secret`, and `password` values are redacted before that
+history is written. Translation caching is local and skips destructive-looking
+plans.
+
+Enable or disable context explicitly:
+
+```console
+synapsekit shell run --mesh-root . '"run the test related to the recent CLI change"'
+synapsekit shell run --no-mesh --ambient-status ~/.synapsekit/ambient/status.json 'git status'
+synapsekit shell history search cli test
+```
+
+## Shell integrations
+
+Source the generated function for your shell:
+
+```console
+synapsekit shell init bash
+synapsekit shell init zsh
+synapsekit shell init fish
+synapsekit shell init powershell
+```
+
+Each integration defines `synshell` (and `synapse`) as a small wrapper around
+`synapsekit shell run`. The standalone `synshell` console script provides the
+same one-shot mode and opens a REPL with no command arguments.
+
+## Embedding in an application
+
+```python
+import asyncio
+
+from synapsekit.shell import ShellSession
+
+
+async def main() -> None:
+    session = ShellSession(cwd=".")
+    result = await session.run('git status && "run tests"')
+    print(result.ok, result.plan.summary)
+
+
+asyncio.run(main())
+```
+
+For a production LLM planner, instantiate `LLMShellPlanner` with a configured
+local-first `BaseLLM`/`EdgeRuntime` and pass it to `ShellSession(planner=...)`.
+The model proposes commands only; it cannot bypass confirmation, signing, or
+the direct-execution boundary.

--- a/examples/agent_os_shell.py
+++ b/examples/agent_os_shell.py
@@ -1,0 +1,25 @@
+"""Run a safe local Agent OS Shell interaction."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from synapsekit.shell import ShellHistory, ShellSession
+
+
+async def main() -> None:
+    root = Path.cwd()
+    session = ShellSession(
+        cwd=root,
+        mesh=None,
+        history=ShellHistory(root / ".synapsekit_shell_history.sqlite3"),
+    )
+    result = await session.run("git status --short --branch")
+    print(result.plan.summary)
+    for command in result.commands:
+        print(command.stdout or command.stderr)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ Discord = "https://discord.gg/PSuAXHRywJ"
 [project.scripts]
 synapsekit = "synapsekit.cli.main:main"
 
+synshell = "synapsekit.cli.shell:main"
+
 [project.optional-dependencies]
 graph = ["networkx>=3.0", "neo4j>=5.0"]
 openai = ["openai>=1.0"]

--- a/src/synapsekit/cli/main.py
+++ b/src/synapsekit/cli/main.py
@@ -172,6 +172,12 @@ def _add_mesh_parser(subparsers: argparse._SubParsersAction) -> None:  # type: i
     build_mesh_parser(subparsers)
 
 
+def _add_shell_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    from .shell import build_shell_parser
+
+    build_shell_parser(subparsers)
+
+
 def _add_agent_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = subparsers.add_parser("agent", help="Inspect and manage SynapseKit agents")
     agent_sub = p.add_subparsers(dest="agent_command")
@@ -321,6 +327,7 @@ def main(argv: list[str] | None = None) -> None:
     _add_bench_parser(subparsers)
     _add_edge_parser(subparsers)
     _add_mesh_parser(subparsers)
+    _add_shell_parser(subparsers)
     _add_agent_parser(subparsers)
     _add_memory_parser(subparsers)
     _add_ui_parser(subparsers)
@@ -371,6 +378,10 @@ def main(argv: list[str] | None = None) -> None:
         from .mesh import run_mesh
 
         run_mesh(args)
+    elif args.command == "shell":
+        from .shell import run_shell
+
+        run_shell(args)
     elif args.command == "agent":
         from .agent import run_agent
 

--- a/src/synapsekit/cli/shell.py
+++ b/src/synapsekit/cli/shell.py
@@ -1,0 +1,280 @@
+"""CLI entry points for the Agent OS Shell."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+from synapsekit.shell import (
+    CachedPlanner,
+    CompletionEngine,
+    JsonAmbientContext,
+    NullAmbientContext,
+    RuleBasedPlanner,
+    ShellHistory,
+    ShellSession,
+    TranslationCache,
+    generate_signing_key,
+    get_adapter,
+    load_signing_policy,
+    result_to_dict,
+)
+
+
+def _add_shell_options(parser: argparse.ArgumentParser, *, suppress_defaults: bool = False) -> None:
+    default = argparse.SUPPRESS if suppress_defaults else None
+    parser.add_argument("--cwd", default=default, help="Working directory for commands")
+    parser.add_argument("--shell", default=default or "auto", help="bash, zsh, fish, or powershell")
+    parser.add_argument("--ambient-status", default=default, help="Ambient Agent status JSON path")
+    parser.add_argument("--history-path", default=default, help="SQLite shell history path")
+    parser.add_argument(
+        "--translation-cache", default=default, help="SQLite translation cache path"
+    )
+    parser.add_argument(
+        "--mesh-root", default=default, help="Project root to query with KnowledgeMesh"
+    )
+    parser.add_argument(
+        "--no-mesh",
+        action="store_true",
+        default=default or False,
+        help="Disable KnowledgeMesh context",
+    )
+    parser.add_argument(
+        "--planner-module", default=default, help="Planner import path, e.g. package.module:planner"
+    )
+    parser.add_argument(
+        "--signing-key", default=default, help="Raw Ed25519 private key for destructive approvals"
+    )
+    parser.add_argument("--key-id", default=default, help="Stable audit signing key id")
+    parser.add_argument("--audit-dir", default=default, help="Directory for signed audit bundles")
+    parser.add_argument(
+        "--timeout", type=float, default=default or 30.0, help="Command timeout in seconds"
+    )
+    parser.add_argument(
+        "--max-output", type=int, default=default or 1_000_000, help="Output cap per command"
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        default=default or False,
+        help="Approve destructive commands after signed preflight",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=default or False,
+        help="Plan and preview without executing",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        default=default or False,
+        dest="json_output",
+        help="Emit machine-readable JSON",
+    )
+
+
+def build_shell_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    parser = subparsers.add_parser(
+        "shell",
+        help="Use a context-aware hybrid natural-language and shell session",
+    )
+    _add_shell_options(parser)
+    shell_sub = parser.add_subparsers(dest="shell_command")
+
+    run = shell_sub.add_parser("run", help="Plan and execute one mixed input line")
+    run.add_argument("text", nargs="+", help="Shell text and/or quoted natural language")
+    _add_shell_options(run, suppress_defaults=True)
+
+    init = shell_sub.add_parser("init", help="Print the integration script for a shell")
+    init.add_argument("shell", choices=["bash", "zsh", "fish", "powershell"])
+
+    complete = shell_sub.add_parser("complete", help="Return local and mesh-enriched completions")
+    complete.add_argument("prefix", nargs="*", default=[])
+    complete.add_argument("--cwd", default=None)
+    complete.add_argument("--mesh-root", default=None)
+    complete.add_argument("--no-mesh", action="store_true")
+
+    history = shell_sub.add_parser("history", help="Search local redacted shell history")
+    history_sub = history.add_subparsers(dest="history_command")
+    search = history_sub.add_parser("search", help="Search history by terms")
+    search.add_argument("query", nargs="*", default=[])
+    search.add_argument("--path", default=None)
+    search.add_argument("--limit", type=int, default=20)
+    recent = history_sub.add_parser("recent", help="Show recent history")
+    recent.add_argument("--path", default=None)
+    recent.add_argument("--limit", type=int, default=20)
+
+    keygen = shell_sub.add_parser("keygen", help="Generate a local Ed25519 shell audit key")
+    keygen.add_argument("private_key")
+    keygen.add_argument("--public-key", default=None)
+
+    status = shell_sub.add_parser("status", help="Show shell integration and context status")
+    status.add_argument("--cwd", default=None)
+    status.add_argument("--shell", default="auto")
+    status.add_argument("--mesh-root", default=None)
+    status.add_argument("--no-mesh", action="store_true")
+
+
+def _load_planner(module_path: str | None) -> Any:
+    if not module_path:
+        return RuleBasedPlanner()
+    module_name, separator, attribute = module_path.partition(":")
+    if not separator or not attribute:
+        raise ValueError("--planner-module must be MODULE:ATTRIBUTE")
+    value = getattr(importlib.import_module(module_name), attribute)
+    return value() if callable(value) and not hasattr(value, "plan") else value
+
+
+def _make_mesh(args: Any) -> Any | None:
+    if getattr(args, "no_mesh", False):
+        return None
+    try:
+        from synapsekit.mesh import KnowledgeMesh, MeshConfig
+
+        root = Path(args.mesh_root or args.cwd or Path.cwd()).expanduser()
+        return KnowledgeMesh(MeshConfig(roots=[root]))
+    except (ImportError, OSError, ValueError):
+        return None
+
+
+def _make_session(args: Any) -> ShellSession:
+    cwd = Path(args.cwd or Path.cwd()).expanduser().resolve()
+    shell = get_adapter(args.shell).kind.value
+    history = ShellHistory(
+        args.history_path or Path.home() / ".synapsekit" / "shell" / "history.sqlite3"
+    )
+    planner = CachedPlanner(
+        _load_planner(args.planner_module),
+        TranslationCache(
+            args.translation_cache or Path.home() / ".synapsekit" / "shell" / "translations.sqlite3"
+        ),
+        model=args.planner_module or "rules",
+    )
+    signing_policy = (
+        load_signing_policy(args.signing_key, key_id=args.key_id) if args.signing_key else None
+    )
+    ambient = (
+        JsonAmbientContext(args.ambient_status) if args.ambient_status else NullAmbientContext()
+    )
+    return ShellSession(
+        planner=planner,
+        cwd=cwd,
+        shell=shell,
+        mesh=_make_mesh(args),
+        ambient=ambient,
+        history=history,
+        signing_policy=signing_policy,
+        audit_dir=args.audit_dir,
+        timeout=args.timeout,
+        max_output_bytes=args.max_output,
+    )
+
+
+async def _confirm(step: Any, preview: str) -> bool:
+    print("\nDestructive command preview:")
+    print(preview)
+    answer = await asyncio.to_thread(input, "Execute this command? [y/N] ")
+    return answer.strip().casefold() in {"y", "yes"}
+
+
+async def _run_once(session: ShellSession, args: Any, text: str) -> int:
+    result = await session.run(text, confirm=_confirm, assume_yes=args.yes, dry_run=args.dry_run)
+    if args.json_output:
+        print(json.dumps(result_to_dict(result), indent=2, default=str))
+    else:
+        if result.plan.steps:
+            print(f"Plan: {result.plan.summary}")
+            for warning in result.plan.warnings:
+                print(f"Preview: {warning}")
+        for item in result.commands:
+            if item.stdout:
+                print(item.stdout, end="" if item.stdout.endswith("\n") else "\n")
+            if item.stderr:
+                print(item.stderr, end="" if item.stderr.endswith("\n") else "\n")
+        if result.audit_path:
+            print(f"Audit: {result.audit_path}")
+        if result.error:
+            print(f"Error: {result.error}")
+    return 0 if result.ok else 1
+
+
+async def _repl(session: ShellSession, args: Any) -> int:
+    prompt = get_adapter(args.shell).prompt()
+    while True:
+        try:
+            line = await asyncio.to_thread(input, prompt)
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 0
+        if not line.strip():
+            continue
+        if line.strip().casefold() in {"exit", "quit"}:
+            return 0
+        code = await _run_once(session, args, line)
+        if code:
+            print("The command was not completed.")
+
+
+def run_shell(args: Any) -> None:
+    command = args.shell_command
+    if command == "init":
+        print(get_adapter(args.shell).init_script(), end="")
+        return
+    if command == "complete":
+        engine = CompletionEngine(_make_mesh(args))
+        prefix = " ".join(args.prefix)
+        values = asyncio.run(engine.complete(prefix, cwd=args.cwd or Path.cwd()))
+        print("\n".join(values))
+        return
+    if command == "keygen":
+        print(json.dumps(generate_signing_key(args.private_key, args.public_key), indent=2))
+        return
+    if command == "history":
+        history = ShellHistory(getattr(args, "path", None))
+        query = " ".join(getattr(args, "query", []))
+        rows = asyncio.run(
+            history.search(query, limit=args.limit)
+            if args.history_command == "search"
+            else history.recent(limit=args.limit)
+        )
+        print(json.dumps(rows, indent=2, default=str))
+        return
+    if command == "status":
+        payload: dict[str, Any] = {
+            "shell": get_adapter(args.shell).name,
+            "cwd": str(Path(args.cwd or Path.cwd()).resolve()),
+        }
+        mesh = _make_mesh(args)
+        if mesh is not None:
+            payload["mesh"] = mesh.status().__dict__
+        print(json.dumps(payload, indent=2, default=str))
+        return
+    session = _make_session(args)
+    text = " ".join(args.text) if command == "run" else None
+    code = (
+        asyncio.run(_run_once(session, args, text))
+        if text is not None
+        else asyncio.run(_repl(session, args))
+    )
+    if code:
+        raise SystemExit(code)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Standalone ``synshell`` entry point."""
+    parser = argparse.ArgumentParser(prog="synshell")
+    _add_shell_options(parser)
+    parser.add_argument("text", nargs="*")
+    args = parser.parse_args(argv)
+    session = _make_session(args)
+    text = " ".join(args.text)
+    code = (
+        asyncio.run(_run_once(session, args, text)) if text else asyncio.run(_repl(session, args))
+    )
+    if code:
+        raise SystemExit(code)

--- a/src/synapsekit/live/instrument.py
+++ b/src/synapsekit/live/instrument.py
@@ -360,6 +360,14 @@ def instrument_all() -> None:
             },
         )
 
+    # -- Agent OS Shell: each plan + execution --
+    def shell() -> None:
+        from ..shell.session import ShellSession
+
+        cmd = lambda self, a, k: {"input": str(a[0])[:120]} if a else {}  # noqa: E731
+        _patch(ShellSession, "plan", "shell.plan", cmd)
+        _patch(ShellSession, "run", "shell.run", cmd)
+
     for step in (
         tools,
         memory,
@@ -372,5 +380,6 @@ def instrument_all() -> None:
         audit,
         swarm,
         agent_evolution,
+        shell,
     ):
         _try(step)

--- a/src/synapsekit/shell/__init__.py
+++ b/src/synapsekit/shell/__init__.py
@@ -1,0 +1,86 @@
+"""Agent OS Shell: mixed natural language and safe shell execution."""
+
+from .adapters import (
+    BashAdapter,
+    FishAdapter,
+    PowerShellAdapter,
+    ShellAdapter,
+    ZshAdapter,
+    all_adapters,
+    detect_shell,
+    get_adapter,
+)
+from .completion import CompletionEngine
+from .context import ContextCollector, JsonAmbientContext, NullAmbientContext
+from .executor import DirectShellExecutor, ShellExecutionError, parse_commands
+from .history import ShellHistory
+from .lexer import lex_input, split_shell_commands
+from .planner import (
+    CachedPlanner,
+    LLMShellPlanner,
+    PlanningError,
+    RuleBasedPlanner,
+    ShellPlanner,
+    TranslationCache,
+)
+from .safety import SafetyAnalyzer, SafetyError, SafetyPolicy
+from .security import generate_signing_key, load_signing_policy
+from .session import ShellSession, result_to_dict
+from .types import (
+    CommandResult,
+    InputSegment,
+    ParsedInput,
+    PlannedStep,
+    SafetyAssessment,
+    SegmentKind,
+    ShellCommand,
+    ShellContext,
+    ShellKind,
+    ShellPlan,
+    ShellRunResult,
+)
+
+__all__ = [
+    "BashAdapter",
+    "CachedPlanner",
+    "CommandResult",
+    "CompletionEngine",
+    "ContextCollector",
+    "DirectShellExecutor",
+    "FishAdapter",
+    "InputSegment",
+    "JsonAmbientContext",
+    "LLMShellPlanner",
+    "NullAmbientContext",
+    "ParsedInput",
+    "PlannedStep",
+    "PlanningError",
+    "PowerShellAdapter",
+    "RuleBasedPlanner",
+    "SafetyAnalyzer",
+    "SafetyAssessment",
+    "SafetyError",
+    "SafetyPolicy",
+    "SegmentKind",
+    "ShellAdapter",
+    "ShellCommand",
+    "ShellContext",
+    "ShellExecutionError",
+    "ShellHistory",
+    "ShellKind",
+    "ShellPlan",
+    "ShellPlanner",
+    "ShellRunResult",
+    "ShellSession",
+    "TranslationCache",
+    "ZshAdapter",
+    "all_adapters",
+    "detect_shell",
+    "generate_signing_key",
+    "get_adapter",
+    "lex_input",
+    "load_signing_policy",
+    "parse_commands",
+    "result_to_dict",
+    "split_shell_commands",
+]

--- a/src/synapsekit/shell/adapters.py
+++ b/src/synapsekit/shell/adapters.py
@@ -1,0 +1,124 @@
+"""Shell integration adapters and portable init scripts."""
+
+from __future__ import annotations
+
+import os
+import sys
+from abc import ABC, abstractmethod
+
+from .types import ShellKind
+
+
+class ShellAdapter(ABC):
+    """Dialect-specific integration surface; execution remains argv-based."""
+
+    kind: ShellKind
+
+    @property
+    def name(self) -> str:
+        return self.kind.value
+
+    @abstractmethod
+    def init_script(self) -> str:
+        """Return a script users can source in their current shell."""
+
+    @abstractmethod
+    def prompt(self) -> str:
+        """Return the prompt marker used by the optional REPL."""
+
+
+class BashAdapter(ShellAdapter):
+    kind = ShellKind.BASH
+
+    def init_script(self) -> str:
+        return """# SynapseKit Agent OS Shell (bash)
+synshell() { synapsekit shell run "$*"; }
+alias synapse="synshell"
+_synshell_complete() {
+    local current="${COMP_WORDS[COMP_CWORD]}"
+    COMPREPLY=( $(synapsekit shell complete --cwd "$PWD" "$current") )
+}
+complete -F _synshell_complete synshell
+"""
+
+    def prompt(self) -> str:
+        return "synshell > "
+
+
+class ZshAdapter(BashAdapter):
+    kind = ShellKind.ZSH
+
+    def init_script(self) -> str:
+        return """# SynapseKit Agent OS Shell (zsh)
+synshell() { synapsekit shell run "$*"; }
+alias synapse="synshell"
+_synshell_complete() { reply=($(synapsekit shell complete --cwd "$PWD" "$words[-1]")); }
+compctl -K _synshell_complete synshell
+"""
+
+
+class FishAdapter(ShellAdapter):
+    kind = ShellKind.FISH
+
+    def init_script(self) -> str:
+        return """# SynapseKit Agent OS Shell (fish)
+function synshell
+    synapsekit shell run (string join " " -- $argv)
+end
+alias synapse synshell
+complete -c synshell -a '(synapsekit shell complete --cwd $PWD (commandline -ct))'
+"""
+
+    def prompt(self) -> str:
+        return "synshell > "
+
+
+class PowerShellAdapter(ShellAdapter):
+    kind = ShellKind.POWERSHELL
+
+    def init_script(self) -> str:
+        return """# SynapseKit Agent OS Shell (PowerShell)
+function synshell { synapsekit shell run ($args -join " ") }
+Set-Alias synapse synshell
+Register-ArgumentCompleter -CommandName synshell -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete)
+    synapsekit shell complete --cwd $pwd $wordToComplete | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+    }
+}
+"""
+
+    def prompt(self) -> str:
+        return "synshell > "
+
+
+_ADAPTERS: dict[ShellKind, ShellAdapter] = {
+    ShellKind.BASH: BashAdapter(),
+    ShellKind.ZSH: ZshAdapter(),
+    ShellKind.FISH: FishAdapter(),
+    ShellKind.POWERSHELL: PowerShellAdapter(),
+}
+
+
+def get_adapter(shell: ShellKind | str | None = None) -> ShellAdapter:
+    if shell is None or str(shell).casefold() == "auto":
+        shell = detect_shell()
+    kind = shell if isinstance(shell, ShellKind) else ShellKind.parse(str(shell))
+    return _ADAPTERS[kind]
+
+
+def detect_shell() -> ShellKind:
+    if os.name == "nt" or os.environ.get("PSMODULEPATH"):
+        return ShellKind.POWERSHELL
+    executable = os.path.basename(os.environ.get("SHELL", "")).casefold()
+    if executable == "zsh":
+        return ShellKind.ZSH
+    if executable == "fish":
+        return ShellKind.FISH
+    if executable == "bash":
+        return ShellKind.BASH
+    return ShellKind.BASH if sys.platform != "win32" else ShellKind.POWERSHELL
+
+
+def all_adapters() -> tuple[ShellAdapter, ...]:
+    return tuple(_ADAPTERS.values())

--- a/src/synapsekit/shell/completion.py
+++ b/src/synapsekit/shell/completion.py
@@ -1,0 +1,40 @@
+"""Local and KnowledgeMesh-enriched completion."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+class CompletionEngine:
+    def __init__(self, mesh: Any | None = None) -> None:
+        self.mesh = mesh
+
+    async def complete(self, prefix: str, *, cwd: str | Path | None = None) -> list[str]:
+        root = Path(cwd or Path.cwd())
+        local = await asyncio.to_thread(self._local, prefix, root)
+        if self.mesh is None or not prefix.strip():
+            return local
+        mesh_items = await asyncio.to_thread(self._mesh, prefix)
+        return list(dict.fromkeys([*local, *mesh_items]))[:100]
+
+    @staticmethod
+    def _local(prefix: str, cwd: Path) -> list[str]:
+        token = prefix.rsplit(maxsplit=1)[-1] if prefix.split() else prefix
+        if token.startswith(".") or "/" in token or "\\" in token:
+            return [str(path.relative_to(cwd)) for path in cwd.glob(token + "*")][:50]
+        path = shutil.which(token)
+        candidates = [token] if path else []
+        return candidates
+
+    def _mesh(self, prefix: str) -> list[str]:
+        mesh = self.mesh
+        if mesh is None:
+            return []
+        try:
+            result = mesh.query_sync(prefix, top_k=10)
+        except Exception:
+            return []
+        return [hit.path for hit in result.hits]

--- a/src/synapsekit/shell/context.py
+++ b/src/synapsekit/shell/context.py
@@ -1,0 +1,144 @@
+"""Context providers used by the shell planner."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import platform
+import subprocess
+from pathlib import Path
+from typing import Any, Protocol
+
+from .adapters import detect_shell
+from .types import ShellContext, ShellKind
+
+
+class AmbientContextProvider(Protocol):
+    async def snapshot(self) -> dict[str, Any]: ...
+
+
+class NullAmbientContext:
+    """No-op provider used when the optional Ambient Agent is unavailable."""
+
+    async def snapshot(self) -> dict[str, Any]:
+        return {}
+
+
+class JsonAmbientContext:
+    """Read a bounded status document produced by an Ambient Agent daemon."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path).expanduser()
+
+    async def snapshot(self) -> dict[str, Any]:
+        return await asyncio.to_thread(self._read)
+
+    def _read(self) -> dict[str, Any]:
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8")[:128_000])
+        except (FileNotFoundError, OSError, ValueError):
+            return {}
+        return data if isinstance(data, dict) else {}
+
+
+def _git_value(cwd: Path, *args: str) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip()[:4_096]
+
+
+class ContextCollector:
+    """Collect local context without leaking an unrestricted environment."""
+
+    _SAFE_ENV_KEYS = (
+        "CI",
+        "GITHUB_ACTIONS",
+        "GITHUB_REF_NAME",
+        "VIRTUAL_ENV",
+        "CONDA_DEFAULT_ENV",
+        "TERM",
+    )
+
+    def __init__(
+        self,
+        *,
+        cwd: str | Path | None = None,
+        shell: ShellKind | str | None = None,
+        mesh: Any | None = None,
+        ambient: AmbientContextProvider | None = None,
+        history: Any | None = None,
+    ) -> None:
+        self.cwd = Path(cwd or Path.cwd()).expanduser().resolve()
+        self.shell = (
+            shell
+            if isinstance(shell, ShellKind)
+            else (detect_shell() if shell is None else ShellKind.parse(str(shell)))
+        )
+        self.mesh = mesh
+        self.ambient = ambient or NullAmbientContext()
+        self.history = history
+
+    async def collect(self, query: str = "") -> ShellContext:
+        branch, status = await asyncio.gather(
+            asyncio.to_thread(_git_value, self.cwd, "branch", "--show-current"),
+            asyncio.to_thread(_git_value, self.cwd, "status", "--short", "--branch"),
+        )
+        mesh_hits: tuple[dict[str, Any], ...] = ()
+        mesh = self.mesh
+        if mesh is not None and query:
+            mesh_hits = await asyncio.to_thread(self._query_mesh, query)
+        ambient, history = await asyncio.gather(
+            self.ambient.snapshot(),
+            self._history_search(query),
+        )
+        environment = {key: os.environ[key] for key in self._SAFE_ENV_KEYS if os.environ.get(key)}
+        return ShellContext(
+            cwd=str(self.cwd),
+            platform=platform.platform(),
+            shell=self.shell,
+            git_branch=branch,
+            git_status=status,
+            mesh_hits=mesh_hits,
+            ambient=ambient,
+            history=history,
+            environment=environment,
+        )
+
+    def _query_mesh(self, query: str) -> tuple[dict[str, Any], ...]:
+        mesh = self.mesh
+        if mesh is None:
+            return ()
+        try:
+            result = mesh.query_sync(query, top_k=5)
+        except Exception:
+            return ()
+        return tuple(
+            {
+                "path": hit.path,
+                "line_start": hit.line_start,
+                "line_end": hit.line_end,
+                "text": " ".join(hit.text.split())[:500],
+                "score": hit.score,
+            }
+            for hit in result.hits
+        )
+
+    async def _history_search(self, query: str) -> tuple[dict[str, Any], ...]:
+        if self.history is None or not query:
+            return ()
+        try:
+            return tuple(await self.history.search(query, limit=5))
+        except Exception:
+            return ()

--- a/src/synapsekit/shell/executor.py
+++ b/src/synapsekit/shell/executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 import shlex
 import subprocess
@@ -109,7 +110,7 @@ class DirectShellExecutor:
         argv = list(command.argv)
         try:
             process = await self._start(argv, context)
-            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=self.timeout)
+            stdout, stderr, _ = await asyncio.wait_for(self._drain(process), timeout=self.timeout)
         except asyncio.TimeoutError:
             if "process" in locals() and process.returncode is None:
                 process.kill()
@@ -147,7 +148,9 @@ class DirectShellExecutor:
 
         Stages are intentionally bounded and run sequentially. This is a
         conservative implementation that preserves the observable pipeline
-        result while avoiding a shell interpreter and unbounded pipe pumps.
+        result while avoiding a shell interpreter and unbounded pipe pumps:
+        each stage's output is streamed under a hard byte cap so an unbounded
+        producer (``yes | head``) is terminated at the cap rather than hanging.
         """
 
         input_data = b""
@@ -156,8 +159,8 @@ class DirectShellExecutor:
             started = time.monotonic()
             try:
                 process = await self._start(list(command.argv), context, pipe_stdin=True)
-                stdout, stderr = await asyncio.wait_for(
-                    process.communicate(input=input_data), timeout=self.timeout
+                stdout, stderr, truncated = await asyncio.wait_for(
+                    self._drain(process, input_data), timeout=self.timeout
                 )
             except asyncio.TimeoutError:
                 if "process" in locals() and process.returncode is None:
@@ -197,9 +200,66 @@ class DirectShellExecutor:
                 )
             )
             input_data = stdout[: self.max_output_bytes]
-            if process.returncode != 0:
+            # A stage killed for exceeding the output cap is expected, not a
+            # genuine failure: feed its (truncated) output to the next stage
+            # instead of aborting the pipeline.
+            if process.returncode != 0 and not truncated:
                 break
         return results
+
+    async def _drain(
+        self,
+        process: asyncio.subprocess.Process,
+        input_data: bytes = b"",
+    ) -> tuple[bytes, bytes, bool]:
+        """Feed stdin and read stdout/stderr under a hard byte cap.
+
+        Unlike ``Process.communicate`` (which buffers the child's entire
+        output into memory before any limit is applied), this reads
+        incrementally and kills the child as soon as either stream exceeds
+        ``max_output_bytes``. That keeps memory bounded and prevents an
+        unbounded producer from hanging a pipeline. Returns
+        ``(stdout, stderr, overflowed)`` where ``overflowed`` is ``True`` when
+        the cap terminated the process.
+        """
+
+        limit = self.max_output_bytes
+        overflowed = False
+
+        async def _read(stream: asyncio.StreamReader | None) -> bytes:
+            nonlocal overflowed
+            if stream is None:
+                return b""
+            chunks: list[bytes] = []
+            total = 0
+            while True:
+                chunk = await stream.read(65536)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                total += len(chunk)
+                if total > limit:
+                    overflowed = True
+                    with contextlib.suppress(ProcessLookupError):
+                        process.kill()
+                    break
+            return b"".join(chunks)
+
+        async def _feed() -> None:
+            stdin = process.stdin
+            if stdin is None:
+                return
+            with contextlib.suppress(BrokenPipeError, ConnectionResetError, RuntimeError, OSError):
+                if input_data:
+                    stdin.write(input_data)
+                    await stdin.drain()
+                stdin.close()
+
+        stdout, stderr, _ = await asyncio.gather(
+            _read(process.stdout), _read(process.stderr), _feed()
+        )
+        await process.wait()
+        return stdout, stderr, overflowed
 
     async def _start(
         self,

--- a/src/synapsekit/shell/executor.py
+++ b/src/synapsekit/shell/executor.py
@@ -1,0 +1,277 @@
+"""Direct subprocess execution for shell plans."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shlex
+import subprocess
+import time
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Literal, cast
+
+from .lexer import split_shell_commands
+from .types import CommandResult, ShellCommand, ShellContext
+
+
+class ShellExecutionError(RuntimeError):
+    """Raised when a command cannot be parsed or started."""
+
+
+def parse_commands(text: str, *, shell: str = "bash") -> list[ShellCommand]:
+    """Parse shell operators into direct argv commands."""
+
+    result: list[ShellCommand] = []
+    for raw, connector in split_shell_commands(text, shell=shell):
+        try:
+            argv = shlex.split(raw, posix=shell != "powershell")
+        except ValueError as exc:
+            raise ShellExecutionError(f"invalid shell command: {exc}") from exc
+        if shell == "powershell":
+            argv = [_strip_power_shell_quotes(value) for value in argv]
+        if not argv:
+            continue
+        result.append(
+            ShellCommand(tuple(argv), raw, cast(Literal["", "&&", "||", ";", "|"], connector or ""))
+        )
+    return result
+
+
+def _strip_power_shell_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+class DirectShellExecutor:
+    """Run argv directly and keep subprocesses bounded and collectable."""
+
+    def __init__(self, *, timeout: float = 30.0, max_output_bytes: int = 1_000_000) -> None:
+        if timeout <= 0:
+            raise ValueError("timeout must be positive")
+        if max_output_bytes <= 0:
+            raise ValueError("max_output_bytes must be positive")
+        self.timeout = timeout
+        self.max_output_bytes = max_output_bytes
+
+    async def run_text(self, text: str, context: ShellContext) -> list[CommandResult]:
+        commands = parse_commands(text, shell=context.shell.value)
+        return await self.run_commands(commands, context)
+
+    async def run_commands(
+        self,
+        commands: Iterable[ShellCommand],
+        context: ShellContext,
+    ) -> list[CommandResult]:
+        command_list = list(commands)
+        results: list[CommandResult] = []
+        index = 0
+        previous: CommandResult | None = None
+        while index < len(command_list):
+            command = command_list[index]
+            if command.connector == "&&" and previous is not None and not previous.ok:
+                result = self._skipped(command)
+                results.append(result)
+                previous = result
+                index += 1
+                continue
+            if command.connector == "||" and previous is not None and previous.ok:
+                result = self._skipped(command)
+                results.append(result)
+                previous = result
+                index += 1
+                continue
+            if command.connector == "|":
+                # A pipe group starts at the previous command. The first
+                # result was already emitted, so execute the group only when
+                # the parser supplied a leading command with no result.
+                index += 1
+                continue
+
+            group = [command]
+            next_index = index + 1
+            while next_index < len(command_list) and command_list[next_index].connector == "|":
+                group.append(command_list[next_index])
+                next_index += 1
+            if len(group) > 1:
+                group_results = await self._run_pipeline(group, context)
+                results.extend(group_results)
+                previous = group_results[-1]
+            else:
+                previous = await self._run_one(command, context)
+                results.append(previous)
+            index = next_index
+        return results
+
+    async def _run_one(self, command: ShellCommand, context: ShellContext) -> CommandResult:
+        started = time.monotonic()
+        argv = list(command.argv)
+        try:
+            process = await self._start(argv, context)
+            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=self.timeout)
+        except asyncio.TimeoutError:
+            if "process" in locals() and process.returncode is None:
+                process.kill()
+                await process.wait()
+            return CommandResult(
+                command=command.raw,
+                stdout="",
+                stderr=f"command timed out after {self.timeout:g}s",
+                exit_code=None,
+                duration_seconds=time.monotonic() - started,
+                timed_out=True,
+            )
+        except OSError as exc:
+            return CommandResult(
+                command=command.raw,
+                stdout="",
+                stderr=str(exc),
+                exit_code=None,
+                duration_seconds=time.monotonic() - started,
+            )
+        return CommandResult(
+            command=command.raw,
+            stdout=_decode(stdout, self.max_output_bytes),
+            stderr=_decode(stderr, self.max_output_bytes),
+            exit_code=process.returncode,
+            duration_seconds=time.monotonic() - started,
+        )
+
+    async def _run_pipeline(
+        self,
+        commands: list[ShellCommand],
+        context: ShellContext,
+    ) -> list[CommandResult]:
+        """Execute a finite pipeline without giving a shell an input string.
+
+        Stages are intentionally bounded and run sequentially. This is a
+        conservative implementation that preserves the observable pipeline
+        result while avoiding a shell interpreter and unbounded pipe pumps.
+        """
+
+        input_data = b""
+        results: list[CommandResult] = []
+        for position, command in enumerate(commands):
+            started = time.monotonic()
+            try:
+                process = await self._start(list(command.argv), context, pipe_stdin=True)
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(input=input_data), timeout=self.timeout
+                )
+            except asyncio.TimeoutError:
+                if "process" in locals() and process.returncode is None:
+                    process.kill()
+                    await process.wait()
+                results.append(
+                    CommandResult(
+                        command=command.raw,
+                        stdout="",
+                        stderr=f"pipeline stage timed out after {self.timeout:g}s",
+                        exit_code=None,
+                        duration_seconds=time.monotonic() - started,
+                        timed_out=True,
+                    )
+                )
+                break
+            except OSError as exc:
+                results.append(
+                    CommandResult(
+                        command=command.raw,
+                        stdout="",
+                        stderr=str(exc),
+                        exit_code=None,
+                        duration_seconds=time.monotonic() - started,
+                    )
+                )
+                break
+            output = _decode(stdout, self.max_output_bytes)
+            error = _decode(stderr, self.max_output_bytes)
+            results.append(
+                CommandResult(
+                    command=command.raw,
+                    stdout=output if position == len(commands) - 1 else "",
+                    stderr=error,
+                    exit_code=process.returncode,
+                    duration_seconds=time.monotonic() - started,
+                )
+            )
+            input_data = stdout[: self.max_output_bytes]
+            if process.returncode != 0:
+                break
+        return results
+
+    async def _start(
+        self,
+        argv: list[str],
+        context: ShellContext,
+        *,
+        pipe_stdin: bool = False,
+    ) -> asyncio.subprocess.Process:
+        stdin = asyncio.subprocess.PIPE if pipe_stdin else asyncio.subprocess.DEVNULL
+        try:
+            return await asyncio.create_subprocess_exec(
+                *argv,
+                cwd=context.cwd,
+                env=dict(os.environ),
+                stdin=stdin,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError:
+            # Common built-ins have no standalone executable on Windows. They
+            # are still invoked with a fixed argv boundary and only after the
+            # command has passed the same analyzer as every other command.
+            if os.name == "nt" and argv and argv[0].casefold() in {"echo", "dir"}:
+                safe_text = " ".join(shlex.quote(value) for value in argv[1:])
+                return await asyncio.create_subprocess_exec(
+                    "cmd.exe",
+                    "/d",
+                    "/c",
+                    argv[0],
+                    safe_text,
+                    cwd=context.cwd,
+                    env=dict(os.environ),
+                    stdin=stdin,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+            raise
+
+    def _skipped(self, command: ShellCommand) -> CommandResult:
+        return CommandResult(
+            command=command.raw,
+            stdout="",
+            stderr="skipped by conditional connector",
+            exit_code=None,
+            duration_seconds=0.0,
+            skipped=True,
+        )
+
+
+def _decode(value: bytes | None, limit: int) -> str:
+    if not value:
+        return ""
+    clipped = value[:limit]
+    suffix = "\n[output truncated]" if len(value) > limit else ""
+    return clipped.decode(errors="replace") + suffix
+
+
+async def git_diff(cwd: str | Path) -> str:
+    """Capture a bounded post-execution working-tree diff."""
+
+    def _read() -> str:
+        try:
+            completed = subprocess.run(
+                ["git", "diff", "--stat", "--no-ext-diff"],
+                cwd=Path(cwd),
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return ""
+        return completed.stdout[:16_384]
+
+    return await asyncio.to_thread(_read)

--- a/src/synapsekit/shell/history.py
+++ b/src/synapsekit/shell/history.py
@@ -1,0 +1,114 @@
+"""Local, redacted semantic-ish shell history backed by SQLite."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+_WORD_RE = re.compile(r"[a-z0-9_./:-]+", re.IGNORECASE)
+
+
+def _redact(value: str) -> str:
+    """Remove common secret-shaped values before local persistence."""
+
+    value = re.sub(r"(?i)(api[_-]?key|token|secret|password)=([^\s]+)", r"\1=<redacted>", value)
+    value = re.sub(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]+", "Bearer <redacted>", value)
+    return value[:16_384]
+
+
+class ShellHistory:
+    """Persist shell interactions locally and search by meaningful terms."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(
+            path or Path.home() / ".synapsekit" / "shell" / "history.sqlite3"
+        ).expanduser()
+        self._ready = False
+        self._ready_lock = asyncio.Lock()
+
+    async def _ensure_ready(self) -> None:
+        if self._ready:
+            return
+        async with self._ready_lock:
+            if not self._ready:
+                await asyncio.to_thread(self._initialize)
+                self._ready = True
+
+    def _initialize(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self.path) as connection:
+            connection.execute(
+                """CREATE TABLE IF NOT EXISTS shell_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    created_at REAL NOT NULL,
+                    cwd TEXT NOT NULL,
+                    input_text TEXT NOT NULL,
+                    commands_json TEXT NOT NULL,
+                    ok INTEGER NOT NULL
+                )"""
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS shell_history_created ON shell_history(created_at DESC)"
+            )
+
+    async def record(
+        self,
+        *,
+        cwd: str,
+        input_text: str,
+        commands: list[str],
+        ok: bool,
+    ) -> None:
+        await self._ensure_ready()
+        await asyncio.to_thread(self._record_sync, cwd, input_text, commands, ok)
+
+    def _record_sync(self, cwd: str, input_text: str, commands: list[str], ok: bool) -> None:
+        with sqlite3.connect(self.path) as connection:
+            connection.execute(
+                "INSERT INTO shell_history(created_at,cwd,input_text,commands_json,ok) VALUES(?,?,?,?,?)",
+                (
+                    time.time(),
+                    cwd,
+                    _redact(input_text),
+                    json.dumps([_redact(c) for c in commands]),
+                    int(ok),
+                ),
+            )
+
+    async def search(self, query: str, *, limit: int = 20) -> list[dict[str, Any]]:
+        await self._ensure_ready()
+        return await asyncio.to_thread(self._search_sync, query, limit)
+
+    def _search_sync(self, query: str, limit: int) -> list[dict[str, Any]]:
+        terms = [term.casefold() for term in _WORD_RE.findall(query) if len(term) > 1]
+        with sqlite3.connect(self.path) as connection:
+            if terms:
+                clauses = " OR ".join("input_text LIKE ?" for _ in terms)
+                params: list[Any] = [f"%{term}%" for term in terms]
+                rows = connection.execute(
+                    f"SELECT created_at,cwd,input_text,commands_json,ok FROM shell_history WHERE {clauses} ORDER BY created_at DESC LIMIT ?",
+                    [*params, limit],
+                ).fetchall()
+            else:
+                rows = connection.execute(
+                    "SELECT created_at,cwd,input_text,commands_json,ok FROM shell_history ORDER BY created_at DESC LIMIT ?",
+                    (limit,),
+                ).fetchall()
+        return [
+            {
+                "created_at": row[0],
+                "cwd": row[1],
+                "input": row[2],
+                "commands": json.loads(row[3]),
+                "ok": bool(row[4]),
+            }
+            for row in rows
+        ]
+
+    async def recent(self, *, limit: int = 20) -> list[dict[str, Any]]:
+        return await self.search("", limit=limit)

--- a/src/synapsekit/shell/lexer.py
+++ b/src/synapsekit/shell/lexer.py
@@ -17,12 +17,19 @@ def _looks_like_natural_language(value: str, *, at_line_start: bool) -> bool:
     text = value.strip()
     if not text:
         return False
+    # Explicit sentinels are always natural language, wherever they appear.
     if text.casefold().startswith(("nl:", "ask:", "natural language:")):
         return True
+    # The cue-word and bare-phrase heuristics only apply to a quote that opens
+    # a command (line start or right after a connector). A quoted argument in
+    # the middle of a command — e.g. ``git commit -m "find and fix the bug"``
+    # or ``grep "search term" file`` — is an ordinary shell token, never NL.
+    if not at_line_start:
+        return False
     if _NL_CUES.match(text):
         return True
     # A standalone quoted phrase with whitespace is the documented shorthand.
-    return at_line_start and any(char.isspace() for char in text)
+    return any(char.isspace() for char in text)
 
 
 def lex_input(raw: str) -> ParsedInput:

--- a/src/synapsekit/shell/lexer.py
+++ b/src/synapsekit/shell/lexer.py
@@ -1,0 +1,145 @@
+"""Lexer for mixed shell and quoted natural-language input."""
+
+from __future__ import annotations
+
+import re
+
+from .types import InputSegment, ParsedInput, SegmentKind
+
+_NL_CUES = re.compile(
+    r"^(?:find|locate|search|why|explain|show me|tell me|open|rerun|run|list|summarize|"
+    r"check|inspect|where|which|what|help|clean up|look for)\b",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_natural_language(value: str, *, at_line_start: bool) -> bool:
+    text = value.strip()
+    if not text:
+        return False
+    if text.casefold().startswith(("nl:", "ask:", "natural language:")):
+        return True
+    if _NL_CUES.match(text):
+        return True
+    # A standalone quoted phrase with whitespace is the documented shorthand.
+    return at_line_start and any(char.isspace() for char in text)
+
+
+def lex_input(raw: str) -> ParsedInput:
+    """Split a line while preserving executable shell text verbatim.
+
+    Quoted natural-language spans are removed from the shell stream, but their
+    source offsets are retained for diagnostics. Quotes used as ordinary shell
+    arguments (``echo "hello"``) remain shell text.
+    """
+
+    segments: list[InputSegment] = []
+    shell_start = 0
+    index = 0
+    length = len(raw)
+    at_line_start = True
+
+    def append_shell(end: int) -> None:
+        nonlocal shell_start
+        if end <= shell_start:
+            return
+        value = raw[shell_start:end]
+        if value.strip():
+            segments.append(InputSegment(value, SegmentKind.SHELL, shell_start, end))
+
+    while index < length:
+        char = raw[index]
+        if char == "\\" and index + 1 < length:
+            index += 2
+            at_line_start = False
+            continue
+        if char not in {"'", '"'}:
+            at_line_start = at_line_start and char.isspace()
+            index += 1
+            continue
+
+        quote = char
+        closing = index + 1
+        escaped = False
+        while closing < length:
+            current = raw[closing]
+            if escaped:
+                escaped = False
+            elif current == "\\" and quote == '"':
+                escaped = True
+            elif current == quote:
+                break
+            closing += 1
+        if closing >= length:
+            # Let the shell parser produce the precise unmatched-quote error.
+            index += 1
+            continue
+
+        value = raw[index + 1 : closing]
+        before = raw[:index].rstrip()
+        quote_at_start = not before or before.endswith(("&&", "||", ";", "|"))
+        if _looks_like_natural_language(value, at_line_start=quote_at_start):
+            append_shell(index)
+            if value.casefold().startswith("nl:"):
+                value = value[3:].lstrip()
+            elif value.casefold().startswith("ask:"):
+                value = value[4:].lstrip()
+            segments.append(InputSegment(value, SegmentKind.NATURAL_LANGUAGE, index, closing + 1))
+            shell_start = closing + 1
+            at_line_start = False
+        index = closing + 1
+
+    append_shell(length)
+    return ParsedInput(raw=raw, segments=tuple(segments))
+
+
+def split_shell_commands(text: str, *, shell: str = "bash") -> list[tuple[str, str]]:
+    """Split safe shell operators without invoking a shell interpreter."""
+
+    commands: list[tuple[str, str]] = []
+    start = 0
+    connector = ""
+    quote: str | None = None
+    escaped = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            index += 1
+            continue
+        if quote:
+            if char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            continue
+        candidate = ""
+        width = 1
+        if text.startswith("&&", index) or text.startswith("||", index):
+            candidate = text[index : index + 2]
+            width = 2
+        elif char in {";", "|"}:
+            candidate = char
+        if candidate:
+            value = text[start:index].strip()
+            if value:
+                commands.append((value, connector))
+            connector = candidate
+            start = index + width
+            index += width
+            continue
+        index += 1
+    if quote:
+        raise ValueError("unmatched quote in shell input")
+    value = text[start:].strip()
+    if value:
+        commands.append((value, connector))
+    return commands

--- a/src/synapsekit/shell/planner.py
+++ b/src/synapsekit/shell/planner.py
@@ -1,0 +1,253 @@
+"""Natural-language shell planning with a deterministic safe default."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from .types import PlannedStep, ShellContext, ShellKind
+
+
+class PlanningError(RuntimeError):
+    """Raised when natural language cannot be translated safely."""
+
+
+class ShellPlanner(Protocol):
+    async def plan(self, request: str, context: ShellContext) -> list[PlannedStep]: ...
+
+
+def _shell_command(context: ShellContext, unix: str, powershell: str | None = None) -> str:
+    return powershell if context.shell is ShellKind.POWERSHELL and powershell else unix
+
+
+class RuleBasedPlanner:
+    """Predictable offline planner for common Agent OS Shell intents."""
+
+    async def plan(self, request: str, context: ShellContext) -> list[PlannedStep]:
+        text = request.strip()
+        lowered = text.casefold()
+        if not text:
+            raise PlanningError("natural-language request is empty")
+        if "directory" in lowered and any(
+            word in lowered for word in ("large", "size", "gb", "space", "12gb")
+        ):
+            return [
+                PlannedStep(
+                    command=_shell_command(
+                        context,
+                        "du -sh -- */ | sort -h",
+                        "Get-ChildItem -Directory | ForEach-Object { $size=(Get-ChildItem $_.FullName -Recurse -File -ErrorAction SilentlyContinue | Measure-Object Length -Sum).Sum; [pscustomobject]@{Size=$size;Name=$_.Name} } | Sort-Object Size",
+                    ),
+                    explanation="Measure immediate subdirectory sizes and sort them.",
+                    source="rule",
+                )
+            ]
+        if any(
+            phrase in lowered for phrase in ("git status", "status of this repo", "what changed")
+        ):
+            return [
+                PlannedStep("git status --short --branch", "Show the repository state.", "rule")
+            ]
+        if "open the pr" in lowered or "open a pr" in lowered:
+            return [
+                PlannedStep(
+                    "gh pr create --fill --web",
+                    "Create a filled GitHub pull request and open it in the browser.",
+                    "rule",
+                )
+            ]
+        if any(phrase in lowered for phrase in ("rerun", "re-run", "run the test", "run tests")):
+            test_path = next(
+                (
+                    hit["path"]
+                    for hit in context.mesh_hits
+                    if str(hit.get("path", "")).endswith(".py")
+                    and "test" in str(hit.get("path", "")).casefold()
+                ),
+                None,
+            )
+            command = f"pytest -q {test_path}" if test_path else "pytest -q"
+            return [PlannedStep(command, "Run the most relevant discovered test target.", "rule")]
+        if any(word in lowered for word in ("find", "locate", "search")):
+            needle = _extract_quoted_or_last_phrase(text)
+            if needle:
+                return [
+                    PlannedStep(
+                        f"rg -n --hidden {needle!r} .", "Search tracked project text.", "rule"
+                    )
+                ]
+            return [PlannedStep("rg --files", "List project files for inspection.", "rule")]
+        if lowered.startswith(("list files", "show files", "what files")):
+            return [
+                PlannedStep(
+                    _shell_command(
+                        context,
+                        "find . -maxdepth 2 -type f",
+                        "Get-ChildItem -File -Recurse | Select-Object -First 200",
+                    ),
+                    "List files near the current directory.",
+                    "rule",
+                )
+            ]
+        if lowered.startswith(("explain", "why ", "what is")) and context.mesh_hits:
+            paths = ", ".join(str(hit.get("path")) for hit in context.mesh_hits[:3])
+            return [
+                PlannedStep(
+                    f"git grep -n {paths!r}",
+                    f"Inspect mesh-ranked sources: {paths}.",
+                    "rule",
+                )
+            ]
+        raise PlanningError(
+            "could not translate that request offline; use shell syntax or configure an LLM planner"
+        )
+
+
+def _extract_quoted_or_last_phrase(text: str) -> str:
+    match = re.search(r"['\"]([^'\"]+)['\"]", text)
+    if match:
+        return match.group(1)
+    words = re.split(r"\s+", text.strip())
+    return words[-1] if words and words[-1].casefold() not in {"for", "in", "from"} else ""
+
+
+class LLMShellPlanner:
+    """Strict JSON planner. It never executes or approves its own output."""
+
+    def __init__(self, llm: Any, *, model_name: str = "configured") -> None:
+        self.llm = llm
+        self.model_name = model_name
+
+    async def plan(self, request: str, context: ShellContext) -> list[PlannedStep]:
+        prompt = (
+            "Translate the request into safe, reviewable command steps. Return ONLY JSON with "
+            '{"steps":[{"command":"...","explanation":"..."}]}. Do not include markdown. '
+            "Never use shell=True, command substitution, or destructive operations unless the "
+            "user explicitly requested them; the host safety gate still decides execution.\n"
+            f"Shell context:\n{json.dumps(context.to_dict(), sort_keys=True)}\n"
+            f"Request: {request}"
+        )
+        response = await self.llm.generate(prompt, temperature=0, max_tokens=800)
+        try:
+            payload = json.loads(_strip_json_fence(response))
+            raw_steps = payload["steps"]
+        except (KeyError, TypeError, ValueError) as exc:
+            raise PlanningError("LLM planner returned invalid JSON") from exc
+        if not isinstance(raw_steps, list) or not raw_steps:
+            raise PlanningError("LLM planner returned no command steps")
+        steps: list[PlannedStep] = []
+        for item in raw_steps:
+            if not isinstance(item, dict) or not isinstance(item.get("command"), str):
+                raise PlanningError("LLM planner returned a malformed command step")
+            command = item["command"].strip()
+            if not command or len(command) > 8_192:
+                raise PlanningError("LLM planner returned an empty or oversized command")
+            steps.append(PlannedStep(command, str(item.get("explanation", "")), "llm", 0.7))
+        return steps
+
+
+def _strip_json_fence(value: str) -> str:
+    stripped = value.strip()
+    if stripped.startswith("```"):
+        stripped = re.sub(r"^```(?:json)?\s*|\s*```$", "", stripped, flags=re.IGNORECASE)
+    return stripped.strip()
+
+
+@dataclass
+class TranslationCache:
+    """Small SQLite cache for repeatable, non-destructive translations."""
+
+    path: Path
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(
+            path or Path.home() / ".synapsekit" / "shell" / "translations.sqlite3"
+        ).expanduser()
+        self._ready = False
+        self._lock = asyncio.Lock()
+
+    async def get(
+        self, request: str, context: ShellContext, model: str = "rules"
+    ) -> list[PlannedStep] | None:
+        await self._ensure()
+        key = self._key(request, context, model)
+        data = await asyncio.to_thread(self._get_sync, key)
+        if data is None:
+            return None
+        return [PlannedStep(**item) for item in data]
+
+    async def put(
+        self, request: str, context: ShellContext, steps: list[PlannedStep], model: str = "rules"
+    ) -> None:
+        if any(
+            step.command.casefold().find(marker) >= 0
+            for step in steps
+            for marker in ("reset", "clean", "--force", "remove", "delete")
+        ):
+            return
+        await self._ensure()
+        key = self._key(request, context, model)
+        await asyncio.to_thread(self._put_sync, key, [step.__dict__ for step in steps])
+
+    async def _ensure(self) -> None:
+        if self._ready:
+            return
+        async with self._lock:
+            if not self._ready:
+                await asyncio.to_thread(self._init_sync)
+                self._ready = True
+
+    def _init_sync(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self.path) as connection:
+            connection.execute(
+                "CREATE TABLE IF NOT EXISTS translations (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+            )
+
+    def _get_sync(self, key: str) -> list[dict[str, Any]] | None:
+        with sqlite3.connect(self.path) as connection:
+            row = connection.execute(
+                "SELECT value FROM translations WHERE key=?", (key,)
+            ).fetchone()
+        return json.loads(row[0]) if row else None
+
+    def _put_sync(self, key: str, value: list[dict[str, Any]]) -> None:
+        with sqlite3.connect(self.path) as connection:
+            connection.execute(
+                "INSERT OR REPLACE INTO translations(key,value) VALUES(?,?)",
+                (key, json.dumps(value)),
+            )
+
+    @staticmethod
+    def _key(request: str, context: ShellContext, model: str) -> str:
+        material = json.dumps(
+            {
+                "request": request.strip().casefold(),
+                "cwd": context.cwd,
+                "shell": context.shell.value,
+                "model": model,
+            },
+            sort_keys=True,
+        )
+        return hashlib.sha256(material.encode()).hexdigest()
+
+
+class CachedPlanner:
+    def __init__(self, planner: ShellPlanner, cache: TranslationCache, *, model: str) -> None:
+        self.planner = planner
+        self.cache = cache
+        self.model = model
+
+    async def plan(self, request: str, context: ShellContext) -> list[PlannedStep]:
+        cached = await self.cache.get(request, context, self.model)
+        if cached is not None:
+            return cached
+        steps = await self.planner.plan(request, context)
+        await self.cache.put(request, context, steps, self.model)
+        return steps

--- a/src/synapsekit/shell/safety.py
+++ b/src/synapsekit/shell/safety.py
@@ -1,0 +1,88 @@
+"""Fail-closed safety policy for agent-generated shell commands."""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+
+from .types import SafetyAssessment
+
+
+class SafetyError(RuntimeError):
+    """Raised when a command cannot pass the shell safety policy."""
+
+
+@dataclass(frozen=True)
+class SafetyPolicy:
+    """Policy knobs intentionally biased toward user confirmation."""
+
+    allow_destructive: bool = True
+    require_signed_approval: bool = True
+    max_command_length: int = 8_192
+
+
+class SafetyAnalyzer:
+    """Classify commands before they reach the subprocess executor."""
+
+    _DESTRUCTIVE = (
+        ("git reset", "rewrites the working tree or index"),
+        ("git clean", "deletes untracked files"),
+        ("git push --force", "rewrites a remote branch"),
+        ("git push -f", "rewrites a remote branch"),
+        ("git branch -D", "force-deletes a branch"),
+        ("git rm", "removes tracked files"),
+        ("git restore", "overwrites working tree changes"),
+        ("git checkout --", "overwrites working tree changes"),
+        ("git push --delete", "deletes a remote branch"),
+        ("rm", "removes files or directories"),
+        ("remove-item", "removes files or directories"),
+        ("rmdir", "removes directories"),
+        ("del", "removes files"),
+        ("docker system prune", "removes Docker resources"),
+        ("docker volume rm", "removes Docker volumes"),
+        ("kubectl delete", "deletes cluster resources"),
+        ("terraform destroy", "destroys infrastructure"),
+    )
+
+    def __init__(self, policy: SafetyPolicy | None = None) -> None:
+        self.policy = policy or SafetyPolicy()
+
+    def assess(self, command: str) -> SafetyAssessment:
+        if len(command) > self.policy.max_command_length:
+            raise SafetyError(
+                f"command is too long ({len(command)} characters; "
+                f"limit is {self.policy.max_command_length})"
+            )
+        normalized = " ".join(command.casefold().split())
+        reasons: list[str] = []
+        try:
+            argv = shlex.split(command, posix=True)
+        except ValueError as exc:
+            raise SafetyError(f"invalid command: {exc}") from exc
+        if not argv:
+            raise SafetyError("empty command")
+
+        executable = argv[0].casefold().rsplit("\\", 1)[-1].rsplit("/", 1)[-1]
+        for marker, reason in self._DESTRUCTIVE:
+            if marker in normalized and (marker != "rm" or executable in {"rm", "rm.exe"}):
+                reasons.append(reason)
+        if executable in {"mv", "move", "move-item", "copy", "cp", "copy-item"} and any(
+            flag in normalized for flag in (" -f", " -force", " --force")
+        ):
+            reasons.append("forcefully overwrites or moves existing data")
+        if any(token in normalized for token in (">", ">>", "2>", " 2>>")):
+            reasons.append("overwrites or redirects a file")
+        if "--force" in argv or "-f" in argv[1:]:
+            reasons.append("uses a force flag")
+        destructive = bool(reasons)
+        preview = self._preview(argv, reasons)
+        return SafetyAssessment(
+            destructive=destructive, reasons=tuple(dict.fromkeys(reasons)), preview=preview
+        )
+
+    @staticmethod
+    def _preview(argv: list[str], reasons: list[str]) -> str:
+        rendered = " ".join(shlex.quote(part) for part in argv)
+        if not reasons:
+            return rendered
+        return f"{rendered}\nReasons: " + "; ".join(dict.fromkeys(reasons))

--- a/src/synapsekit/shell/security.py
+++ b/src/synapsekit/shell/security.py
@@ -1,0 +1,51 @@
+"""Ed25519 key helpers for shell pre-execution receipts."""
+
+from __future__ import annotations
+
+import base64
+from contextlib import suppress
+from pathlib import Path
+
+
+def generate_signing_key(
+    private_path: str | Path, public_path: str | Path | None = None
+) -> dict[str, str]:
+    """Generate a raw Ed25519 keypair for local shell audit receipts."""
+
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    private_key = Ed25519PrivateKey.generate()
+    private_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_bytes = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    private = Path(private_path).expanduser()
+    private.parent.mkdir(parents=True, exist_ok=True)
+    private.write_bytes(private_bytes)
+    with suppress(OSError):
+        private.chmod(0o600)
+    public = (
+        Path(public_path).expanduser()
+        if public_path
+        else private.with_suffix(private.suffix + ".pub")
+    )
+    public.write_text(base64.b64encode(public_bytes).decode("ascii") + "\n", encoding="utf-8")
+    return {
+        "private_key": str(private),
+        "public_key": str(public),
+        "key_id": base64.urlsafe_b64encode(public_bytes[:12]).decode("ascii").rstrip("="),
+    }
+
+
+def load_signing_policy(path: str | Path, *, key_id: str | None = None):
+    """Load a raw Ed25519 private key into SynapseKit's audit policy."""
+
+    from synapsekit.audit import SigningPolicy
+
+    return SigningPolicy.ed25519(Path(path).expanduser().read_bytes(), key_id=key_id)

--- a/src/synapsekit/shell/session.py
+++ b/src/synapsekit/shell/session.py
@@ -1,0 +1,265 @@
+"""High-level Agent OS Shell session orchestration."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+from synapsekit.audit import AuditTracer, EventKind, PIIRedactor, export_audit_bundle
+
+from .context import ContextCollector, NullAmbientContext
+from .executor import DirectShellExecutor, git_diff
+from .history import ShellHistory
+from .lexer import lex_input
+from .planner import CachedPlanner, PlanningError, RuleBasedPlanner, ShellPlanner, TranslationCache
+from .safety import SafetyAnalyzer, SafetyError, SafetyPolicy
+from .types import (
+    CommandResult,
+    PlannedStep,
+    SegmentKind,
+    ShellContext,
+    ShellPlan,
+    ShellRunResult,
+)
+
+ConfirmCallback = Callable[[PlannedStep, str], Awaitable[bool]]
+
+
+class ShellSession:
+    """Plan, preview, confirm, execute, and attest one shell interaction."""
+
+    def __init__(
+        self,
+        *,
+        planner: ShellPlanner | None = None,
+        cwd: str | Path | None = None,
+        shell: str | None = None,
+        mesh: Any | None = None,
+        ambient: Any | None = None,
+        history: ShellHistory | None = None,
+        safety_policy: SafetyPolicy | None = None,
+        signing_policy: Any | None = None,
+        audit_dir: str | Path | None = None,
+        timeout: float = 30.0,
+        max_output_bytes: int = 1_000_000,
+    ) -> None:
+        self.history = history or ShellHistory()
+        self.context_collector = ContextCollector(
+            cwd=cwd,
+            shell=shell,
+            mesh=mesh,
+            ambient=ambient or NullAmbientContext(),
+            history=self.history,
+        )
+        self.planner = planner or CachedPlanner(
+            RuleBasedPlanner(), TranslationCache(), model="rules"
+        )
+        self.safety = SafetyAnalyzer(safety_policy)
+        self.signing_policy = signing_policy
+        self.audit_dir = Path(audit_dir).expanduser() if audit_dir else None
+        self.executor = DirectShellExecutor(timeout=timeout, max_output_bytes=max_output_bytes)
+        self.tracer = AuditTracer(run_id=uuid.uuid4().hex, redactor=PIIRedactor())
+        self.last_context: ShellContext | None = None
+
+    async def plan(self, input_text: str) -> ShellPlan:
+        if not input_text.strip():
+            raise PlanningError("input is empty")
+        context = await self.context_collector.collect(input_text)
+        self.last_context = context
+        self.tracer.record(
+            EventKind.USER_INPUT,
+            {"input": input_text, "cwd": context.cwd, "shell": context.shell.value},
+            actor="user",
+        )
+        if context.mesh_hits:
+            self.tracer.record(
+                EventKind.RETRIEVAL, {"query": input_text, "hits": list(context.mesh_hits)}
+            )
+        self.tracer.record(EventKind.STATE_CHANGE, {"context": context.to_dict()}, actor="shell")
+
+        parsed = lex_input(input_text)
+        steps: list[PlannedStep] = []
+        warnings: list[str] = []
+        for segment in parsed.segments:
+            if segment.kind is SegmentKind.SHELL:
+                if segment.text.strip(" &|;\t\r\n"):
+                    steps.append(
+                        PlannedStep(
+                            segment.text.strip(), "Execute the supplied shell text.", "shell"
+                        )
+                    )
+                continue
+            try:
+                planned = await self.planner.plan(segment.text, context)
+            except PlanningError:
+                raise
+            steps.extend(planned)
+        if not steps:
+            raise PlanningError("no shell or natural-language steps were found")
+        for step in steps:
+            assessment = self.safety.assess(step.command)
+            if assessment.destructive:
+                warnings.append(assessment.preview)
+        return ShellPlan(
+            input_text=input_text,
+            steps=tuple(steps),
+            summary="; ".join(step.explanation or step.command for step in steps),
+            warnings=tuple(warnings),
+        )
+
+    async def run(
+        self,
+        input_text: str,
+        *,
+        confirm: ConfirmCallback | None = None,
+        assume_yes: bool = False,
+        dry_run: bool = False,
+    ) -> ShellRunResult:
+        try:
+            plan = await self.plan(input_text)
+        except (PlanningError, SafetyError) as exc:
+            return ShellRunResult(
+                plan=ShellPlan(input_text, (), "", ()), commands=(), aborted=True, error=str(exc)
+            )
+
+        destructive_steps: list[tuple[PlannedStep, str]] = []
+        for step in plan.steps:
+            assessment = self.safety.assess(step.command)
+            if assessment.destructive:
+                destructive_steps.append((step, assessment.preview))
+        if destructive_steps:
+            if not self.safety.policy.allow_destructive:
+                return await self._abort(plan, "destructive commands are disabled by policy")
+            if self.safety.policy.require_signed_approval and self.signing_policy is None:
+                return await self._abort(
+                    plan,
+                    "destructive commands require --signing-key; unsigned execution is disabled",
+                )
+            for step, preview in destructive_steps:
+                approved = assume_yes
+                if not approved and confirm is not None:
+                    approved = await confirm(step, preview)
+                if not approved:
+                    self.tracer.record(
+                        EventKind.DECISION,
+                        {"command": step.command, "approved": False, "preview": preview},
+                        actor="user",
+                    )
+                    audit_path = await self._export_audit("denied")
+                    return ShellRunResult(
+                        plan,
+                        (),
+                        aborted=True,
+                        error="destructive command not approved",
+                        audit_path=audit_path,
+                    )
+                self.tracer.record(
+                    EventKind.DECISION,
+                    {"command": step.command, "approved": True, "preview": preview},
+                    actor="user",
+                )
+            # This export is the signed pre-execution receipt. The final
+            # export below adds tool results and the post-execution diff.
+            audit_path = await self._export_audit("preflight")
+        else:
+            audit_path = None
+
+        if dry_run:
+            return ShellRunResult(plan, (), audit_path=audit_path)
+
+        results: list[CommandResult] = []
+        for step in plan.steps:
+            self.tracer.record(
+                EventKind.TOOL_CALL, {"command": step.command, "source": step.source}, actor="shell"
+            )
+            step_results = await self.executor.run_text(
+                step.command, self.last_context or await self.context_collector.collect()
+            )
+            results.extend(step_results)
+            self.tracer.record(
+                EventKind.TOOL_RESULT,
+                {
+                    "command": step.command,
+                    "results": [
+                        {
+                            "exit_code": result.exit_code,
+                            "stdout": result.stdout,
+                            "stderr": result.stderr,
+                            "timed_out": result.timed_out,
+                            "skipped": result.skipped,
+                        }
+                        for result in step_results
+                    ],
+                },
+                actor="shell",
+            )
+        if destructive_steps:
+            self.tracer.record(
+                EventKind.STATE_CHANGE,
+                {"git_diff_stat": await git_diff(self.context_collector.cwd)},
+                actor="shell",
+            )
+        ok = all(result.ok for result in results)
+        await self.history.record(
+            cwd=str(self.context_collector.cwd),
+            input_text=input_text,
+            commands=[step.command for step in plan.steps],
+            ok=ok,
+        )
+        final_audit = (
+            await self._export_audit("final") if self.signing_policy is not None else audit_path
+        )
+        return ShellRunResult(plan, tuple(results), audit_path=final_audit)
+
+    async def _abort(self, plan: ShellPlan, message: str) -> ShellRunResult:
+        self.tracer.record(EventKind.ERROR, {"error": message}, actor="shell")
+        audit_path = await self._export_audit("abort")
+        return ShellRunResult(plan, (), aborted=True, error=message, audit_path=audit_path)
+
+    async def _export_audit(self, suffix: str) -> str | None:
+        if self.signing_policy is None:
+            return None
+        directory = self.audit_dir or Path.home() / ".synapsekit" / "shell" / "audit"
+        await asyncio.to_thread(directory.mkdir, parents=True, exist_ok=True)
+        path = directory / f"{self.tracer.run_id}-{suffix}.audit.zip"
+        records = list(self.tracer.records)
+        await asyncio.to_thread(export_audit_bundle, records, self.signing_policy, path)
+        return str(path)
+
+
+def result_to_dict(result: ShellRunResult) -> dict[str, Any]:
+    return {
+        "ok": result.ok,
+        "aborted": result.aborted,
+        "error": result.error,
+        "audit_path": result.audit_path,
+        "plan": {
+            "input": result.plan.input_text,
+            "summary": result.plan.summary,
+            "warnings": list(result.plan.warnings),
+            "steps": [
+                {
+                    "command": step.command,
+                    "explanation": step.explanation,
+                    "source": step.source,
+                    "confidence": step.confidence,
+                }
+                for step in result.plan.steps
+            ],
+        },
+        "commands": [
+            {
+                "command": item.command,
+                "stdout": item.stdout,
+                "stderr": item.stderr,
+                "exit_code": item.exit_code,
+                "duration_seconds": item.duration_seconds,
+                "timed_out": item.timed_out,
+                "skipped": item.skipped,
+            }
+            for item in result.commands
+        ],
+    }

--- a/src/synapsekit/shell/types.py
+++ b/src/synapsekit/shell/types.py
@@ -1,0 +1,186 @@
+"""Public contracts for SynapseKit's agent-aware shell."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Literal
+
+
+class ShellKind(str, Enum):
+    """Shell dialects supported by the integration plugins."""
+
+    BASH = "bash"
+    ZSH = "zsh"
+    FISH = "fish"
+    POWERSHELL = "powershell"
+
+    @classmethod
+    def parse(cls, value: str) -> ShellKind:
+        normalized = value.casefold().strip()
+        if normalized in {"pwsh", "ps", "powershell.exe"}:
+            normalized = cls.POWERSHELL.value
+        try:
+            return cls(normalized)
+        except ValueError as exc:
+            raise ValueError(f"unsupported shell: {value!r}") from exc
+
+
+class SegmentKind(str, Enum):
+    """Whether an input segment is executable shell text or natural language."""
+
+    SHELL = "shell"
+    NATURAL_LANGUAGE = "natural_language"
+
+
+@dataclass(frozen=True)
+class InputSegment:
+    """A source-preserving part of a mixed shell line."""
+
+    text: str
+    kind: SegmentKind
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class ParsedInput:
+    """Result of lexing one line."""
+
+    raw: str
+    segments: tuple[InputSegment, ...]
+
+    @property
+    def has_natural_language(self) -> bool:
+        return any(segment.kind is SegmentKind.NATURAL_LANGUAGE for segment in self.segments)
+
+
+@dataclass(frozen=True)
+class ShellCommand:
+    """A shell command represented as argv, never as an executable shell string."""
+
+    argv: tuple[str, ...]
+    raw: str
+    connector: Literal["", "&&", "||", ";", "|"] = ""
+
+    @property
+    def executable(self) -> str:
+        return self.argv[0] if self.argv else ""
+
+
+@dataclass(frozen=True)
+class ShellContext:
+    """Minimal, redaction-friendly context supplied to planners."""
+
+    cwd: str
+    platform: str
+    shell: ShellKind
+    git_branch: str | None = None
+    git_status: str | None = None
+    mesh_hits: tuple[dict[str, Any], ...] = ()
+    ambient: dict[str, Any] = field(default_factory=dict)
+    history: tuple[dict[str, Any], ...] = ()
+    environment: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cwd": self.cwd,
+            "platform": self.platform,
+            "shell": self.shell.value,
+            "git_branch": self.git_branch,
+            "git_status": self.git_status,
+            "mesh_hits": list(self.mesh_hits),
+            "ambient": dict(self.ambient),
+            "history": list(self.history),
+            "environment": dict(self.environment),
+        }
+
+
+@dataclass(frozen=True)
+class PlannedStep:
+    """A planner output that still must pass the safety analyzer."""
+
+    command: str
+    explanation: str = ""
+    source: Literal["shell", "rule", "llm"] = "shell"
+    confidence: float = 1.0
+    connector: Literal["", "&&", "||", ";", "|"] = ""
+
+
+@dataclass(frozen=True)
+class ShellPlan:
+    """Validated plan shown to a user before execution."""
+
+    input_text: str
+    steps: tuple[PlannedStep, ...]
+    summary: str
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def requires_confirmation(self) -> bool:
+        return any(step_is_destructive(step.command) for step in self.steps)
+
+
+@dataclass(frozen=True)
+class SafetyAssessment:
+    """Classification of a command and its reasons."""
+
+    destructive: bool
+    reasons: tuple[str, ...] = ()
+    preview: str = ""
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Captured result of one direct subprocess invocation."""
+
+    command: str
+    stdout: str
+    stderr: str
+    exit_code: int | None
+    duration_seconds: float
+    timed_out: bool = False
+    skipped: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return not self.timed_out and not self.skipped and self.exit_code == 0
+
+
+@dataclass(frozen=True)
+class ShellRunResult:
+    """Complete execution result returned by :class:`ShellSession`."""
+
+    plan: ShellPlan
+    commands: tuple[CommandResult, ...]
+    aborted: bool = False
+    error: str | None = None
+    audit_path: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return (
+            not self.aborted and self.error is None and all(result.ok for result in self.commands)
+        )
+
+
+def step_is_destructive(command: str) -> bool:
+    """Small dependency-free helper used by the immutable plan contract."""
+
+    lowered = command.casefold().strip()
+    return any(
+        marker in lowered
+        for marker in (
+            "git reset",
+            "git clean",
+            "git push --force",
+            "git push -f",
+            "rm ",
+            "remove-item",
+            " rmdir",
+            " del ",
+            "docker system prune",
+            "docker volume rm",
+            "kubectl delete",
+        )
+    )

--- a/tests/live/test_instrument_shell.py
+++ b/tests/live/test_instrument_shell.py
@@ -1,0 +1,53 @@
+"""Auto-instrumentation of the Agent OS Shell → SynapseKit Live.
+
+Real objects only — a real ShellSession running a real (safe) subprocess. No
+server, no mocks: instrument the class and toggle the bus directly.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from synapsekit.live import bus
+from synapsekit.live.instrument import instrument_all
+from synapsekit.shell import ShellHistory, ShellSession
+
+
+@pytest.fixture(autouse=True)
+def _instrumented_bus():
+    instrument_all()
+    was = bus.enabled
+    bus.enabled = True
+    bus.clear()
+    yield
+    bus.enabled = was
+
+
+def _session(tmp_path: Path) -> ShellSession:
+    return ShellSession(
+        cwd=tmp_path,
+        shell="bash",
+        mesh=None,
+        history=ShellHistory(tmp_path / "history.sqlite3"),
+    )
+
+
+def test_run_and_plan_stay_coroutines_after_instrumentation() -> None:
+    assert inspect.iscoroutinefunction(ShellSession.run)
+    assert inspect.iscoroutinefunction(ShellSession.plan)
+
+
+async def test_shell_run_publishes_plan_and_run_events(tmp_path: Path) -> None:
+    result = await _session(tmp_path).run("echo hello")
+    assert result.ok
+
+    kinds = [e["kind"] for e in bus.history()]
+    assert "shell.plan" in kinds
+    assert "shell.run" in kinds
+    run_event = [e for e in bus.history() if e["kind"] == "shell.run"][-1]
+    assert run_event["attributes"]["input"] == "echo hello"
+    assert run_event["status"] == "ok"
+    assert run_event["duration_ms"] >= 0

--- a/tests/shell/__init__.py
+++ b/tests/shell/__init__.py
@@ -1,0 +1,1 @@
+"""Agent OS Shell tests."""

--- a/tests/shell/test_adapters.py
+++ b/tests/shell/test_adapters.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from synapsekit.shell import all_adapters
+
+
+def test_all_supported_shells_have_init_plugins() -> None:
+    scripts = {adapter.name: adapter.init_script() for adapter in all_adapters()}
+
+    assert set(scripts) == {"bash", "zsh", "fish", "powershell"}
+    assert all(
+        "synshell" in script and "synapsekit shell run" in script for script in scripts.values()
+    )

--- a/tests/shell/test_completion.py
+++ b/tests/shell/test_completion.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from synapsekit.shell import CompletionEngine, SafetyAnalyzer, all_adapters
+
+
+def test_each_shell_plugin_calls_completion_command() -> None:
+    scripts = [adapter.init_script() for adapter in all_adapters()]
+
+    assert all("synapsekit shell complete" in script for script in scripts)
+
+
+def test_local_completion_returns_executable_prefix() -> None:
+    values = asyncio.run(CompletionEngine().complete("python", cwd=Path.cwd()))
+
+    assert "python" in values
+
+
+def test_git_rm_is_destructive() -> None:
+    assessment = SafetyAnalyzer().assess("git rm important.txt")
+
+    assert assessment.destructive
+    assert "tracked files" in assessment.preview

--- a/tests/shell/test_executor.py
+++ b/tests/shell/test_executor.py
@@ -1,0 +1,71 @@
+"""Regression tests for bounded output and non-hanging pipelines (#929)."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+from synapsekit.shell import DirectShellExecutor, ShellCommand, ShellContext, ShellKind
+
+# A cross-platform, unbounded stdout producer. Emits short newline-terminated
+# lines forever so a downstream reader (and the output cap) has something to bite
+# on regardless of pipe buffering.
+_PRODUCER = "import sys\nwhile True:\n sys.stdout.write('x' * 63 + '\\n')\n sys.stdout.flush()"
+_READ_ONE_LINE = "import sys; sys.stdout.write(sys.stdin.readline())"
+
+
+def _context(tmp_path: Path) -> ShellContext:
+    return ShellContext(cwd=str(tmp_path), platform=sys.platform, shell=ShellKind.BASH)
+
+
+def _cmd(argv: tuple[str, ...], connector: str = "") -> ShellCommand:
+    return ShellCommand(argv, " ".join(argv), connector)  # type: ignore[arg-type]
+
+
+def test_unbounded_output_is_capped_and_does_not_hang(tmp_path: Path) -> None:
+    executor = DirectShellExecutor(timeout=15.0, max_output_bytes=2000)
+    producer = _cmd((sys.executable, "-c", _PRODUCER))
+
+    started = time.monotonic()
+    results = asyncio.run(executor.run_commands([producer], _context(tmp_path)))
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 12.0  # capped and killed, nowhere near the 15s timeout
+    assert len(results) == 1
+    result = results[0]
+    assert "[output truncated]" in result.stdout
+    # Output is bounded by the cap (+ the short truncation marker), not unbounded.
+    assert len(result.stdout.encode()) <= 2000 + len("\n[output truncated]")
+    assert not result.timed_out
+
+
+def test_pipeline_with_unbounded_producer_terminates(tmp_path: Path) -> None:
+    executor = DirectShellExecutor(timeout=15.0, max_output_bytes=2000)
+    commands = [
+        _cmd((sys.executable, "-c", _PRODUCER)),
+        _cmd((sys.executable, "-c", _READ_ONE_LINE), connector="|"),
+    ]
+
+    started = time.monotonic()
+    results = asyncio.run(executor.run_commands(commands, _context(tmp_path)))
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 12.0  # the classic `yes | head -1` hang is gone
+    assert len(results) == 2
+    # The consumer ran on the producer's (truncated) output and exited cleanly.
+    consumer = results[-1]
+    assert consumer.exit_code == 0
+    assert consumer.stdout.startswith("x")
+
+
+def test_bounded_output_below_cap_is_untouched(tmp_path: Path) -> None:
+    executor = DirectShellExecutor(timeout=10.0, max_output_bytes=1_000_000)
+    echo = _cmd((sys.executable, "-c", "print('hello world')"))
+
+    results = asyncio.run(executor.run_commands([echo], _context(tmp_path)))
+
+    assert results[0].exit_code == 0
+    assert results[0].stdout.strip() == "hello world"
+    assert "[output truncated]" not in results[0].stdout

--- a/tests/shell/test_lexer.py
+++ b/tests/shell/test_lexer.py
@@ -20,6 +20,36 @@ def test_ordinary_shell_quotes_are_not_reclassified() -> None:
     assert parsed.segments[0].kind is SegmentKind.SHELL
 
 
+def test_quoted_arg_starting_with_cue_word_stays_shell() -> None:
+    # Regression for #930: a quoted argument mid-command that happens to begin
+    # with a cue word (find/run/search/...) must remain a shell token, not be
+    # reclassified as natural language and stripped out of the command.
+    parsed = lex_input('git commit -m "find and fix the bug"')
+
+    assert not parsed.has_natural_language
+    assert len(parsed.segments) == 1
+    assert parsed.segments[0].kind is SegmentKind.SHELL
+    assert parsed.segments[0].text.strip() == 'git commit -m "find and fix the bug"'
+
+    commands = parse_commands('git commit -m "find and fix the bug"', shell=ShellKind.BASH.value)
+    assert commands[0].argv == ("git", "commit", "-m", "find and fix the bug")
+
+
+def test_grep_pattern_with_cue_word_is_preserved() -> None:
+    parsed = lex_input('grep "search term" file.txt')
+    assert not parsed.has_natural_language
+
+    commands = parse_commands('grep "search term" file.txt', shell=ShellKind.BASH.value)
+    assert commands[0].argv == ("grep", "search term", "file.txt")
+
+
+def test_leading_cue_phrase_is_still_natural_language() -> None:
+    # The bare-phrase / cue-word shorthand still applies when the quote opens a
+    # command (line start or right after a connector).
+    assert lex_input('"find the flaky test"').has_natural_language
+    assert lex_input('git push && "run the tests"').has_natural_language
+
+
 def test_operators_become_direct_argv_commands() -> None:
     commands = parse_commands("echo hello && echo world | sort", shell=ShellKind.BASH.value)
 

--- a/tests/shell/test_lexer.py
+++ b/tests/shell/test_lexer.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from synapsekit.shell import SegmentKind, ShellKind, lex_input, parse_commands
+
+
+def test_lexer_preserves_shell_and_extracts_natural_language() -> None:
+    parsed = lex_input('git push && "open the PR I just pushed"')
+
+    assert parsed.has_natural_language
+    assert parsed.segments[0].kind is SegmentKind.SHELL
+    assert parsed.segments[0].text.strip() == "git push &&"
+    assert parsed.segments[1].kind is SegmentKind.NATURAL_LANGUAGE
+    assert parsed.segments[1].text == "open the PR I just pushed"
+
+
+def test_ordinary_shell_quotes_are_not_reclassified() -> None:
+    parsed = lex_input('echo "hello world"')
+
+    assert not parsed.has_natural_language
+    assert parsed.segments[0].kind is SegmentKind.SHELL
+
+
+def test_operators_become_direct_argv_commands() -> None:
+    commands = parse_commands("echo hello && echo world | sort", shell=ShellKind.BASH.value)
+
+    assert [command.argv for command in commands] == [
+        ("echo", "hello"),
+        ("echo", "world"),
+        ("sort",),
+    ]
+    assert [command.connector for command in commands] == ["", "&&", "|"]

--- a/tests/shell/test_planner.py
+++ b/tests/shell/test_planner.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from synapsekit.shell import LLMShellPlanner, RuleBasedPlanner, ShellContext, ShellKind
+
+
+def _context() -> ShellContext:
+    return ShellContext(cwd=str(Path.cwd()), platform="test", shell=ShellKind.BASH)
+
+
+def test_rule_planner_translates_common_status_request() -> None:
+    steps = asyncio.run(RuleBasedPlanner().plan("show me git status", _context()))
+
+    assert steps[0].command == "git status --short --branch"
+    assert steps[0].source == "rule"
+
+
+def test_llm_planner_requires_strict_json() -> None:
+    class FakeLLM:
+        async def generate(self, _prompt: str, **_kwargs: object) -> str:
+            return '{"steps":[{"command":"echo hello","explanation":"say hello"}]}'
+
+    steps = asyncio.run(LLMShellPlanner(FakeLLM()).plan("say hello", _context()))
+
+    assert steps[0].command == "echo hello"
+    assert steps[0].source == "llm"

--- a/tests/shell/test_safety.py
+++ b/tests/shell/test_safety.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from synapsekit.shell import SafetyAnalyzer
+
+
+def test_destructive_commands_are_previewed() -> None:
+    assessment = SafetyAnalyzer().assess("git reset --hard HEAD")
+
+    assert assessment.destructive
+    assert "working tree" in assessment.preview
+
+
+def test_similarly_named_safe_command_is_not_rm() -> None:
+    assessment = SafetyAnalyzer().assess("rmdir --help")
+
+    assert assessment.destructive
+
+
+def test_read_only_command_is_not_destructive() -> None:
+    assessment = SafetyAnalyzer().assess("git status --short")
+
+    assert not assessment.destructive

--- a/tests/shell/test_session.py
+++ b/tests/shell/test_session.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from synapsekit.audit import Verdict, verify
+from synapsekit.shell import ShellHistory, ShellSession, generate_signing_key, load_signing_policy
+
+
+def test_safe_command_runs_without_a_signing_key(tmp_path: Path) -> None:
+    session = ShellSession(
+        cwd=tmp_path,
+        shell="bash",
+        mesh=None,
+        history=ShellHistory(tmp_path / "history.sqlite3"),
+    )
+
+    result = asyncio.run(session.run("echo hello"))
+
+    assert result.ok
+    assert result.commands[0].stdout.strip() == "hello"
+
+
+def test_destructive_command_fails_closed_when_unsigned(tmp_path: Path) -> None:
+    session = ShellSession(
+        cwd=tmp_path,
+        shell="bash",
+        mesh=None,
+        history=ShellHistory(tmp_path / "history.sqlite3"),
+    )
+
+    result = asyncio.run(session.run("git reset --hard HEAD", assume_yes=True))
+
+    assert result.aborted
+    assert result.error is not None
+    assert "--signing-key" in result.error
+
+
+def test_denied_destructive_command_writes_signed_receipt(tmp_path: Path) -> None:
+    private = tmp_path / "shell.key"
+    generate_signing_key(private)
+    policy = load_signing_policy(private)
+    session = ShellSession(
+        cwd=tmp_path,
+        shell="bash",
+        mesh=None,
+        history=ShellHistory(tmp_path / "history.sqlite3"),
+        signing_policy=policy,
+        audit_dir=tmp_path / "audit",
+    )
+
+    async def deny(_step: object, _preview: str) -> bool:
+        return False
+
+    result = asyncio.run(session.run("git reset --hard HEAD", confirm=deny))
+
+    assert result.aborted
+    assert result.audit_path is not None
+    verification = verify(
+        result.audit_path,
+        trusted_keys={policy.provider.key_id: policy.provider.public_key_bytes()},
+    )
+    assert verification.verdict is Verdict.MATCH
+
+
+def test_history_redacts_secret_shaped_values(tmp_path: Path) -> None:
+    history = ShellHistory(tmp_path / "history.sqlite3")
+
+    async def exercise() -> list[dict[str, object]]:
+        await history.record(
+            cwd=str(tmp_path),
+            input_text="echo api_key=top-secret",
+            commands=["echo api_key=top-secret"],
+            ok=True,
+        )
+        return await history.search("api_key")
+
+    rows = asyncio.run(exercise())
+
+    assert rows
+    assert "top-secret" not in str(rows[0])
+    assert "<redacted>" in str(rows[0])


### PR DESCRIPTION
## Summary

Implements the Agent OS Shell described in #750: a local-first hybrid shell that accepts ordinary shell syntax and quoted natural-language requests in the same input line.

Closes #750

## What changed

- Added `synapsekit.shell` contracts, mixed-input lexer, direct argv executor, conditional operators, bounded output, timeouts, and subprocess cleanup.
- Added deterministic offline planning plus injectable strict-JSON `LLMShellPlanner` support for local-first `BaseLLM`/`EdgeRuntime` integrations.
- Added KnowledgeMesh, optional Ambient Agent status, bounded Git context, redacted SQLite history, translation caching, and mesh-enriched completion.
- Added bash, zsh, fish, and PowerShell init/completion plugins.
- Added fail-closed destructive-operation previews. Destructive commands require confirmation and an Ed25519 signing key; signed preflight and final audit bundles include post-command Git diff metadata.
- Added `synapsekit shell`, standalone `synshell`, key generation, history, status, completion, init, JSON, dry-run, and audit options.
- Added documentation, executable example, and focused acceptance tests.

## Verification

- `16 passed` in `tests/shell`
- async-blocking gate clean (`515 files scanned`)
- Ruff check clean
- Ruff format check clean
- targeted mypy clean (`13 source files`)
- compileall and `git diff --check` clean

The branch contains three logical commits and no co-author trailers.