### PR TITLE
feat: add Dream Mode overnight self-reflection

### DIFF
--- a/docs/agent-dream-mode.md
+++ b/docs/agent-dream-mode.md
@@ -1,0 +1,51 @@
+# Dream Mode
+
+Dream Mode is an explicit, local-first overnight reflection runner. It reads
+completed `AuditTracer` records, validates their hash chains, distills durable
+corrections, proposes (but does not apply) `LivingMemory` patches, refreshes a
+`KnowledgeMesh`, flags stale memory files, and writes a signed audit bundle.
+
+Nothing starts in the background merely because the module is imported. A
+caller opts into a one-shot run or the cancellable scheduler:
+
+```python
+from synapsekit.dream import DreamConfig, DreamMode, PowerStatus
+
+dream = DreamMode(
+    config=DreamConfig(schedule="idle_30m or 02:00", budget_tokens=100_000),
+    memory_paths=["CLAUDE.md", "MEMORY.md"],
+    backend=edge_runtime,  # EdgeRuntime keeps inference local by default
+)
+dream.ingest_traces(tracer.records)
+report = await dream.run_once(
+    force=True,
+    power=PowerStatus(plugged_in=True, battery_percent=100),
+)
+print(dream.morning_briefing(report))
+dream.close()
+```
+
+The same flow is available from the CLI:
+
+```text
+synapsekit dream run --force --trace-bundle ./day.audit.zip --memory-path ./MEMORY.md --json
+synapsekit dream status
+```
+
+Safety boundaries:
+
+- Trace input is local and replay-checked; malformed or broken chains are not
+  distilled.
+- Cloud fallback remains governed by the supplied `EdgeRuntime` policy.
+- Memory output is a signed, pending `LivingMemory` patch and requires normal
+  human review before application.
+- Entity consolidation reports duplicate candidates; it never merges or
+  deletes files automatically.
+- Stale-memory pruning is a report-only operation.
+- The default scheduler fails closed when power state is unknown or the
+  machine is not plugged in.
+
+The state database and audit bundles default to `~/.synapsekit/dream/` and can
+be redirected with `DreamConfig` or the CLI flags. The default tasks are
+`distill_lessons`, `propose_memory_patches`, `consolidate_entities`, and
+`prune_stale`.

--- a/examples/agent_dream_mode.py
+++ b/examples/agent_dream_mode.py
@@ -1,0 +1,38 @@
+"""Minimal explicit Dream Mode example.
+
+Run with a configured local ``BaseLLM``/``EdgeRuntime`` in place of the
+``backend`` placeholder. No background work begins until ``run_once`` or
+``run_forever`` is called.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from synapsekit.audit import AuditTracer, EventKind
+from synapsekit.dream import DreamConfig, DreamMode, PowerStatus
+
+
+async def main() -> None:
+    tracer = AuditTracer(run_id="example-day")
+    tracer.record(EventKind.ERROR, {"message": "retrieval failed; should retry with mesh"})
+    dream = DreamMode(
+        config=DreamConfig(
+            schedule="idle_30m or 02:00",
+            state_path=Path(".synapsekit/dream/state.sqlite3"),
+            audit_dir=Path(".synapsekit/dream/audit"),
+        ),
+        memory_paths=["MEMORY.md"],
+    )
+    dream.ingest_traces(tracer.records)
+    report = await dream.run_once(
+        force=True,
+        power=PowerStatus(plugged_in=True, battery_percent=100),
+    )
+    print(dream.morning_briefing(report))
+    dream.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -169,6 +169,21 @@ from .audit import (
 )
 from .audit import PIIRedactor as AuditPIIRedactor
 from .audit import verify as verify_audit_bundle
+from .dream import (
+    DEFAULT_TASKS,
+    DreamConfig,
+    DreamMode,
+    DreamRunResult,
+    DreamSchedule,
+    DreamScheduler,
+    DreamStateStore,
+    Lesson,
+    MeshConsolidation,
+    PowerStatus,
+    StaleMemory,
+    TraceWindow,
+)
+
 from .embeddings.backend import SynapsekitEmbeddings
 from .evaluation import (
     EmailAlertSink,
@@ -691,6 +706,18 @@ __all__ = [
     "WorldModelNode",
     "WorldModelQueryResult",
     "KnowledgeMesh",
+    "DEFAULT_TASKS",
+    "DreamConfig",
+    "DreamMode",
+    "DreamRunResult",
+    "DreamSchedule",
+    "DreamScheduler",
+    "DreamStateStore",
+    "Lesson",
+    "MeshConsolidation",
+    "PowerStatus",
+    "StaleMemory",
+    "TraceWindow",
     "MeshConfig",
     "MeshDaemon",
     "MeshHit",

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -183,7 +183,6 @@ from .dream import (
     StaleMemory,
     TraceWindow,
 )
-
 from .embeddings.backend import SynapsekitEmbeddings
 from .evaluation import (
     EmailAlertSink,

--- a/src/synapsekit/cli/dream.py
+++ b/src/synapsekit/cli/dream.py
@@ -1,0 +1,79 @@
+"""CLI entry points for explicit Dream Mode runs."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+from ..dream import DreamConfig, DreamMode
+from ..mesh import KnowledgeMesh, MeshConfig
+
+
+def build_dream_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    parser = subparsers.add_parser("dream", help="Run local-first overnight self-reflection")
+    dream_sub = parser.add_subparsers(dest="dream_command")
+
+    run = dream_sub.add_parser("run", help="Run one bounded Dream Mode cycle")
+    run.add_argument("--state-path", default="~/.synapsekit/dream/state.sqlite3")
+    run.add_argument("--audit-dir", default="~/.synapsekit/dream/audit")
+    run.add_argument(
+        "--trace-bundle", action="append", default=[], help="Local signed audit bundle"
+    )
+    run.add_argument("--memory-path", action="append", default=[], help="Memory markdown file")
+    run.add_argument("--mesh-root", action="append", default=[], help="Local KnowledgeMesh root")
+    run.add_argument("--schedule", default="idle_30m or 02:00")
+    run.add_argument("--budget-tokens", type=int, default=100_000)
+    run.add_argument("--stale-after-days", type=int, default=90)
+    run.add_argument(
+        "--force", action="store_true", help="Bypass schedule; power policy remains active"
+    )
+    run.add_argument("--json", action="store_true", dest="json_output")
+
+    status = dream_sub.add_parser("status", help="Show the latest local Dream Mode briefing")
+    status.add_argument("--state-path", default="~/.synapsekit/dream/state.sqlite3")
+    status.add_argument("--json", action="store_true", dest="json_output")
+
+
+def run_dream(args: Any) -> None:
+    state_path = Path(args.state_path).expanduser()
+    if args.dream_command == "status":
+        mode = DreamMode(config=DreamConfig(state_path=state_path))
+        try:
+            result = mode.state.last_run()
+            print(
+                json.dumps(result.to_dict() if result else None, indent=2)
+                if args.json_output
+                else mode.morning_briefing(result)
+            )
+        finally:
+            mode.close()
+        return
+
+    if args.dream_command != "run":
+        raise SystemExit("choose a Dream Mode command: run or status")
+    mesh = None
+    if args.mesh_root:
+        mesh = KnowledgeMesh(MeshConfig(roots=[Path(root).expanduser() for root in args.mesh_root]))
+    mode = DreamMode(
+        config=DreamConfig(
+            schedule=args.schedule,
+            budget_tokens=args.budget_tokens,
+            stale_after_days=args.stale_after_days,
+            state_path=state_path,
+            audit_dir=args.audit_dir,
+        ),
+        memory_paths=args.memory_path,
+        mesh=mesh,
+    )
+    try:
+        result = asyncio.run(mode.run_once(force=args.force, trace_bundles=args.trace_bundle))
+        print(
+            json.dumps(result.to_dict(), indent=2)
+            if args.json_output
+            else mode.morning_briefing(result)
+        )
+    finally:
+        mode.close()

--- a/src/synapsekit/cli/main.py
+++ b/src/synapsekit/cli/main.py
@@ -178,6 +178,12 @@ def _add_shell_parser(subparsers: argparse._SubParsersAction) -> None:  # type: 
     build_shell_parser(subparsers)
 
 
+def _add_dream_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    from .dream import build_dream_parser
+
+    build_dream_parser(subparsers)
+
+
 def _add_agent_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = subparsers.add_parser("agent", help="Inspect and manage SynapseKit agents")
     agent_sub = p.add_subparsers(dest="agent_command")
@@ -328,6 +334,7 @@ def main(argv: list[str] | None = None) -> None:
     _add_edge_parser(subparsers)
     _add_mesh_parser(subparsers)
     _add_shell_parser(subparsers)
+    _add_dream_parser(subparsers)
     _add_agent_parser(subparsers)
     from .hive import build_hive_parser
 
@@ -385,6 +392,10 @@ def main(argv: list[str] | None = None) -> None:
         from .shell import run_shell
 
         run_shell(args)
+    elif args.command == "dream":
+        from .dream import run_dream
+
+        run_dream(args)
     elif args.command == "agent":
         from .agent import run_agent
 

--- a/src/synapsekit/dream/__init__.py
+++ b/src/synapsekit/dream/__init__.py
@@ -1,0 +1,35 @@
+"""Local-first overnight self-reflection for SynapseKit agents."""
+
+from .core import DreamMode, load_dream_report
+from .scheduler import DreamSchedule, DreamScheduler, SystemIdleMonitor, SystemPowerMonitor
+from .store import DreamStateStore
+from .types import (
+    DEFAULT_TASKS,
+    DreamConfig,
+    DreamRunResult,
+    DreamTask,
+    Lesson,
+    MeshConsolidation,
+    PowerStatus,
+    StaleMemory,
+    TraceWindow,
+)
+
+__all__ = [
+    "DEFAULT_TASKS",
+    "DreamConfig",
+    "DreamMode",
+    "DreamRunResult",
+    "DreamSchedule",
+    "DreamScheduler",
+    "DreamStateStore",
+    "DreamTask",
+    "Lesson",
+    "MeshConsolidation",
+    "PowerStatus",
+    "StaleMemory",
+    "SystemIdleMonitor",
+    "SystemPowerMonitor",
+    "TraceWindow",
+    "load_dream_report",
+]

--- a/src/synapsekit/dream/core.py
+++ b/src/synapsekit/dream/core.py
@@ -90,6 +90,7 @@ class DreamMode:
         self._owns_state = state_store is None
         self._stop_event = asyncio.Event()
 
+        self.memory: LivingMemory | None
         if memory is not None:
             self.memory = memory
         elif self.memory_paths:

--- a/src/synapsekit/dream/core.py
+++ b/src/synapsekit/dream/core.py
@@ -1,0 +1,424 @@
+"""Dream Mode orchestration: replay, distill, propose, consolidate, report."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from collections import defaultdict
+from collections.abc import Iterable, Sequence
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, cast
+
+from ..audit import (
+    AuditRecord,
+    AuditTracer,
+    EventKind,
+    PIIRedactor,
+    ReplayEngine,
+    SigningPolicy,
+    export_audit_bundle,
+    load_bundle,
+)
+from ..memory import LivingMemory
+from ..mesh import KnowledgeMesh
+from .distill import (
+    DeterministicLessonDistiller,
+    LessonBackend,
+    ModelLessonDistiller,
+    estimate_tokens,
+    trace_transcript,
+)
+from .scheduler import (
+    DreamSchedule,
+    DreamScheduler,
+    IdleMonitor,
+    PowerMonitor,
+    SystemIdleMonitor,
+    SystemPowerMonitor,
+    wait_for_stop,
+)
+from .store import DreamStateStore
+from .types import (
+    DreamConfig,
+    DreamRunResult,
+    Lesson,
+    MeshConsolidation,
+    PowerStatus,
+    StaleMemory,
+    TraceWindow,
+)
+
+
+class DreamMode:
+    """Run bounded, local-first overnight reflection.
+
+    Dream Mode is opt-in: constructing this class never starts a background
+    task, changes memory files, or contacts a cloud provider. ``run_once``
+    must be called explicitly, and LivingMemory keeps every generated patch in
+    its normal pending-for-review state.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: DreamConfig | None = None,
+        backend: LessonBackend | None = None,
+        memory: LivingMemory | None = None,
+        memory_paths: Sequence[str | Path] = (),
+        mesh: KnowledgeMesh | None = None,
+        state_store: DreamStateStore | None = None,
+        power_monitor: PowerMonitor | None = None,
+        idle_monitor: IdleMonitor | None = None,
+        signing_policy: SigningPolicy | None = None,
+    ) -> None:
+        self.config = config or DreamConfig()
+        self.backend = backend
+        self.memory_paths = tuple(str(Path(path).expanduser()) for path in memory_paths)
+        self.mesh = mesh
+        self.state = state_store or DreamStateStore(self.config.state_path)
+        self.power_monitor = power_monitor or SystemPowerMonitor()
+        self.idle_monitor = idle_monitor or SystemIdleMonitor()
+        self.signing_policy = signing_policy or SigningPolicy.ed25519()
+        self.scheduler = DreamScheduler(
+            DreamSchedule.parse(
+                self.config.schedule,
+                default_idle_seconds=self.config.idle_after_seconds,
+            )
+        )
+        self._owns_state = state_store is None
+        self._stop_event = asyncio.Event()
+
+        if memory is not None:
+            self.memory = memory
+        elif self.memory_paths:
+            self.memory = LivingMemory(
+                list(self.memory_paths),
+                proposer=backend,
+                require_approval=True,
+                occurrence_threshold=1,
+                store_path=str(
+                    Path(self.config.state_path).expanduser().with_name("memory_patches.jsonl")
+                ),
+                occurrence_path=str(
+                    Path(self.config.state_path).expanduser().with_name("memory_occurrences.json")
+                ),
+            )
+        else:
+            self.memory = None
+
+    def close(self) -> None:
+        """Close the local state database when the caller owns it."""
+
+        if self._owns_state:
+            self.state.close()
+
+    def stop(self) -> None:
+        """Request that a running scheduler stop after its current iteration."""
+
+        self._stop_event.set()
+
+    def ingest_traces(self, records: Iterable[AuditRecord]) -> int:
+        """Persist completed local audit traces for a future dream run."""
+
+        records_list = list(records)
+        inserted = self.state.append_traces(records_list)
+        self.state.update_memory_reads(records_list)
+        return inserted
+
+    async def run_once(
+        self,
+        *,
+        now: datetime | None = None,
+        force: bool = False,
+        idle_seconds: float | None = None,
+        power: PowerStatus | None = None,
+        trace_bundles: Sequence[str | Path] = (),
+    ) -> DreamRunResult:
+        """Run one bounded reflection cycle."""
+
+        started = now or datetime.now(UTC)
+        if started.tzinfo is None:
+            raise ValueError("now must be timezone-aware")
+        if power is None:
+            power = await asyncio.to_thread(self.power_monitor.status)
+        if self.config.require_plugged_in and (not power.known or not power.plugged_in):
+            return DreamRunResult.skipped(
+                "Dream Mode requires a known plugged-in power source", now=started
+            )
+        if not force:
+            observed_idle = idle_seconds
+            if observed_idle is None:
+                observed_idle = await asyncio.to_thread(self.idle_monitor.idle_seconds)
+            due, reason = self.scheduler.should_run(
+                started,
+                idle_seconds=observed_idle,
+                power=power,
+                require_plugged_in=self.config.require_plugged_in,
+            )
+            if not due:
+                return DreamRunResult.skipped(reason, now=started)
+
+        run_id = uuid.uuid4().hex
+        tracer = AuditTracer(run_id=run_id, redactor=PIIRedactor())
+        window = TraceWindow(
+            start=started - timedelta(hours=self.config.lookback_hours),
+            end=started,
+        )
+        result = DreamRunResult(
+            run_id=run_id,
+            status="completed",
+            started_at=started.isoformat(),
+            completed_at=started.isoformat(),
+        )
+        tracer.record(
+            EventKind.SYSTEM_EVENT,
+            {
+                "stage": "dream_started",
+                "window_start": window.start.isoformat(),
+                "window_end": window.end.isoformat(),
+                "tasks": list(self.config.tasks),
+                "budget_tokens": self.config.budget_tokens,
+            },
+            actor="dream-mode",
+        )
+        try:
+            records = await self._collect_records(window, trace_bundles)
+            result.traces_replayed = len(records)
+            result.estimated_tokens = estimate_tokens(
+                trace_transcript(
+                    records,
+                    max_chars=self.config.max_trace_chars,
+                )
+            )
+            tracer.record(
+                EventKind.RETRIEVAL,
+                {
+                    "stage": "trace_replay",
+                    "record_count": len(records),
+                    "run_ids": sorted({record.run_id for record in records}),
+                },
+                actor="dream-mode",
+            )
+            if "distill_lessons" in self.config.tasks:
+                result.lessons = await self._distill(records)
+                tracer.record(
+                    EventKind.DECISION,
+                    {"stage": "lesson_distillation", "lesson_count": len(result.lessons)},
+                    actor="dream-mode",
+                )
+            if "propose_memory_patches" in self.config.tasks:
+                result.patch_ids = await self._propose_patches(result.lessons, records, run_id)
+                tracer.record(
+                    EventKind.MEMORY_WRITE,
+                    {
+                        "stage": "patch_proposals",
+                        "patch_ids": result.patch_ids,
+                        "approval_required": True,
+                    },
+                    actor="dream-mode",
+                )
+            if "consolidate_entities" in self.config.tasks and self.mesh is not None:
+                result.mesh_reindexed, result.mesh_consolidations = await self._consolidate_mesh()
+                tracer.record(
+                    EventKind.STATE_CHANGE,
+                    {
+                        "stage": "mesh_consolidation",
+                        "candidate_count": len(result.mesh_consolidations),
+                    },
+                    actor="dream-mode",
+                )
+            if "prune_stale" in self.config.tasks:
+                result.stale_memories = await self._find_stale_memories(started)
+                tracer.record(
+                    EventKind.MEMORY_READ,
+                    {"stage": "stale_memory_scan", "candidate_count": len(result.stale_memories)},
+                    actor="dream-mode",
+                )
+        except Exception as exc:
+            result.status = "failed"
+            result.warnings.append(f"Dream Mode failed: {type(exc).__name__}: {exc}")
+            tracer.record(
+                EventKind.ERROR,
+                {"stage": "dream_failed", "error": f"{type(exc).__name__}: {exc}"},
+                actor="dream-mode",
+            )
+
+        result.completed_at = datetime.now(UTC).isoformat()
+        tracer.record(
+            EventKind.SYSTEM_EVENT,
+            {
+                "stage": "dream_completed",
+                "status": result.status,
+                "traces_replayed": result.traces_replayed,
+            },
+            actor="dream-mode",
+        )
+        result.audit_path = await self._export_audit(tracer, run_id)
+        await asyncio.to_thread(self.state.save_run, result)
+        return result
+
+    async def run_forever(self) -> None:
+        """Poll the schedule until :meth:`stop` is called or cancelled."""
+
+        self._stop_event.clear()
+        while not self._stop_event.is_set():
+            now = datetime.now(UTC)
+            power = await asyncio.to_thread(self.power_monitor.status)
+            idle = await asyncio.to_thread(self.idle_monitor.idle_seconds)
+            due, _ = self.scheduler.should_run(
+                now,
+                idle_seconds=idle,
+                power=power,
+                require_plugged_in=self.config.require_plugged_in,
+            )
+            if due:
+                await self.run_once(now=now, force=True, idle_seconds=idle, power=power)
+            await wait_for_stop(self._stop_event, self.config.poll_seconds)
+
+    def morning_briefing(self, result: DreamRunResult | None = None) -> str:
+        """Render a concise, actionable terminal briefing."""
+
+        report = result or self.state.last_run()
+        if report is None:
+            return "Dream Mode: no run has completed."
+        if report.status == "skipped":
+            return f"Dream Mode skipped: {report.skipped_reason or 'not eligible'}."
+        lines = [
+            f"Dream Mode {report.status} ({report.completed_at})",
+            f"  traces replayed: {report.traces_replayed}",
+            f"  lessons distilled: {len(report.lessons)}",
+            f"  memory patches proposed: {len(report.patch_ids)} (human review required)",
+            f"  mesh reindexed: {'yes' if report.mesh_reindexed else 'no'}",
+            f"  entity candidates: {len(report.mesh_consolidations)}",
+            f"  stale memories flagged: {len(report.stale_memories)}",
+        ]
+        if report.audit_path:
+            lines.append(f"  signed audit: {report.audit_path}")
+        lines.extend(f"  warning: {warning}" for warning in report.warnings)
+        return "\n".join(lines)
+
+    async def _collect_records(
+        self,
+        window: TraceWindow,
+        trace_bundles: Sequence[str | Path],
+    ) -> list[AuditRecord]:
+        records = await asyncio.to_thread(self.state.records, window)
+        bundle_records: list[AuditRecord] = []
+        for bundle_path in trace_bundles:
+            loaded = await asyncio.to_thread(load_bundle, bundle_path)
+            replay = await asyncio.to_thread(ReplayEngine().replay, bundle_path)
+            if not replay.ok:
+                raise ValueError(f"trace bundle failed replay validation: {bundle_path}")
+            if any(
+                window.start <= record.timestamp.astimezone(UTC) <= window.end
+                for record in loaded.records
+            ):
+                bundle_records.extend(loaded.records)
+        if bundle_records:
+            await asyncio.to_thread(self.state.append_traces, bundle_records)
+            await asyncio.to_thread(self.state.update_memory_reads, bundle_records)
+            records.extend(bundle_records)
+        unique = {record.event_id: record for record in records}
+        return self._valid_trace_groups(list(unique.values()))
+
+    @staticmethod
+    def _valid_trace_groups(records: list[AuditRecord]) -> list[AuditRecord]:
+        grouped: dict[str, list[AuditRecord]] = defaultdict(list)
+        for record in records:
+            grouped[record.run_id].append(record)
+        valid: list[AuditRecord] = []
+        for group in grouped.values():
+            try:
+                AuditTracer.verify_chain(group)
+            except Exception:
+                continue
+            valid.extend(group)
+        return sorted(valid, key=lambda record: (record.timestamp, record.event_id))
+
+    async def _distill(self, records: list[AuditRecord]) -> list[Lesson]:
+        bounded = trace_transcript(
+            records,
+            max_chars=self.config.max_trace_chars,
+        )
+        if estimate_tokens(bounded) > self.config.budget_tokens:
+            return await asyncio.to_thread(DeterministicLessonDistiller().distill, records)
+        if self.backend is not None:
+            distiller = ModelLessonDistiller(self.backend)
+            lessons, consumed = await distiller.distill(
+                records,
+                max_chars=self.config.max_trace_chars,
+            )
+            if consumed > self.config.budget_tokens:
+                return await asyncio.to_thread(DeterministicLessonDistiller().distill, records)
+            return lessons
+        return await asyncio.to_thread(DeterministicLessonDistiller().distill, records)
+
+    async def _propose_patches(
+        self,
+        lessons: list[Lesson],
+        records: list[AuditRecord],
+        run_id: str,
+    ) -> list[str]:
+        if self.memory is None or not lessons:
+            return []
+        evidence = trace_transcript(
+            records, max_chars=min(self.config.max_trace_chars // 2, self.config.budget_tokens * 2)
+        )
+        lesson_text = "\n".join(
+            f"- {lesson.text} (theme={lesson.theme}, confidence={lesson.confidence:.2f}, "
+            f"evidence={','.join(lesson.evidence_event_ids)})"
+            for lesson in lessons
+        )
+        transcript = f"Dream Mode lessons:\n{lesson_text}\n\nTrace evidence:\n{evidence}"
+        patches = await self.memory.propose_from_session(run_id, transcript=transcript)
+        return [patch.patch_id for patch in patches]
+
+    async def _consolidate_mesh(self) -> tuple[bool, list[MeshConsolidation]]:
+        if self.mesh is None:
+            return False, []
+        await self.mesh.reindex()
+        matches = await asyncio.to_thread(self.mesh.duplicates, limit=20)
+        candidates: list[MeshConsolidation] = []
+        for match in matches:
+            left = str(getattr(match, "left_path", getattr(match, "path_a", "")))
+            right = str(getattr(match, "right_path", getattr(match, "path_b", "")))
+            score = float(getattr(match, "score", 0.0))
+            if left and right:
+                candidates.append(
+                    MeshConsolidation(
+                        left_path=left,
+                        right_path=right,
+                        score=score,
+                        reason="KnowledgeMesh duplicate candidate; no automatic merge performed",
+                    )
+                )
+        return True, candidates
+
+    async def _find_stale_memories(self, now: datetime) -> list[StaleMemory]:
+        paths = self.memory_paths
+        if self.memory is not None and not paths:
+            paths = tuple(self.memory.managed_paths)
+        return await asyncio.to_thread(
+            self.state.stale_memories,
+            paths,
+            now=now,
+            stale_after_days=self.config.stale_after_days,
+        )
+
+    async def _export_audit(self, tracer: AuditTracer, run_id: str) -> str | None:
+        output = Path(self.config.audit_dir).expanduser() / f"{run_id}.audit.zip"
+        await asyncio.to_thread(
+            export_audit_bundle,
+            list(tracer.records),
+            self.signing_policy,
+            output,
+        )
+        return str(output)
+
+
+def load_dream_report(path: str | Path) -> dict[str, Any]:
+    """Load a JSON report written by a caller from a local path."""
+
+    return cast(dict[str, Any], json.loads(Path(path).expanduser().read_text(encoding="utf-8")))

--- a/src/synapsekit/dream/distill.py
+++ b/src/synapsekit/dream/distill.py
@@ -1,0 +1,183 @@
+"""Bounded, local-first lesson distillation for Dream Mode."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict
+from collections.abc import Iterable
+from typing import Any, Protocol
+
+from ..audit import AuditRecord, EventKind
+from .types import Lesson
+
+_SIGNAL_RE = re.compile(r"(?i)\b(correct|correction|wrong|failed|failure|fix|should|retry|error)\b")
+
+
+class LessonBackend(Protocol):
+    """Minimal async generation contract accepted by Dream Mode."""
+
+    async def generate(self, prompt: str, **kwargs: Any) -> str: ...
+
+
+def estimate_tokens(text: str) -> int:
+    """Use a conservative, dependency-free token estimate."""
+
+    compact = " ".join(text.split())
+    return max(0, (len(compact) + 3) // 4)
+
+
+def trace_transcript(records: Iterable[AuditRecord], *, max_chars: int) -> str:
+    """Serialize trace evidence without including full arbitrary objects."""
+
+    lines: list[str] = []
+    used = 0
+    for record in records:
+        payload = json.dumps(record.payload, sort_keys=True, default=str)
+        line = f"[{record.timestamp.isoformat()}] {record.kind} {record.event_id}: {payload}"
+        remaining = max_chars - used
+        if remaining <= 0:
+            break
+        lines.append(line[:remaining])
+        used += min(len(line), remaining) + 1
+    return "\n".join(lines)
+
+
+class DeterministicLessonDistiller:
+    """Extract repeatable lessons when no model is configured.
+
+    It intentionally surfaces only error/correction-shaped evidence.  This
+    keeps the offline fallback useful while avoiding speculative memory writes.
+    """
+
+    def distill(self, records: list[AuditRecord], *, max_lessons: int = 20) -> list[Lesson]:
+        groups: dict[str, list[tuple[AuditRecord, str]]] = defaultdict(list)
+        for record in records:
+            text = self._signal_text(record)
+            if not text or not _SIGNAL_RE.search(text):
+                continue
+            key = self._normalise(text)
+            groups[key].append((record, text))
+
+        lessons: list[Lesson] = []
+        for key, evidence in sorted(groups.items(), key=lambda item: (-len(item[1]), item[0])):
+            records_for_lesson = [record for record, _ in evidence]
+            examples = tuple(text[:300] for _, text in evidence[:3])
+            confidence = min(0.98, 0.55 + 0.12 * min(len(evidence), 3))
+            lessons.append(
+                Lesson(
+                    text=f"Review and retain this recurring correction: {examples[0]}",
+                    theme=key,
+                    confidence=confidence,
+                    evidence_event_ids=tuple(record.event_id for record in records_for_lesson[:8]),
+                    corrections=examples,
+                )
+            )
+            if len(lessons) >= max_lessons:
+                break
+        return lessons
+
+    @staticmethod
+    def _signal_text(record: AuditRecord) -> str:
+        payload = record.payload
+        candidates = [
+            payload.get("error"),
+            payload.get("message"),
+            payload.get("output"),
+            payload.get("reason"),
+            payload.get("content"),
+        ]
+        for candidate in candidates:
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate.strip()
+            if isinstance(candidate, dict):
+                nested = candidate.get("error") or candidate.get("message")
+                if isinstance(nested, str) and nested.strip():
+                    return nested.strip()
+        if record.kind == EventKind.ERROR.value:
+            return json.dumps(payload, sort_keys=True, default=str)
+        return ""
+
+    @staticmethod
+    def _normalise(text: str) -> str:
+        return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9 ]", " ", text.lower())).strip()[:120]
+
+
+class ModelLessonDistiller:
+    """Ask an injected local-first backend for structured lessons.
+
+    A malformed or empty response never blocks a run: deterministic evidence
+    extraction remains the safety fallback.
+    """
+
+    def __init__(
+        self, backend: LessonBackend, fallback: DeterministicLessonDistiller | None = None
+    ):
+        self.backend = backend
+        self.fallback = fallback or DeterministicLessonDistiller()
+
+    async def distill(
+        self,
+        records: list[AuditRecord],
+        *,
+        max_chars: int,
+        max_lessons: int = 20,
+    ) -> tuple[list[Lesson], int]:
+        transcript = trace_transcript(records, max_chars=max_chars)
+        if not transcript:
+            return [], 0
+        prompt = (
+            "You are Dream Mode's offline memory consolidator. Analyze the trace below and "
+            "return only a JSON array. Each item must contain text, theme, confidence "
+            "(0..1), evidence_event_ids, and corrections. Surface durable corrections and "
+            "repeated failures; omit guesses and one-off noise.\n\nTRACE:\n" + transcript
+        )
+        try:
+            raw = await self.backend.generate(prompt, max_tokens=max_lessons * 120)
+            lessons = self._parse(raw, max_lessons=max_lessons)
+        except Exception:
+            lessons = []
+        if not lessons:
+            lessons = self.fallback.distill(records, max_lessons=max_lessons)
+        return lessons, estimate_tokens(prompt)
+
+    @staticmethod
+    def _parse(raw: str, *, max_lessons: int) -> list[Lesson]:
+        cleaned = str(raw).strip()
+        if cleaned.startswith("```"):
+            cleaned = cleaned.strip("`").removeprefix("json").strip()
+        try:
+            parsed = json.loads(cleaned)
+        except json.JSONDecodeError:
+            start, end = cleaned.find("["), cleaned.rfind("]")
+            if start < 0 or end <= start:
+                return []
+            try:
+                parsed = json.loads(cleaned[start : end + 1])
+            except json.JSONDecodeError:
+                return []
+        if not isinstance(parsed, list):
+            return []
+        lessons: list[Lesson] = []
+        for item in parsed:
+            if not isinstance(item, dict) or not str(item.get("text", "")).strip():
+                continue
+            try:
+                lessons.append(
+                    Lesson(
+                        text=str(item["text"]).strip()[:1000],
+                        theme=str(item.get("theme", "general")).strip()[:120] or "general",
+                        confidence=max(0.0, min(1.0, float(item.get("confidence", 0.5)))),
+                        evidence_event_ids=tuple(
+                            str(value) for value in item.get("evidence_event_ids", [])
+                        )[:8],
+                        corrections=tuple(
+                            str(value)[:300] for value in item.get("corrections", [])
+                        )[:5],
+                    )
+                )
+            except (TypeError, ValueError):
+                continue
+            if len(lessons) >= max_lessons:
+                break
+        return lessons

--- a/src/synapsekit/dream/scheduler.py
+++ b/src/synapsekit/dream/scheduler.py
@@ -13,7 +13,7 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime, time
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import Protocol
 
 from .types import PowerStatus
 
@@ -116,6 +116,10 @@ class SystemPowerMonitor:
 
     @staticmethod
     def _windows_status() -> PowerStatus:
+        windll = getattr(ctypes, "windll", None)
+        if windll is None:
+            return PowerStatus(plugged_in=False, known=False)
+
         class _SystemPowerStatus(ctypes.Structure):
             _fields_ = [
                 ("ACLineStatus", ctypes.c_ubyte),
@@ -128,7 +132,7 @@ class SystemPowerMonitor:
 
         value = _SystemPowerStatus()
         try:
-            ok = cast(Any, ctypes.windll).kernel32.GetSystemPowerStatus(ctypes.byref(value))
+            ok = windll.kernel32.GetSystemPowerStatus(ctypes.byref(value))
         except (AttributeError, OSError):
             return PowerStatus(plugged_in=False, known=False)
         if not ok or value.ACLineStatus == 255:
@@ -165,14 +169,18 @@ class SystemIdleMonitor:
         if sys.platform != "win32":
             return 0.0
 
+        windll = getattr(ctypes, "windll", None)
+        if windll is None:
+            return 0.0
+
         class _LastInputInfo(ctypes.Structure):
             _fields_ = [("cbSize", ctypes.c_uint), ("dwTime", ctypes.c_uint)]
 
         info = _LastInputInfo(ctypes.sizeof(_LastInputInfo), 0)
         try:
-            if not cast(Any, ctypes.windll).user32.GetLastInputInfo(ctypes.byref(info)):
+            if not windll.user32.GetLastInputInfo(ctypes.byref(info)):
                 return 0.0
-            tick = cast(Any, ctypes.windll).kernel32.GetTickCount()
+            tick = windll.kernel32.GetTickCount()
         except (AttributeError, OSError):
             return 0.0
         elapsed_ms = (int(tick) - int(info.dwTime)) & 0xFFFFFFFF

--- a/src/synapsekit/dream/scheduler.py
+++ b/src/synapsekit/dream/scheduler.py
@@ -1,0 +1,214 @@
+"""Schedule, idle, and power gates for Dream Mode.
+
+The scheduler is deliberately small and injectable.  The default monitors use
+only the standard library, while tests and desktop integrations can provide
+their own power and idle readings without mocking operating-system calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ctypes
+import sys
+from dataclasses import dataclass
+from datetime import datetime, time
+from pathlib import Path
+from typing import Protocol
+
+from .types import PowerStatus
+
+
+class PowerMonitor(Protocol):
+    """Provider for the current power state."""
+
+    def status(self) -> PowerStatus: ...
+
+
+class IdleMonitor(Protocol):
+    """Provider for seconds since the last user input."""
+
+    def idle_seconds(self) -> float: ...
+
+
+@dataclass(frozen=True)
+class DreamSchedule:
+    """Parsed ``idle_30m or 02:00`` schedule expression."""
+
+    idle_after_seconds: float | None = None
+    clock_times: tuple[time, ...] = ()
+
+    @classmethod
+    def parse(cls, expression: str, *, default_idle_seconds: float = 1800.0) -> DreamSchedule:
+        if not expression.strip():
+            raise ValueError("Dream Mode schedule must not be empty")
+        idle_after: float | None = None
+        clocks: list[time] = []
+        for raw_part in expression.split(" or "):
+            part = raw_part.strip().lower()
+            if part == "idle":
+                idle_after = default_idle_seconds
+                continue
+            if part.startswith("idle_") and part.endswith("m"):
+                try:
+                    minutes = float(part[5:-1])
+                except ValueError as exc:
+                    raise ValueError(f"invalid idle schedule component: {raw_part!r}") from exc
+                if minutes < 0:
+                    raise ValueError("idle duration cannot be negative")
+                idle_after = minutes * 60
+                continue
+            if part.startswith("idle_") and part.endswith("s"):
+                try:
+                    seconds = float(part[5:-1])
+                except ValueError as exc:
+                    raise ValueError(f"invalid idle schedule component: {raw_part!r}") from exc
+                if seconds < 0:
+                    raise ValueError("idle duration cannot be negative")
+                idle_after = seconds
+                continue
+            try:
+                hour, minute = (int(value) for value in part.split(":", 1))
+                clocks.append(time(hour=hour, minute=minute))
+            except (ValueError, TypeError) as exc:
+                raise ValueError(
+                    f"invalid Dream Mode schedule component {raw_part!r}; expected idle_30m or HH:MM"
+                ) from exc
+        if idle_after is None and not clocks:
+            raise ValueError("Dream Mode schedule contains no usable trigger")
+        return cls(idle_after_seconds=idle_after, clock_times=tuple(clocks))
+
+    def due(self, now: datetime, *, idle_seconds: float) -> bool:
+        """Return whether a trigger is active at ``now``."""
+
+        local_now = now.astimezone()
+        idle_due = self.idle_after_seconds is not None and idle_seconds >= self.idle_after_seconds
+        clock_due = any(
+            local_now.hour == clock.hour and local_now.minute == clock.minute
+            for clock in self.clock_times
+        )
+        return idle_due or clock_due
+
+    def trigger_key(self, now: datetime, *, idle_seconds: float) -> str | None:
+        """Return a stable per-day key so a poll loop runs once per trigger."""
+
+        local_now = now.astimezone()
+        if self.clock_times and any(
+            local_now.hour == clock.hour and local_now.minute == clock.minute
+            for clock in self.clock_times
+        ):
+            return (
+                f"clock:{local_now.date().isoformat()}:{local_now.hour:02d}:{local_now.minute:02d}"
+            )
+        if self.idle_after_seconds is not None and idle_seconds >= self.idle_after_seconds:
+            return f"idle:{local_now.date().isoformat()}"
+        return None
+
+
+class SystemPowerMonitor:
+    """Best-effort standard-library power monitor for Windows and Linux."""
+
+    def status(self) -> PowerStatus:
+        if sys.platform == "win32":
+            return self._windows_status()
+        if sys.platform.startswith("linux"):
+            return self._linux_status()
+        return PowerStatus(plugged_in=False, known=False)
+
+    @staticmethod
+    def _windows_status() -> PowerStatus:
+        class _SystemPowerStatus(ctypes.Structure):
+            _fields_ = [
+                ("ACLineStatus", ctypes.c_ubyte),
+                ("BatteryFlag", ctypes.c_ubyte),
+                ("BatteryLifePercent", ctypes.c_ubyte),
+                ("Reserved", ctypes.c_ubyte),
+                ("BatteryLifeTime", ctypes.c_ulong),
+                ("BatteryFullLifeTime", ctypes.c_ulong),
+            ]
+
+        value = _SystemPowerStatus()
+        try:
+            ok = ctypes.windll.kernel32.GetSystemPowerStatus(ctypes.byref(value))
+        except (AttributeError, OSError):
+            return PowerStatus(plugged_in=False, known=False)
+        if not ok or value.ACLineStatus == 255:
+            return PowerStatus(plugged_in=False, known=False)
+        percent = None if value.BatteryLifePercent == 255 else int(value.BatteryLifePercent)
+        return PowerStatus(plugged_in=value.ACLineStatus == 1, battery_percent=percent)
+
+    @staticmethod
+    def _linux_status() -> PowerStatus:
+        power_root = Path("/sys/class/power_supply")
+        try:
+            online_values = [
+                (entry / "online").read_text(encoding="ascii").strip()
+                for entry in power_root.glob("AC*/online")
+            ]
+            capacity_values = [
+                int((entry / "capacity").read_text(encoding="ascii").strip())
+                for entry in power_root.glob("BAT*/capacity")
+            ]
+        except (OSError, ValueError):
+            return PowerStatus(plugged_in=False, known=False)
+        if not online_values:
+            return PowerStatus(plugged_in=False, known=False)
+        return PowerStatus(
+            plugged_in=any(value == "1" for value in online_values),
+            battery_percent=capacity_values[0] if capacity_values else None,
+        )
+
+
+class SystemIdleMonitor:
+    """Return system idle seconds where the platform exposes that signal."""
+
+    def idle_seconds(self) -> float:
+        if sys.platform != "win32":
+            return 0.0
+
+        class _LastInputInfo(ctypes.Structure):
+            _fields_ = [("cbSize", ctypes.c_uint), ("dwTime", ctypes.c_uint)]
+
+        info = _LastInputInfo(ctypes.sizeof(_LastInputInfo), 0)
+        try:
+            if not ctypes.windll.user32.GetLastInputInfo(ctypes.byref(info)):
+                return 0.0
+            tick = ctypes.windll.kernel32.GetTickCount()
+        except (AttributeError, OSError):
+            return 0.0
+        elapsed_ms = (int(tick) - int(info.dwTime)) & 0xFFFFFFFF
+        return elapsed_ms / 1000.0
+
+
+@dataclass
+class DreamScheduler:
+    """Stateful trigger gate used by ``DreamMode.run_forever``."""
+
+    schedule: DreamSchedule
+    last_trigger_key: str | None = None
+
+    def should_run(
+        self,
+        now: datetime,
+        *,
+        idle_seconds: float,
+        power: PowerStatus,
+        require_plugged_in: bool,
+    ) -> tuple[bool, str]:
+        if require_plugged_in and (not power.known or not power.plugged_in):
+            return False, "Dream Mode requires a known plugged-in power source"
+        key = self.schedule.trigger_key(now, idle_seconds=idle_seconds)
+        if key is None or not self.schedule.due(now, idle_seconds=idle_seconds):
+            return False, "schedule is not due"
+        if key == self.last_trigger_key:
+            return False, "schedule trigger already consumed"
+        self.last_trigger_key = key
+        return True, key
+
+
+async def wait_for_stop(stop_event: asyncio.Event, seconds: float) -> None:
+    """Sleep while remaining cancellable for scheduler shutdown."""
+
+    try:
+        await asyncio.wait_for(stop_event.wait(), timeout=seconds)
+    except TimeoutError:
+        return

--- a/src/synapsekit/dream/scheduler.py
+++ b/src/synapsekit/dream/scheduler.py
@@ -13,7 +13,7 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime, time
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol, cast
 
 from .types import PowerStatus
 
@@ -128,7 +128,7 @@ class SystemPowerMonitor:
 
         value = _SystemPowerStatus()
         try:
-            ok = ctypes.windll.kernel32.GetSystemPowerStatus(ctypes.byref(value))
+            ok = cast(Any, ctypes.windll).kernel32.GetSystemPowerStatus(ctypes.byref(value))
         except (AttributeError, OSError):
             return PowerStatus(plugged_in=False, known=False)
         if not ok or value.ACLineStatus == 255:
@@ -170,9 +170,9 @@ class SystemIdleMonitor:
 
         info = _LastInputInfo(ctypes.sizeof(_LastInputInfo), 0)
         try:
-            if not ctypes.windll.user32.GetLastInputInfo(ctypes.byref(info)):
+            if not cast(Any, ctypes.windll).user32.GetLastInputInfo(ctypes.byref(info)):
                 return 0.0
-            tick = ctypes.windll.kernel32.GetTickCount()
+            tick = cast(Any, ctypes.windll).kernel32.GetTickCount()
         except (AttributeError, OSError):
             return 0.0
         elapsed_ms = (int(tick) - int(info.dwTime)) & 0xFFFFFFFF

--- a/src/synapsekit/dream/store.py
+++ b/src/synapsekit/dream/store.py
@@ -1,0 +1,200 @@
+"""Local-only trace and Dream Mode state storage."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from pathlib import Path
+
+from ..audit import AuditRecord, EventKind
+from .types import DreamRunResult, Lesson, MeshConsolidation, StaleMemory, TraceWindow
+
+
+class DreamStateStore:
+    """SQLite journal for traces, memory reads, and completed dream reports.
+
+    The store is intentionally independent from the memory patch store and the
+    mesh index.  Dream Mode can therefore be enabled or removed without
+    changing either product's persistence format.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path).expanduser()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(self.path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._ensure_schema()
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def append_traces(self, records: Iterable[AuditRecord]) -> int:
+        """Persist trace records idempotently and return newly stored count."""
+
+        rows = [
+            (
+                record.event_id,
+                record.run_id,
+                record.timestamp.astimezone(UTC).isoformat(),
+                json.dumps(record.to_dict(), sort_keys=True),
+            )
+            for record in records
+        ]
+        if not rows:
+            return 0
+        with self._lock, self._conn:
+            before = self._conn.total_changes
+            self._conn.executemany(
+                """
+                INSERT OR IGNORE INTO traces(event_id, run_id, timestamp, record_json)
+                VALUES (?, ?, ?, ?)
+                """,
+                rows,
+            )
+            inserted = self._conn.total_changes - before
+        return int(inserted)
+
+    def records(self, window: TraceWindow) -> list[AuditRecord]:
+        """Return local traces in timestamp order for ``window``."""
+
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT record_json FROM traces
+                WHERE run_id IN (SELECT run_id FROM traces WHERE timestamp >= ? AND timestamp <= ?)
+                ORDER BY timestamp, event_id
+                """,
+                (window.start.astimezone(UTC).isoformat(), window.end.astimezone(UTC).isoformat()),
+            ).fetchall()
+        return [AuditRecord.from_dict(json.loads(str(row["record_json"]))) for row in rows]
+
+    def update_memory_reads(self, records: Iterable[AuditRecord]) -> int:
+        """Record ``MEMORY_READ`` paths found in imported traces."""
+
+        values: list[tuple[str, str]] = []
+        for record in records:
+            if record.kind != EventKind.MEMORY_READ.value:
+                continue
+            path = record.payload.get("path")
+            if isinstance(path, str) and path.strip():
+                values.append((path, record.timestamp.astimezone(UTC).isoformat()))
+        if not values:
+            return 0
+        with self._lock, self._conn:
+            self._conn.executemany(
+                """
+                INSERT INTO memory_reads(path, last_read_at) VALUES (?, ?)
+                ON CONFLICT(path) DO UPDATE SET
+                    last_read_at = CASE
+                        WHEN excluded.last_read_at > memory_reads.last_read_at
+                        THEN excluded.last_read_at
+                        ELSE memory_reads.last_read_at
+                    END
+                """,
+                values,
+            )
+        return len(values)
+
+    def stale_memories(
+        self,
+        paths: Iterable[str | Path],
+        *,
+        now: datetime,
+        stale_after_days: int,
+    ) -> list[StaleMemory]:
+        """Return old memory files without deleting or mutating them."""
+
+        cutoff = now.astimezone(UTC).timestamp() - stale_after_days * 86400
+        path_list = [Path(path).expanduser() for path in paths]
+        if not path_list:
+            return []
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT path, last_read_at FROM memory_reads WHERE path IN ({})".format(
+                    ",".join("?" for _ in path_list)
+                ),
+                [str(path) for path in path_list],
+            ).fetchall()
+        last_reads = {str(row["path"]): str(row["last_read_at"]) for row in rows}
+        stale: list[StaleMemory] = []
+        for path in path_list:
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            modified = datetime.fromtimestamp(stat.st_mtime, UTC)
+            read_text = last_reads.get(str(path))
+            try:
+                read_at = datetime.fromisoformat(read_text) if read_text else None
+            except ValueError:
+                read_at = None
+            reference = max(modified, read_at or datetime.fromtimestamp(0, UTC))
+            if reference.timestamp() >= cutoff:
+                continue
+            age_days = max(0, int((now.astimezone(UTC) - reference).total_seconds() // 86400))
+            stale.append(
+                StaleMemory(
+                    path=str(path),
+                    last_read_at=read_text,
+                    last_modified_at=modified.isoformat(),
+                    age_days=age_days,
+                    reason="not read or modified within the configured retention window",
+                )
+            )
+        return sorted(stale, key=lambda item: (-item.age_days, item.path))
+
+    def save_run(self, result: DreamRunResult) -> None:
+        payload = json.dumps(result.to_dict(), sort_keys=True)
+        with self._lock, self._conn:
+            self._conn.execute(
+                """
+                INSERT OR REPLACE INTO dream_runs(run_id, started_at, status, report_json)
+                VALUES (?, ?, ?, ?)
+                """,
+                (result.run_id, result.started_at, result.status, payload),
+            )
+
+    def last_run(self) -> DreamRunResult | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT report_json FROM dream_runs ORDER BY started_at DESC LIMIT 1"
+            ).fetchone()
+        if row is None:
+            return None
+        data = json.loads(str(row["report_json"]))
+        data["lessons"] = [Lesson(**lesson) for lesson in data.get("lessons", [])]
+        data["mesh_consolidations"] = [
+            MeshConsolidation(**item) for item in data.get("mesh_consolidations", [])
+        ]
+        data["stale_memories"] = [StaleMemory(**item) for item in data.get("stale_memories", [])]
+        return DreamRunResult(**data)
+
+    def _ensure_schema(self) -> None:
+        with self._lock:
+            self._conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS traces (
+                    event_id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    record_json TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_traces_timestamp ON traces(timestamp);
+                CREATE TABLE IF NOT EXISTS memory_reads (
+                    path TEXT PRIMARY KEY,
+                    last_read_at TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS dream_runs (
+                    run_id TEXT PRIMARY KEY,
+                    started_at TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    report_json TEXT NOT NULL
+                );
+                """
+            )
+            self._conn.commit()

--- a/src/synapsekit/dream/types.py
+++ b/src/synapsekit/dream/types.py
@@ -1,0 +1,158 @@
+"""Public data contracts for local-first Dream Mode runs."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+DreamTask = Literal[
+    "distill_lessons",
+    "propose_memory_patches",
+    "consolidate_entities",
+    "prune_stale",
+]
+DreamRunStatus = Literal["completed", "skipped", "failed"]
+
+DEFAULT_TASKS: tuple[DreamTask, ...] = (
+    "distill_lessons",
+    "propose_memory_patches",
+    "consolidate_entities",
+    "prune_stale",
+)
+
+
+@dataclass(frozen=True)
+class PowerStatus:
+    """Power information used by the overnight safety gate.
+
+    ``known=False`` is intentional: a Dream Mode run fails closed when the
+    platform cannot report whether the machine is plugged in.
+    """
+
+    plugged_in: bool
+    battery_percent: int | None = None
+    known: bool = True
+
+
+@dataclass(frozen=True)
+class DreamConfig:
+    """Resource and policy settings for :class:`~synapsekit.dream.DreamMode`."""
+
+    schedule: str = "idle_30m or 02:00"
+    budget_tokens: int = 100_000
+    tasks: tuple[DreamTask, ...] = DEFAULT_TASKS
+    lookback_hours: float = 24.0
+    stale_after_days: int = 90
+    max_trace_chars: int = 120_000
+    idle_after_seconds: float = 30 * 60
+    poll_seconds: float = 60.0
+    require_plugged_in: bool = True
+    state_path: str | Path = "~/.synapsekit/dream/state.sqlite3"
+    audit_dir: str | Path = "~/.synapsekit/dream/audit"
+
+    def __post_init__(self) -> None:
+        if self.budget_tokens <= 0:
+            raise ValueError("budget_tokens must be positive")
+        if self.lookback_hours <= 0:
+            raise ValueError("lookback_hours must be positive")
+        if self.stale_after_days <= 0:
+            raise ValueError("stale_after_days must be positive")
+        if self.max_trace_chars <= 0:
+            raise ValueError("max_trace_chars must be positive")
+        if self.idle_after_seconds < 0:
+            raise ValueError("idle_after_seconds cannot be negative")
+        if self.poll_seconds <= 0:
+            raise ValueError("poll_seconds must be positive")
+        unknown = set(self.tasks) - set(DEFAULT_TASKS)
+        if unknown:
+            raise ValueError(f"unknown Dream Mode task(s): {sorted(unknown)}")
+
+
+@dataclass(frozen=True)
+class Lesson:
+    """A distilled, evidence-linked lesson from one or more traces."""
+
+    text: str
+    theme: str
+    confidence: float
+    evidence_event_ids: tuple[str, ...] = ()
+    corrections: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.text.strip():
+            raise ValueError("lesson text must not be empty")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("lesson confidence must be between 0 and 1")
+
+
+@dataclass(frozen=True)
+class StaleMemory:
+    """A memory file flagged for review; Dream Mode never deletes it."""
+
+    path: str
+    last_read_at: str | None
+    last_modified_at: str | None
+    age_days: int
+    reason: str
+
+
+@dataclass(frozen=True)
+class MeshConsolidation:
+    """A duplicate/entity candidate surfaced for human review."""
+
+    left_path: str
+    right_path: str
+    score: float
+    reason: str
+
+
+@dataclass
+class DreamRunResult:
+    """Serializable morning-briefing result for one Dream Mode run."""
+
+    run_id: str
+    status: DreamRunStatus
+    started_at: str
+    completed_at: str
+    traces_replayed: int = 0
+    lessons: list[Lesson] = field(default_factory=list)
+    patch_ids: list[str] = field(default_factory=list)
+    mesh_reindexed: bool = False
+    mesh_consolidations: list[MeshConsolidation] = field(default_factory=list)
+    stale_memories: list[StaleMemory] = field(default_factory=list)
+    estimated_tokens: int = 0
+    audit_path: str | None = None
+    warnings: list[str] = field(default_factory=list)
+    skipped_reason: str | None = None
+
+    @classmethod
+    def skipped(cls, reason: str, *, now: datetime | None = None) -> DreamRunResult:
+        timestamp = (now or datetime.now(UTC)).isoformat()
+        return cls(
+            run_id="",
+            status="skipped",
+            started_at=timestamp,
+            completed_at=timestamp,
+            skipped_reason=reason,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly report suitable for a morning briefing."""
+
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class TraceWindow:
+    """The bounded local time window replayed by Dream Mode."""
+
+    start: datetime
+    end: datetime
+
+    def __post_init__(self) -> None:
+        if self.start.tzinfo is None or self.end.tzinfo is None:
+            raise ValueError("trace window datetimes must be timezone-aware")
+        if self.end < self.start:
+            raise ValueError("trace window end must not precede start")

--- a/src/synapsekit/timetravel/evolution_index.py
+++ b/src/synapsekit/timetravel/evolution_index.py
@@ -66,7 +66,7 @@ class EvolutionIndex:
         max_count: int | None = None,
     ) -> list[EvolutionEntry]:
         """Build evolution entries by traversing commit history."""
-        target_paths = paths if paths else [None]
+        target_paths: list[str | None] = list(paths) if paths else [None]
         all_entries: list[EvolutionEntry] = []
 
         for p in target_paths:

--- a/tests/dream/test_dream_mode.py
+++ b/tests/dream/test_dream_mode.py
@@ -1,0 +1,125 @@
+"""Focused Dream Mode workflow tests."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from synapsekit.audit import AuditTracer, EventKind, Verdict, verify
+from synapsekit.dream import DreamConfig, DreamMode, DreamSchedule, PowerStatus
+
+
+class FakeBackend:
+    async def generate(self, prompt: str, **kwargs: object) -> str:
+        if "Memory Writer" in prompt or "propose updates" in prompt:
+            return (
+                '[{"file_path":"MEMORY.md","section":"general",'
+                '"fact_key":"mesh_retry_rule",'
+                '"proposed_addition":"Retry mesh retrieval after transient failures.",'
+                '"rationale":"Repeated retrieval correction.",'
+                '"evidence":"retrieval failed; should retry with mesh"}]'
+            )
+        return "not a lesson response"
+
+
+def _trace(at: datetime) -> AuditTracer:
+    tracer = AuditTracer(run_id="day-1")
+    tracer.record(
+        EventKind.ERROR,
+        {"message": "retrieval failed; should retry with mesh"},
+        timestamp=at,
+    )
+    return tracer
+
+
+def test_schedule_parses_idle_and_clock() -> None:
+    schedule = DreamSchedule.parse("idle_30m or 02:00")
+    now = datetime.now().astimezone().replace(hour=2, minute=0, second=0, microsecond=0)
+    assert schedule.due(now, idle_seconds=0)
+    assert schedule.trigger_key(now, idle_seconds=0) == "clock:2026-08-13:02:00"
+    assert schedule.due(now, idle_seconds=1800)
+
+
+def test_unplugged_run_is_skipped(tmp_path: Path) -> None:
+    mode = DreamMode(
+        config=DreamConfig(
+            schedule="02:00",
+            state_path=tmp_path / "state.sqlite3",
+            audit_dir=tmp_path / "audit",
+        )
+    )
+    try:
+        result = asyncio.run(
+            mode.run_once(
+                force=True,
+                power=PowerStatus(plugged_in=False, battery_percent=50),
+            )
+        )
+        assert result.status == "skipped"
+        assert result.audit_path is None
+    finally:
+        mode.close()
+
+
+def test_end_to_end_run_proposes_pending_patch_and_signed_audit(tmp_path: Path) -> None:
+    memory_path = tmp_path / "MEMORY.md"
+    memory_path.write_text("# General\n\nExisting context.\n", encoding="utf-8")
+    old_time = (datetime.now(UTC) - timedelta(days=120)).timestamp()
+    os.utime(memory_path, (old_time, old_time))
+
+    now = datetime.now(UTC)
+    mode = DreamMode(
+        config=DreamConfig(
+            schedule="02:00",
+            lookback_hours=4,
+            stale_after_days=90,
+            state_path=tmp_path / "state.sqlite3",
+            audit_dir=tmp_path / "audit",
+        ),
+        backend=FakeBackend(),
+        memory_paths=[memory_path],
+    )
+    try:
+        assert mode.ingest_traces(_trace(now - timedelta(hours=1)).records) == 1
+        result = asyncio.run(
+            mode.run_once(
+                now=now,
+                force=True,
+                power=PowerStatus(plugged_in=True, battery_percent=100),
+            )
+        )
+        assert result.status == "completed"
+        assert result.traces_replayed == 1
+        assert result.lessons
+        assert result.patch_ids
+        assert result.stale_memories
+        assert result.audit_path is not None
+        assert Path(result.audit_path).exists()
+        assert verify(result.audit_path).verdict == Verdict.UNVERIFIABLE
+        assert "human review required" in mode.morning_briefing(result)
+    finally:
+        mode.close()
+
+
+def test_state_store_last_run_round_trips_typed_report(tmp_path: Path) -> None:
+    mode = DreamMode(
+        config=DreamConfig(
+            schedule="02:00",
+            state_path=tmp_path / "state.sqlite3",
+            audit_dir=tmp_path / "audit",
+        )
+    )
+    try:
+        tracer = _trace(datetime.now(UTC) - timedelta(minutes=10))
+        mode.ingest_traces(tracer.records)
+        result = asyncio.run(
+            mode.run_once(force=True, power=PowerStatus(plugged_in=True, battery_percent=100))
+        )
+        loaded = mode.state.last_run()
+        assert loaded is not None
+        assert loaded.run_id == result.run_id
+        assert loaded.status == "completed"
+    finally:
+        mode.close()

--- a/tests/dream/test_dream_mode.py
+++ b/tests/dream/test_dream_mode.py
@@ -38,7 +38,7 @@ def test_schedule_parses_idle_and_clock() -> None:
     schedule = DreamSchedule.parse("idle_30m or 02:00")
     now = datetime.now().astimezone().replace(hour=2, minute=0, second=0, microsecond=0)
     assert schedule.due(now, idle_seconds=0)
-    assert schedule.trigger_key(now, idle_seconds=0) == "clock:2026-08-13:02:00"
+    assert schedule.trigger_key(now, idle_seconds=0) == f"clock:{now.strftime('%Y-%m-%d')}:02:00"
     assert schedule.due(now, idle_seconds=1800)
 
 

--- a/tests/dream/test_dream_safety.py
+++ b/tests/dream/test_dream_safety.py
@@ -1,0 +1,84 @@
+"""Dream Mode resource and mesh-safety tests."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+from synapsekit.audit import AuditTracer, EventKind
+from synapsekit.dream import DreamConfig, DreamMode, PowerStatus
+
+
+class CountingBackend:
+    calls = 0
+
+    async def generate(self, prompt: str, **kwargs: object) -> str:
+        self.calls += 1
+        return "[]"
+
+
+class FakeMesh:
+    def __init__(self) -> None:
+        self.reindexed = False
+
+    async def reindex(self) -> None:
+        self.reindexed = True
+
+    def duplicates(self, *, limit: int) -> list[object]:
+        assert limit == 20
+        return [SimpleNamespace(left_path="a.md", right_path="b.md", score=0.91)]
+
+
+def test_budget_guard_uses_deterministic_path_without_model_call(tmp_path: Path) -> None:
+    tracer = AuditTracer(run_id="budget-day")
+    tracer.record(EventKind.ERROR, {"message": "failed " + "x" * 10_000})
+    backend = CountingBackend()
+    mode = DreamMode(
+        config=DreamConfig(
+            schedule="02:00",
+            budget_tokens=1,
+            state_path=tmp_path / "state.sqlite3",
+            audit_dir=tmp_path / "audit",
+        ),
+        backend=backend,
+    )
+    try:
+        mode.ingest_traces(tracer.records)
+        result = asyncio.run(
+            mode.run_once(
+                force=True,
+                power=PowerStatus(plugged_in=True),
+            )
+        )
+        assert result.lessons
+        assert backend.calls == 0
+    finally:
+        mode.close()
+
+
+def test_mesh_refresh_reports_candidates_without_merging(tmp_path: Path) -> None:
+    now = datetime.now(UTC)
+    mode = DreamMode(
+        config=DreamConfig(
+            schedule="02:00",
+            tasks=("consolidate_entities",),
+            state_path=tmp_path / "state.sqlite3",
+            audit_dir=tmp_path / "audit",
+        ),
+        mesh=FakeMesh(),  # type: ignore[arg-type]
+    )
+    try:
+        result = asyncio.run(
+            mode.run_once(
+                now=now,
+                force=True,
+                power=PowerStatus(plugged_in=True),
+            )
+        )
+        assert result.mesh_reindexed
+        assert result.mesh_consolidations[0].left_path == "a.md"
+        assert result.mesh_consolidations[0].score == 0.91
+    finally:
+        mode.close()


### PR DESCRIPTION
﻿## Summary

Implements issue #749, Dream Mode: an explicit, local-first overnight reflection runner that replays the day's signed traces, distills durable corrections, proposes human-reviewed LivingMemory patches, refreshes KnowledgeMesh state, flags stale memories, and emits a signed audit bundle.

## Detailed implementation plan delivered

- Add typed Dream Mode contracts for configuration, schedules, power state, lessons, stale-memory candidates, mesh consolidation candidates, trace windows, and serializable run reports.
- Add a local SQLite state store for idempotent trace ingestion, complete-run replay windows, memory-read timestamps, stale-memory reporting, and morning-briefing persistence.
- Add an injectable scheduler with `idle_30m`/`idle_30m or HH:MM` parsing, per-trigger de-duplication, Windows/Linux power monitoring, Windows idle monitoring, cancellation, and fail-closed plugged-in policy.
- Add deterministic offline lesson extraction plus an injected async model backend path. The model path is bounded by `budget_tokens`; oversized traces never invoke the backend.
- Orchestrate replay, lesson distillation, LivingMemory proposals, KnowledgeMesh reindex/duplicate candidates, report-only stale pruning, signed `AuditTracer` output, and a concise terminal briefing.
- Keep all mutations opt-in and gated: no background task on import/constructor, memory patches remain pending, entity matches are proposals only, stale pruning never deletes, and audit bundles are locally signed.
- Expose `synapsekit dream run/status`, public package exports, documentation, and an executable example.

## Safety boundaries

- Trace bundles are loaded locally and validated with `ReplayEngine`/hash-chain verification before distillation.
- `EdgeRuntime` can be passed as the backend, preserving its local-first and explicit cloud-fallback policy.
- LivingMemory remains the approval boundary; Dream Mode never applies a patch automatically.
- KnowledgeMesh duplicate/entity work is report-only; no automatic merges or deletes.
- Stale-memory pruning is report-only.
- The scheduler refuses to run when power state is unknown or the machine is not plugged in by default.
- Token and transcript limits prevent unbounded overnight work.

## Verification

- Dream Mode focused suite: 6 passed
- LivingMemory regressions: 14 passed
- EdgeRuntime regressions: 15 passed
- KnowledgeMesh regressions: 14 passed
- Signed audit regressions: 66 passed
- Ruff lint: passed
- Ruff formatting: passed
- Bounded mypy: passed for 7 Dream Mode source/CLI modules
- `compileall`: passed
- async-blocking gate: clean, 544 files scanned
- `git diff --check`: passed

The normal pytest plugin environment has an unrelated installed `logfire`/OpenTelemetry version mismatch. Async suites were verified with only the repository-relevant `pytest-asyncio` plugin enabled.

## Commits

1. `feat(dream): add local reflection contracts and state`
2. `feat(dream): orchestrate audited overnight reflection`
3. `test(dream): cover safety and morning briefing workflows`

Closes #749
