### PR TITLE
feat(archaeology): Code Archaeology Agent — reconstruct why decisions were made

### DIFF
--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -150,6 +150,17 @@ from .agents import (
     requires_human_confirmation,
     tool,
 )
+from .archaeology import (
+    ArchaeologyAgent,
+    ArchaeologyResult,
+    CausalClaim,
+    Citation,
+    EvolutionDiff,
+    EvolutionSnapshot,
+    SourceConfig,
+    TimelineEvent,
+    TimelineReconstructor,
+)
 from .audit import (
     AuditMetrics,
     AuditRecord,
@@ -766,6 +777,16 @@ __all__ = [
     "EvolutionEntry",
     "EvolutionIndex",
     "GitBackend",
+    # Code Archaeology
+    "ArchaeologyAgent",
+    "ArchaeologyResult",
+    "CausalClaim",
+    "Citation",
+    "EvolutionDiff",
+    "EvolutionSnapshot",
+    "SourceConfig",
+    "TimelineEvent",
+    "TimelineReconstructor",
     # Cost intelligence
     "CostTracker",
     "CostRecord",

--- a/src/synapsekit/archaeology/__init__.py
+++ b/src/synapsekit/archaeology/__init__.py
@@ -1,5 +1,6 @@
 """Code Archaeology Agent — reconstruct why code decisions were made."""
 
+from .causal_linker import CausalLinker
 from .timeline_reconstructor import TimelineReconstructor
 from .types import (
     ArchaeologyResult,
@@ -13,6 +14,7 @@ from .types import (
 __all__ = [
     "ArchaeologyResult",
     "CausalClaim",
+    "CausalLinker",
     "Citation",
     "EvolutionSnapshot",
     "SourceConfig",

--- a/src/synapsekit/archaeology/__init__.py
+++ b/src/synapsekit/archaeology/__init__.py
@@ -1,5 +1,6 @@
 """Code Archaeology Agent — reconstruct why code decisions were made."""
 
+from .agent import ArchaeologyAgent
 from .causal_linker import CausalLinker
 from .evolution_diff import EvolutionDiff
 from .timeline_reconstructor import TimelineReconstructor
@@ -13,6 +14,7 @@ from .types import (
 )
 
 __all__ = [
+    "ArchaeologyAgent",
     "ArchaeologyResult",
     "CausalClaim",
     "CausalLinker",

--- a/src/synapsekit/archaeology/__init__.py
+++ b/src/synapsekit/archaeology/__init__.py
@@ -1,6 +1,7 @@
 """Code Archaeology Agent — reconstruct why code decisions were made."""
 
 from .causal_linker import CausalLinker
+from .evolution_diff import EvolutionDiff
 from .timeline_reconstructor import TimelineReconstructor
 from .types import (
     ArchaeologyResult,
@@ -16,6 +17,7 @@ __all__ = [
     "CausalClaim",
     "CausalLinker",
     "Citation",
+    "EvolutionDiff",
     "EvolutionSnapshot",
     "SourceConfig",
     "TimelineEvent",

--- a/src/synapsekit/archaeology/__init__.py
+++ b/src/synapsekit/archaeology/__init__.py
@@ -1,5 +1,6 @@
 """Code Archaeology Agent — reconstruct why code decisions were made."""
 
+from .timeline_reconstructor import TimelineReconstructor
 from .types import (
     ArchaeologyResult,
     CausalClaim,
@@ -16,4 +17,5 @@ __all__ = [
     "EvolutionSnapshot",
     "SourceConfig",
     "TimelineEvent",
+    "TimelineReconstructor",
 ]

--- a/src/synapsekit/archaeology/__init__.py
+++ b/src/synapsekit/archaeology/__init__.py
@@ -1,0 +1,19 @@
+"""Code Archaeology Agent — reconstruct why code decisions were made."""
+
+from .types import (
+    ArchaeologyResult,
+    CausalClaim,
+    Citation,
+    EvolutionSnapshot,
+    SourceConfig,
+    TimelineEvent,
+)
+
+__all__ = [
+    "ArchaeologyResult",
+    "CausalClaim",
+    "Citation",
+    "EvolutionSnapshot",
+    "SourceConfig",
+    "TimelineEvent",
+]

--- a/src/synapsekit/archaeology/_terms.py
+++ b/src/synapsekit/archaeology/_terms.py
@@ -1,0 +1,27 @@
+"""Shared query-term extraction/matching for archaeology sources."""
+
+from __future__ import annotations
+
+_STRIP_CHARS = "?,.'\"`"
+
+
+def extract_terms(query: str, *, min_len: int = 3, lower: bool = True) -> list[str]:
+    """Split a query into search terms, dropping short/punctuation-only tokens.
+
+    `lower=False` preserves case for callers matching against case-sensitive
+    identifiers (e.g. Python symbol names via `EvolutionIndex.query`).
+    """
+    terms = []
+    for t in query.split():
+        stripped = t.strip(_STRIP_CHARS)
+        if lower:
+            stripped = stripped.lower()
+        if len(stripped) >= min_len:
+            terms.append(stripped)
+    return terms
+
+
+def matches(text: str, terms: list[str]) -> bool:
+    """Return True if any term appears in text (case-insensitive)."""
+    text_lower = text.lower()
+    return any(term in text_lower for term in terms)

--- a/src/synapsekit/archaeology/agent.py
+++ b/src/synapsekit/archaeology/agent.py
@@ -1,0 +1,198 @@
+"""ArchaeologyAgent — reconstruct why code exists by fusing multi-source evidence."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ..llm._factory import make_llm
+from ..llm.base import BaseLLM
+from .causal_linker import CausalLinker
+from .evolution_diff import EvolutionDiff
+from .timeline_reconstructor import TimelineReconstructor
+from .types import ArchaeologyResult, SourceConfig
+
+if TYPE_CHECKING:
+    from ..symbolic.agent import NeuroSymbolicAgent
+
+logger = logging.getLogger(__name__)
+
+_NARRATIVE_PROMPT = """\
+You are a Code Archaeology expert. Based on the following evidence, write a
+clear, developer-friendly explanation answering: "{query}"
+
+## Timeline ({n_events} events from {n_sources} sources)
+{timeline_summary}
+
+## Causal Chain ({n_claims} causal links identified)
+{causal_summary}
+
+## Evolution History ({n_snapshots} versions)
+{evolution_summary}
+
+Write a concise but comprehensive narrative that:
+1. Explains WHY the code exists in its current form
+2. Traces the decision chain that led to this state
+3. Cites specific evidence (commits, PRs, messages, notes)
+4. Highlights any still-justified vs. potentially outdated decisions
+"""
+
+
+class ArchaeologyAgent:
+    """Agent that fuses git log, notes, and external archives to explain WHY code exists.
+
+    Parameters
+    ----------
+    sources:
+        Configuration for data sources (git, markdown, Slack, email, mesh).
+    llm:
+        BaseLLM instance. If None, one is created from model/api_key.
+    model:
+        LLM model name (used if llm is None).
+    api_key:
+        API key for LLM provider (used if llm is None).
+    provider:
+        Optional LLM provider name.
+    causal_engine:
+        Optional NeuroSymbolicAgent for causal plausibility checks.
+    """
+
+    def __init__(
+        self,
+        sources: SourceConfig | None = None,
+        *,
+        llm: BaseLLM | None = None,
+        model: str = "gpt-4o-mini",
+        api_key: str = "",
+        provider: str | None = None,
+        causal_engine: NeuroSymbolicAgent | None = None,
+    ) -> None:
+        self.sources = sources or SourceConfig()
+
+        if llm is not None:
+            self.llm: BaseLLM | None = llm
+        else:
+            try:
+                self.llm = make_llm(
+                    model,
+                    api_key,
+                    provider,
+                    "You are a code archaeology and history analyst.",
+                    0.3,
+                    2048,
+                )
+            except Exception:
+                self.llm = None
+
+        repo_path = Path(self.sources.repo_path).resolve()
+        self.timeline_reconstructor = TimelineReconstructor(repo_path)
+        self.evolution_diff = EvolutionDiff(repo_path)
+        self.causal_linker: CausalLinker | None = None
+        if self.llm is not None:
+            self.causal_linker = CausalLinker(
+                self.llm,
+                verifier=causal_engine,
+                min_citations=self.sources.min_citations_per_claim,
+            )
+        self.causal_engine = causal_engine
+
+    async def explain(self, query: str) -> ArchaeologyResult:
+        """Answer 'Why does this code exist?' with a full causal chain and evidence.
+
+        Returns an ArchaeologyResult with:
+        - timeline: chronological events from all sources
+        - causes: causal claims with evidence and optional verification
+        - evolution: how the code changed over time
+        - narrative: human-readable markdown summary
+        """
+        src = self.sources
+
+        # Phase 1: Reconstruct timeline from all sources
+        timeline = await self.timeline_reconstructor.reconstruct(
+            query,
+            include_git=src.include_git,
+            slack_bot_token=src.slack_bot_token,
+            slack_channel_ids=src.slack_channel_ids or None,
+            email_imap_server=src.email_imap_server,
+            email_address=src.email_address,
+            email_password=src.email_password,
+            email_folder=src.email_folder,
+            markdown_roots=[Path(r) for r in src.markdown_roots] or None,
+            max_events=src.max_events,
+        )
+
+        # Phase 2 & 3: Run causal linking and evolution diff concurrently
+        causal_task = (
+            self.causal_linker.link(timeline, query)
+            if self.causal_linker is not None
+            else _empty_list()
+        )
+        evolution_task = self.evolution_diff.trace(query)
+
+        causes, evolution = await asyncio.gather(causal_task, evolution_task)
+
+        # Phase 4: Generate narrative summary
+        narrative = ""
+        if self.llm is not None:
+            narrative = await self._generate_narrative(
+                query,
+                timeline,
+                causes,
+                evolution,
+            )
+
+        return ArchaeologyResult(
+            query=query,
+            timeline=timeline,
+            causes=causes,
+            evolution=evolution,
+            narrative=narrative,
+        )
+
+    async def _generate_narrative(
+        self,
+        query: str,
+        timeline: list,
+        causes: list,
+        evolution: list,
+    ) -> str:
+        """Generate a human-readable narrative from the evidence."""
+        if self.llm is None:
+            return ""
+
+        source_types = {e.source_type for e in timeline}
+        timeline_lines = [
+            f"- [{e.timestamp.strftime('%Y-%m-%d')}] ({e.source_type}) {e.summary}"
+            for e in timeline[:30]
+        ]
+        causal_lines = [
+            f"- {c.cause} → {c.effect} (confidence: {c.confidence:.0%}, verified: {c.verified})"
+            for c in causes
+        ]
+        evolution_lines = [
+            f"- [{s.date.strftime('%Y-%m-%d')}] {s.diff_summary}: {s.reason[:100]}"
+            for s in evolution[:20]
+        ]
+
+        prompt = _NARRATIVE_PROMPT.format(
+            query=query,
+            n_events=len(timeline),
+            n_sources=len(source_types),
+            timeline_summary="\n".join(timeline_lines) or "No events found.",
+            n_claims=len(causes),
+            causal_summary="\n".join(causal_lines) or "No causal links identified.",
+            n_snapshots=len(evolution),
+            evolution_summary="\n".join(evolution_lines) or "No evolution data.",
+        )
+
+        chunks: list[str] = []
+        async for chunk in self.llm.stream(prompt):
+            chunks.append(chunk)
+        return "".join(chunks)
+
+
+async def _empty_list() -> list:
+    """Async no-op returning an empty list."""
+    return []

--- a/src/synapsekit/archaeology/agent.py
+++ b/src/synapsekit/archaeology/agent.py
@@ -84,11 +84,25 @@ class ArchaeologyAgent:
                     2048,
                 )
             except Exception:
+                logger.warning(
+                    "ArchaeologyAgent could not construct an LLM (model=%r, provider=%r) — "
+                    "falling back to timeline-only mode with no causal linking or narrative.",
+                    model,
+                    provider,
+                    exc_info=True,
+                )
                 self.llm = None
 
         repo_path = Path(self.sources.repo_path).resolve()
-        self.timeline_reconstructor = TimelineReconstructor(repo_path)
-        self.evolution_diff = EvolutionDiff(repo_path)
+        from ..timetravel.evolution_index import EvolutionIndex
+        from ..timetravel.git_backend import GitBackend
+
+        # Shared across timeline + evolution so `explain()` walks git history once.
+        evolution_index = EvolutionIndex(GitBackend(repo_path))
+        self.timeline_reconstructor = TimelineReconstructor(
+            repo_path, evolution_index=evolution_index
+        )
+        self.evolution_diff = EvolutionDiff(repo_path, evolution_index=evolution_index)
         self.causal_linker: CausalLinker | None = None
         if self.llm is not None:
             self.causal_linker = CausalLinker(

--- a/src/synapsekit/archaeology/causal_linker.py
+++ b/src/synapsekit/archaeology/causal_linker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING
 
@@ -164,35 +165,58 @@ class CausalLinker:
         self,
         claims: list[CausalClaim],
     ) -> list[CausalClaim]:
-        """Verify causal claims using NeuroSymbolicAgent for plausibility."""
+        """Best-effort claim verification via NeuroSymbolicAgent.
+
+        NeuroSymbolicAgent.solve() formalizes its input into an SMT/Prolog/
+        MiniZinc/Sympy constraint program and checks it with a solver — it was
+        built for problems with decidable formal structure, not prose
+        plausibility judgments. Free-text causal claims have no reliable
+        formalization, so `verified` here is a best-effort signal, not a
+        formal proof; treat it as informational rather than authoritative.
+        """
         if self.verifier is None:
             return claims
 
+        logger.info(
+            "CausalLinker verifying %d claim(s) via NeuroSymbolicAgent — "
+            "verdicts are best-effort, not formal proofs, since causal claims "
+            "are prose rather than a decidable constraint problem.",
+            len(claims),
+        )
+
+        results = await asyncio.gather(
+            *(self._verify_claim(claim) for claim in claims),
+            return_exceptions=True,
+        )
+
         verified_claims: list[CausalClaim] = []
-        for claim in claims:
-            try:
-                evidence = [c.content_preview for c in claim.citations]
-                problem = (
-                    f"Verify this causal claim: '{claim.cause}' caused '{claim.effect}'. "
-                    f"Evidence: {'; '.join(evidence[:3])}"
-                )
-                result = await self.verifier.solve(problem)
-                verified_claims.append(
-                    CausalClaim(
-                        cause=claim.cause,
-                        effect=claim.effect,
-                        confidence=claim.confidence,
-                        citations=claim.citations,
-                        verified=bool(getattr(result, "verified", False)),
-                        reasoning=claim.reasoning,
-                    )
-                )
-            except Exception:
+        for claim, result in zip(claims, results, strict=True):
+            if isinstance(result, BaseException):
                 logger.warning(
-                    "Verification failed for claim: %s -> %s",
+                    "Verification failed for claim: %s -> %s (%s)",
                     claim.cause,
                     claim.effect,
+                    result,
                 )
                 verified_claims.append(claim)
+            else:
+                verified_claims.append(result)
 
         return verified_claims
+
+    async def _verify_claim(self, claim: CausalClaim) -> CausalClaim:
+        assert self.verifier is not None
+        evidence = [c.content_preview for c in claim.citations]
+        problem = (
+            f"Verify this causal claim: '{claim.cause}' caused '{claim.effect}'. "
+            f"Evidence: {'; '.join(evidence[:3])}"
+        )
+        result = await self.verifier.solve(problem)
+        return CausalClaim(
+            cause=claim.cause,
+            effect=claim.effect,
+            confidence=claim.confidence,
+            citations=claim.citations,
+            verified=bool(getattr(result, "verified", False)),
+            reasoning=claim.reasoning,
+        )

--- a/src/synapsekit/archaeology/causal_linker.py
+++ b/src/synapsekit/archaeology/causal_linker.py
@@ -1,0 +1,198 @@
+"""CausalLinker — extract and verify causal claims from multi-source evidence."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from .types import CausalClaim, Citation, TimelineEvent
+
+if TYPE_CHECKING:
+    from ..llm.base import BaseLLM
+    from ..symbolic.agent import NeuroSymbolicAgent
+
+logger = logging.getLogger(__name__)
+
+_CAUSAL_PROMPT = """\
+Given the following chronological events related to the query "{query}",
+identify causal relationships (what caused what). For each causal link, provide:
+1. The cause (what happened first that led to the next event)
+2. The effect (what resulted from the cause)
+3. Your confidence level (0.0 to 1.0)
+4. Brief reasoning
+
+Events:
+{events}
+
+Return your analysis as a numbered list of causal links in this exact format:
+CAUSE: <description>
+EFFECT: <description>
+CONFIDENCE: <0.0-1.0>
+REASONING: <explanation>
+---
+"""
+
+
+class CausalLinker:
+    """Extracts causal relationships from timeline events and optionally verifies them."""
+
+    def __init__(
+        self,
+        llm: BaseLLM,
+        *,
+        verifier: NeuroSymbolicAgent | None = None,
+        min_citations: int = 2,
+    ) -> None:
+        self.llm = llm
+        self.verifier = verifier
+        self.min_citations = min_citations
+
+    async def link(
+        self,
+        events: list[TimelineEvent],
+        query: str,
+    ) -> list[CausalClaim]:
+        """Extract causal claims from timeline events and verify them."""
+        if not events:
+            return []
+
+        # Format events for LLM
+        event_strs: list[str] = []
+        for i, e in enumerate(events[:50], 1):  # Cap for context length
+            cite_refs = ", ".join(c.reference for c in e.citations)
+            event_strs.append(
+                f"{i}. [{e.timestamp.strftime('%Y-%m-%d')}] "
+                f"({e.source_type}) {e.summary} [refs: {cite_refs}]"
+            )
+
+        prompt = _CAUSAL_PROMPT.format(
+            query=query,
+            events="\n".join(event_strs),
+        )
+
+        response_chunks: list[str] = []
+        async for chunk in self.llm.stream(prompt):
+            response_chunks.append(chunk)
+        response = "".join(response_chunks)
+
+        claims = self._parse_claims(response, events)
+
+        # Filter claims with insufficient evidence
+        claims = [c for c in claims if len(c.citations) >= self.min_citations]
+
+        # Verify with NeuroSymbolicAgent if available
+        if self.verifier is not None:
+            claims = await self._verify_claims(claims)
+
+        return claims
+
+    def _parse_claims(
+        self,
+        response: str,
+        events: list[TimelineEvent],
+    ) -> list[CausalClaim]:
+        """Parse LLM response into CausalClaim objects."""
+        claims: list[CausalClaim] = []
+        blocks = response.split("---")
+
+        all_citations: list[Citation] = []
+        for e in events:
+            all_citations.extend(e.citations)
+
+        for block in blocks:
+            block = block.strip()
+            if not block:
+                continue
+
+            cause = effect = reasoning = ""
+            confidence = 0.5
+
+            for line in block.split("\n"):
+                line = line.strip()
+                if line.upper().startswith("CAUSE:"):
+                    cause = line[6:].strip()
+                elif line.upper().startswith("EFFECT:"):
+                    effect = line[7:].strip()
+                elif line.upper().startswith("CONFIDENCE:"):
+                    try:
+                        confidence = float(line[11:].strip())
+                    except ValueError:
+                        confidence = 0.5
+                elif line.upper().startswith("REASONING:"):
+                    reasoning = line[10:].strip()
+
+            if cause and effect:
+                # Find matching citations from events
+                matched_citations = self._match_citations(
+                    cause + " " + effect,
+                    all_citations,
+                )
+                claims.append(
+                    CausalClaim(
+                        cause=cause,
+                        effect=effect,
+                        confidence=confidence,
+                        citations=matched_citations,
+                        verified=False,
+                        reasoning=reasoning,
+                    )
+                )
+
+        return claims
+
+    def _match_citations(
+        self,
+        text: str,
+        all_citations: list[Citation],
+    ) -> list[Citation]:
+        """Find citations whose content is relevant to the claim text."""
+        text_lower = text.lower()
+        terms = [w for w in text_lower.split() if len(w) > 3]
+
+        scored: list[tuple[int, Citation]] = []
+        for c in all_citations:
+            preview_lower = c.content_preview.lower()
+            ref_lower = c.reference.lower()
+            score = sum(1 for t in terms if t in preview_lower or t in ref_lower)
+            if score > 0:
+                scored.append((score, c))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [c for _, c in scored[:5]]
+
+    async def _verify_claims(
+        self,
+        claims: list[CausalClaim],
+    ) -> list[CausalClaim]:
+        """Verify causal claims using NeuroSymbolicAgent for plausibility."""
+        if self.verifier is None:
+            return claims
+
+        verified_claims: list[CausalClaim] = []
+        for claim in claims:
+            try:
+                evidence = [c.content_preview for c in claim.citations]
+                problem = (
+                    f"Verify this causal claim: '{claim.cause}' caused '{claim.effect}'. "
+                    f"Evidence: {'; '.join(evidence[:3])}"
+                )
+                result = await self.verifier.solve(problem)
+                verified_claims.append(
+                    CausalClaim(
+                        cause=claim.cause,
+                        effect=claim.effect,
+                        confidence=claim.confidence,
+                        citations=claim.citations,
+                        verified=bool(getattr(result, "verified", False)),
+                        reasoning=claim.reasoning,
+                    )
+                )
+            except Exception:
+                logger.warning(
+                    "Verification failed for claim: %s -> %s",
+                    claim.cause,
+                    claim.effect,
+                )
+                verified_claims.append(claim)
+
+        return verified_claims

--- a/src/synapsekit/archaeology/evolution_diff.py
+++ b/src/synapsekit/archaeology/evolution_diff.py
@@ -8,11 +8,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from ._terms import extract_terms
 from .types import Citation, EvolutionSnapshot
 
 if TYPE_CHECKING:
     from ..llm.base import BaseLLM
-    from ..timetravel.evolution_index import EvolutionEntry
+    from ..timetravel.evolution_index import EvolutionEntry, EvolutionIndex
 
 logger = logging.getLogger(__name__)
 
@@ -20,8 +21,14 @@ logger = logging.getLogger(__name__)
 class EvolutionDiff:
     """Tracks how a file or symbol evolved over time, extracting rationale from commits."""
 
-    def __init__(self, repo_path: str | Path = ".") -> None:
+    def __init__(
+        self,
+        repo_path: str | Path = ".",
+        *,
+        evolution_index: EvolutionIndex | None = None,
+    ) -> None:
         self.repo_path = Path(repo_path).resolve()
+        self._evolution_index = evolution_index
 
     async def trace(
         self,
@@ -35,12 +42,19 @@ class EvolutionDiff:
         from ..timetravel.evolution_index import EvolutionIndex
         from ..timetravel.git_backend import GitBackend
 
-        backend = GitBackend(self.repo_path)
-        index = EvolutionIndex(backend)
-        all_entries = await asyncio.to_thread(index.build, since=since, until=until)
+        if self._evolution_index is not None:
+            # A shared, already-built index ignores since/until scoping at the
+            # git-log level (it was built once, unscoped) but `query()` still
+            # applies since/until filtering in-memory, so results stay correct.
+            index = self._evolution_index
+            await asyncio.to_thread(index.ensure_built)
+        else:
+            index = EvolutionIndex(GitBackend(self.repo_path))
+            await asyncio.to_thread(index.build, since=since, until=until)
 
-        # Extract search terms from file_or_symbol
-        terms = [t.strip("?,.'\"`") for t in file_or_symbol.split() if len(t) > 2]
+        # Extract search terms from file_or_symbol (case preserved: EvolutionIndex.query
+        # matches file paths/symbols case-sensitively).
+        terms = extract_terms(file_or_symbol, lower=False)
         matching_entries: list[EvolutionEntry] = []
         for term in terms:
             res = index.query(term, since=since, until=until)
@@ -48,9 +62,12 @@ class EvolutionDiff:
                 matching_entries.extend(res)
 
         if not matching_entries:
+            # Whole-string fallback only (e.g. a bare file path) — do NOT fall
+            # back further to the full unfiltered history: for natural-language
+            # queries (the common case via ArchaeologyAgent.explain()) that
+            # would silently return every commit in the repo instead of an
+            # empty, honest "nothing matched" result.
             matching_entries = index.query(file_or_symbol, since=since, until=until)
-        if not matching_entries:
-            matching_entries = all_entries
 
         # Deduplicate and sort chronologically
         seen = set()

--- a/src/synapsekit/archaeology/evolution_diff.py
+++ b/src/synapsekit/archaeology/evolution_diff.py
@@ -12,6 +12,7 @@ from .types import Citation, EvolutionSnapshot
 
 if TYPE_CHECKING:
     from ..llm.base import BaseLLM
+    from ..timetravel.evolution_index import EvolutionEntry
 
 logger = logging.getLogger(__name__)
 
@@ -30,18 +31,35 @@ class EvolutionDiff:
         until: str | datetime | None = None,
         llm: BaseLLM | None = None,
     ) -> list[EvolutionSnapshot]:
-        """Build a chronological evolution trace for a file or symbol."""
+        """Build a chronological evolution trace for a file, symbol, or question."""
         from ..timetravel.evolution_index import EvolutionIndex
         from ..timetravel.git_backend import GitBackend
 
         backend = GitBackend(self.repo_path)
         index = EvolutionIndex(backend)
-        entries = await asyncio.to_thread(
-            index.timeline,
-            file_or_symbol,
-            since=since,
-            until=until,
-        )
+        all_entries = await asyncio.to_thread(index.build, since=since, until=until)
+
+        # Extract search terms from file_or_symbol
+        terms = [t.strip("?,.'\"`") for t in file_or_symbol.split() if len(t) > 2]
+        matching_entries: list[EvolutionEntry] = []
+        for term in terms:
+            res = index.query(term, since=since, until=until)
+            if res:
+                matching_entries.extend(res)
+
+        if not matching_entries:
+            matching_entries = index.query(file_or_symbol, since=since, until=until)
+        if not matching_entries:
+            matching_entries = all_entries
+
+        # Deduplicate and sort chronologically
+        seen = set()
+        entries: list[EvolutionEntry] = []
+        for e in sorted(matching_entries, key=lambda x: x.commit.date):
+            key = (e.commit.hash, e.file_path, e.symbol)
+            if key not in seen:
+                seen.add(key)
+                entries.append(e)
 
         snapshots: list[EvolutionSnapshot] = []
         for entry in entries:

--- a/src/synapsekit/archaeology/evolution_diff.py
+++ b/src/synapsekit/archaeology/evolution_diff.py
@@ -73,11 +73,7 @@ class EvolutionDiff:
                     f"commit {entry.commit.hash[:8]}"
                     + (f" (PR #{entry.pr_number})" if entry.pr_number else "")
                 ),
-                content_preview=(
-                    entry.diff_snippet[:200]
-                    if entry.diff_snippet
-                    else reason
-                ),
+                content_preview=(entry.diff_snippet[:200] if entry.diff_snippet else reason),
                 timestamp=entry.commit.date,
                 metadata={
                     "author": entry.commit.author,

--- a/src/synapsekit/archaeology/evolution_diff.py
+++ b/src/synapsekit/archaeology/evolution_diff.py
@@ -1,0 +1,89 @@
+"""EvolutionDiff — track how code evolved across versions with rationale."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .types import Citation, EvolutionSnapshot
+
+if TYPE_CHECKING:
+    from ..llm.base import BaseLLM
+
+logger = logging.getLogger(__name__)
+
+
+class EvolutionDiff:
+    """Tracks how a file or symbol evolved over time, extracting rationale from commits."""
+
+    def __init__(self, repo_path: str | Path = ".") -> None:
+        self.repo_path = Path(repo_path).resolve()
+
+    async def trace(
+        self,
+        file_or_symbol: str,
+        *,
+        since: str | datetime | None = None,
+        until: str | datetime | None = None,
+        llm: BaseLLM | None = None,
+    ) -> list[EvolutionSnapshot]:
+        """Build a chronological evolution trace for a file or symbol."""
+        from ..timetravel.evolution_index import EvolutionIndex
+        from ..timetravel.git_backend import GitBackend
+
+        backend = GitBackend(self.repo_path)
+        index = EvolutionIndex(backend)
+        entries = await asyncio.to_thread(
+            index.timeline,
+            file_or_symbol,
+            since=since,
+            until=until,
+        )
+
+        snapshots: list[EvolutionSnapshot] = []
+        for entry in entries:
+            reason = entry.commit.subject
+            if entry.commit.body:
+                reason += f" — {entry.commit.body.strip()}"
+
+            citation = Citation(
+                source_type="git",
+                reference=(
+                    f"commit {entry.commit.hash[:8]}"
+                    + (f" (PR #{entry.pr_number})" if entry.pr_number else "")
+                ),
+                content_preview=(
+                    entry.diff_snippet[:200]
+                    if entry.diff_snippet
+                    else reason
+                ),
+                timestamp=entry.commit.date,
+                metadata={
+                    "author": entry.commit.author,
+                    "file_path": entry.file_path,
+                    "symbol": entry.symbol,
+                    "lines_added": entry.lines_added,
+                    "lines_removed": entry.lines_removed,
+                },
+            )
+
+            diff_summary = (
+                f"{entry.change_type} in {entry.file_path}"
+                + (f" [{entry.symbol}]" if entry.symbol else "")
+                + f" (+{entry.lines_added}/-{entry.lines_removed})"
+            )
+
+            snapshots.append(
+                EvolutionSnapshot(
+                    version_hash=entry.commit.hash,
+                    date=entry.commit.date,
+                    diff_summary=diff_summary,
+                    reason=reason,
+                    citations=[citation],
+                )
+            )
+
+        return snapshots

--- a/src/synapsekit/archaeology/timeline_reconstructor.py
+++ b/src/synapsekit/archaeology/timeline_reconstructor.py
@@ -5,9 +5,15 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from ._terms import extract_terms, matches
 from .types import Citation, TimelineEvent
+
+if TYPE_CHECKING:
+    from ..timetravel.evolution_index import EvolutionIndex
 
 logger = logging.getLogger(__name__)
 
@@ -15,8 +21,14 @@ logger = logging.getLogger(__name__)
 class TimelineReconstructor:
     """Collects events from git, Slack, email, and markdown, then merges chronologically."""
 
-    def __init__(self, repo_path: str | Path = ".") -> None:
+    def __init__(
+        self,
+        repo_path: str | Path = ".",
+        *,
+        evolution_index: EvolutionIndex | None = None,
+    ) -> None:
         self.repo_path = Path(repo_path).resolve()
+        self._evolution_index = evolution_index
 
     async def reconstruct(
         self,
@@ -74,23 +86,21 @@ class TimelineReconstructor:
 
     async def _git_events(self, query: str, max_events: int) -> list[TimelineEvent]:
         """Extract timeline events from git history."""
-        from ..timetravel.evolution_index import EvolutionIndex
-        from ..timetravel.git_backend import GitBackend
+        if self._evolution_index is not None:
+            index = self._evolution_index
+        else:
+            from ..timetravel.evolution_index import EvolutionIndex
+            from ..timetravel.git_backend import GitBackend
 
-        backend = GitBackend(self.repo_path)
-        index = EvolutionIndex(backend)
+            index = EvolutionIndex(GitBackend(self.repo_path))
 
-        entries = await asyncio.to_thread(index.build)
-        terms = [t.strip("?,.'\"`") for t in query.split() if len(t) > 2]
+        entries = await asyncio.to_thread(index.ensure_built)
+        terms = extract_terms(query)
 
         matching = [
             e
             for e in entries
-            if any(
-                term.lower()
-                in (e.file_path + " " + (e.symbol or "") + " " + e.commit.subject).lower()
-                for term in terms
-            )
+            if matches(e.file_path + " " + (e.symbol or "") + " " + e.commit.subject, terms)
         ] or entries[:max_events]
 
         events: list[TimelineEvent] = []
@@ -133,14 +143,13 @@ class TimelineReconstructor:
         from ..loaders.slack import SlackLoader
 
         events: list[TimelineEvent] = []
-        terms = [t.lower().strip("?,.'\"`") for t in query.split() if len(t) > 2]
+        terms = extract_terms(query)
 
         for channel_id in channel_ids:
             loader = SlackLoader(bot_token=bot_token, channel_id=channel_id)
             docs = await loader.aload()
             for doc in docs:
-                text_lower = doc.text.lower()
-                if not any(term in text_lower for term in terms):
+                if not matches(doc.text, terms):
                     continue
                 ts_str = str(doc.metadata.get("timestamp", ""))
                 try:
@@ -183,17 +192,16 @@ class TimelineReconstructor:
             folder=folder,
         )
         docs = await loader.aload()
-        terms = [t.lower().strip("?,.'\"`") for t in query.split() if len(t) > 2]
+        terms = extract_terms(query)
         events: list[TimelineEvent] = []
 
         for doc in docs:
-            text_lower = (doc.text + " " + doc.metadata.get("subject", "")).lower()
-            if not any(term in text_lower for term in terms):
+            if not matches(doc.text + " " + doc.metadata.get("subject", ""), terms):
                 continue
             date_str = doc.metadata.get("date", "")
             try:
-                ts = datetime.fromisoformat(date_str) if date_str else datetime.now(UTC)
-            except ValueError:
+                ts = parsedate_to_datetime(date_str) if date_str else datetime.now(UTC)
+            except (ValueError, TypeError):
                 ts = datetime.now(UTC)
             if ts.tzinfo is None:
                 ts = ts.replace(tzinfo=UTC)
@@ -221,7 +229,7 @@ class TimelineReconstructor:
         roots: list[Path],
     ) -> list[TimelineEvent]:
         """Extract timeline events from local markdown notes."""
-        terms = [t.lower().strip("?,.'\"`") for t in query.split() if len(t) > 2]
+        terms = extract_terms(query)
         events: list[TimelineEvent] = []
 
         for root in roots:
@@ -234,7 +242,7 @@ class TimelineReconstructor:
                     content = await asyncio.to_thread(md_file.read_text, encoding="utf-8")
                 except Exception:
                     continue
-                if not any(term in content.lower() for term in terms):
+                if not matches(content, terms):
                     continue
                 stat = md_file.stat()
                 ts = datetime.fromtimestamp(stat.st_mtime, tz=UTC)

--- a/src/synapsekit/archaeology/timeline_reconstructor.py
+++ b/src/synapsekit/archaeology/timeline_reconstructor.py
@@ -1,0 +1,263 @@
+"""TimelineReconstructor — merge multi-source events into a single timeline."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .types import Citation, TimelineEvent
+
+logger = logging.getLogger(__name__)
+
+
+class TimelineReconstructor:
+    """Collects events from git, Slack, email, and markdown, then merges chronologically."""
+
+    def __init__(self, repo_path: str | Path = ".") -> None:
+        self.repo_path = Path(repo_path).resolve()
+
+    async def reconstruct(
+        self,
+        query: str,
+        *,
+        include_git: bool = True,
+        slack_bot_token: str | None = None,
+        slack_channel_ids: list[str] | None = None,
+        email_imap_server: str | None = None,
+        email_address: str | None = None,
+        email_password: str | None = None,
+        email_folder: str = "INBOX",
+        markdown_roots: list[str | Path] | None = None,
+        max_events: int = 200,
+    ) -> list[TimelineEvent]:
+        """Gather and merge events from all configured sources."""
+        tasks: list[asyncio.Task[list[TimelineEvent]]] = []
+
+        if include_git:
+            tasks.append(asyncio.create_task(self._git_events(query, max_events)))
+
+        if slack_bot_token and slack_channel_ids:
+            tasks.append(
+                asyncio.create_task(
+                    self._slack_events(query, slack_bot_token, slack_channel_ids)
+                )
+            )
+
+        if email_imap_server and email_address and email_password:
+            tasks.append(
+                asyncio.create_task(
+                    self._email_events(
+                        query,
+                        email_imap_server,
+                        email_address,
+                        email_password,
+                        email_folder,
+                    )
+                )
+            )
+
+        if markdown_roots:
+            tasks.append(
+                asyncio.create_task(
+                    self._markdown_events(query, [Path(r) for r in markdown_roots])
+                )
+            )
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        events: list[TimelineEvent] = []
+        for result in results:
+            if isinstance(result, BaseException):
+                logger.warning("Source failed in TimelineReconstructor: %s", result)
+                continue
+            events.extend(result)
+
+        events.sort(key=lambda e: e.timestamp)
+        return events[:max_events]
+
+    async def _git_events(self, query: str, max_events: int) -> list[TimelineEvent]:
+        """Extract timeline events from git history."""
+        from ..timetravel.evolution_index import EvolutionIndex
+        from ..timetravel.git_backend import GitBackend
+
+        backend = GitBackend(self.repo_path)
+        index = EvolutionIndex(backend)
+
+        entries = await asyncio.to_thread(index.build)
+        terms = [t.strip("?,.'\"`") for t in query.split() if len(t) > 2]
+
+        matching = [
+            e
+            for e in entries
+            if any(
+                term.lower()
+                in (e.file_path + " " + (e.symbol or "") + " " + e.commit.subject).lower()
+                for term in terms
+            )
+        ] or entries[:max_events]
+
+        events: list[TimelineEvent] = []
+        for entry in matching[:max_events]:
+            pr_ref = f" (PR #{entry.pr_number})" if entry.pr_number else ""
+            citation = Citation(
+                source_type="git",
+                reference=f"commit {entry.commit.hash[:8]}{pr_ref}",
+                content_preview=entry.commit.subject,
+                timestamp=entry.commit.date,
+                metadata={
+                    "file_path": entry.file_path,
+                    "symbol": entry.symbol,
+                    "author": entry.commit.author,
+                },
+            )
+            events.append(
+                TimelineEvent(
+                    timestamp=entry.commit.date,
+                    source_type="git",
+                    summary=(
+                        f"{entry.change_type} {entry.file_path}"
+                        + (f" [{entry.symbol}]" if entry.symbol else "")
+                        + f": {entry.commit.subject}"
+                    ),
+                    citations=[citation],
+                    metadata={"commit_hash": entry.commit.hash},
+                )
+            )
+
+        return events
+
+    async def _slack_events(
+        self,
+        query: str,
+        bot_token: str,
+        channel_ids: list[str],
+    ) -> list[TimelineEvent]:
+        """Extract timeline events from Slack messages."""
+        from ..loaders.slack import SlackLoader
+
+        events: list[TimelineEvent] = []
+        terms = [t.lower().strip("?,.'\"`") for t in query.split() if len(t) > 2]
+
+        for channel_id in channel_ids:
+            loader = SlackLoader(bot_token=bot_token, channel_id=channel_id)
+            docs = await loader.aload()
+            for doc in docs:
+                text_lower = doc.text.lower()
+                if not any(term in text_lower for term in terms):
+                    continue
+                ts_str = str(doc.metadata.get("timestamp", ""))
+                try:
+                    ts = datetime.fromtimestamp(float(ts_str), tz=UTC)
+                except (ValueError, TypeError, OSError):
+                    ts = datetime.now(UTC)
+                citation = Citation(
+                    source_type="slack",
+                    reference=f"slack://{channel_id}/{ts_str}",
+                    content_preview=doc.text[:200],
+                    timestamp=ts,
+                    metadata=doc.metadata,
+                )
+                events.append(
+                    TimelineEvent(
+                        timestamp=ts,
+                        source_type="slack",
+                        summary=doc.text[:200],
+                        citations=[citation],
+                    )
+                )
+
+        return events
+
+    async def _email_events(
+        self,
+        query: str,
+        imap_server: str,
+        email_address: str,
+        password: str,
+        folder: str,
+    ) -> list[TimelineEvent]:
+        """Extract timeline events from email archives."""
+        from ..loaders.email import EmailLoader
+
+        loader = EmailLoader(
+            imap_server=imap_server,
+            email_address=email_address,
+            password=password,
+            folder=folder,
+        )
+        docs = await loader.aload()
+        terms = [t.lower().strip("?,.'\"`") for t in query.split() if len(t) > 2]
+        events: list[TimelineEvent] = []
+
+        for doc in docs:
+            text_lower = (doc.text + " " + doc.metadata.get("subject", "")).lower()
+            if not any(term in text_lower for term in terms):
+                continue
+            date_str = doc.metadata.get("date", "")
+            try:
+                ts = datetime.fromisoformat(date_str) if date_str else datetime.now(UTC)
+            except ValueError:
+                ts = datetime.now(UTC)
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=UTC)
+            citation = Citation(
+                source_type="email",
+                reference=f"email://{doc.metadata.get('email_id', 'unknown')}",
+                content_preview=doc.text[:200],
+                timestamp=ts,
+                metadata=doc.metadata,
+            )
+            events.append(
+                TimelineEvent(
+                    timestamp=ts,
+                    source_type="email",
+                    summary=f"{doc.metadata.get('subject', 'No subject')}: {doc.text[:100]}",
+                    citations=[citation],
+                )
+            )
+
+        return events
+
+    async def _markdown_events(
+        self,
+        query: str,
+        roots: list[Path],
+    ) -> list[TimelineEvent]:
+        """Extract timeline events from local markdown notes."""
+        terms = [t.lower().strip("?,.'\"`") for t in query.split() if len(t) > 2]
+        events: list[TimelineEvent] = []
+
+        for root in roots:
+            root = root.resolve()
+            if not root.exists():
+                continue
+            md_files = list(root.rglob("*.md"))
+            for md_file in md_files:
+                try:
+                    content = await asyncio.to_thread(
+                        md_file.read_text, encoding="utf-8"
+                    )
+                except Exception:
+                    continue
+                if not any(term in content.lower() for term in terms):
+                    continue
+                stat = md_file.stat()
+                ts = datetime.fromtimestamp(stat.st_mtime, tz=UTC)
+                citation = Citation(
+                    source_type="markdown",
+                    reference=f"file://{md_file}",
+                    content_preview=content[:200],
+                    timestamp=ts,
+                    metadata={"path": str(md_file)},
+                )
+                events.append(
+                    TimelineEvent(
+                        timestamp=ts,
+                        source_type="markdown",
+                        summary=f"Note: {md_file.name} — {content[:100]}",
+                        citations=[citation],
+                    )
+                )
+
+        return events

--- a/src/synapsekit/archaeology/timeline_reconstructor.py
+++ b/src/synapsekit/archaeology/timeline_reconstructor.py
@@ -40,9 +40,7 @@ class TimelineReconstructor:
 
         if slack_bot_token and slack_channel_ids:
             tasks.append(
-                asyncio.create_task(
-                    self._slack_events(query, slack_bot_token, slack_channel_ids)
-                )
+                asyncio.create_task(self._slack_events(query, slack_bot_token, slack_channel_ids))
             )
 
         if email_imap_server and email_address and email_password:
@@ -60,9 +58,7 @@ class TimelineReconstructor:
 
         if markdown_roots:
             tasks.append(
-                asyncio.create_task(
-                    self._markdown_events(query, [Path(r) for r in markdown_roots])
-                )
+                asyncio.create_task(self._markdown_events(query, [Path(r) for r in markdown_roots]))
             )
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
@@ -235,9 +231,7 @@ class TimelineReconstructor:
             md_files = list(root.rglob("*.md"))
             for md_file in md_files:
                 try:
-                    content = await asyncio.to_thread(
-                        md_file.read_text, encoding="utf-8"
-                    )
+                    content = await asyncio.to_thread(md_file.read_text, encoding="utf-8")
                 except Exception:
                     continue
                 if not any(term in content.lower() for term in terms):

--- a/src/synapsekit/archaeology/types.py
+++ b/src/synapsekit/archaeology/types.py
@@ -1,0 +1,152 @@
+"""Data types for Code Archaeology results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Literal
+
+SourceType = Literal["git", "markdown", "slack", "email", "mesh"]
+
+
+@dataclass(frozen=True)
+class Citation:
+    """A specific evidence reference supporting a claim."""
+
+    source_type: SourceType
+    reference: str  # e.g., "commit abc1234", "PR #42", "slack://C123/msg456"
+    content_preview: str  # First ~200 chars of the evidence
+    timestamp: datetime | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TimelineEvent:
+    """A single event in the chronological reconstruction."""
+
+    timestamp: datetime
+    source_type: SourceType
+    summary: str
+    citations: list[Citation] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CausalClaim:
+    """A causal relationship between events, with evidence."""
+
+    cause: str
+    effect: str
+    confidence: float  # 0.0–1.0
+    citations: list[Citation] = field(default_factory=list)
+    verified: bool = False  # True if NeuroSymbolicAgent plausibility check passed
+    reasoning: str = ""
+
+
+@dataclass(frozen=True)
+class EvolutionSnapshot:
+    """How a file/symbol changed at a specific version."""
+
+    version_hash: str
+    date: datetime
+    diff_summary: str
+    reason: str  # Extracted "why" from commit message/PR/linked discussion
+    citations: list[Citation] = field(default_factory=list)
+
+
+@dataclass
+class ArchaeologyResult:
+    """Complete result from an archaeology query."""
+
+    query: str
+    timeline: list[TimelineEvent] = field(default_factory=list)
+    causes: list[CausalClaim] = field(default_factory=list)
+    evolution: list[EvolutionSnapshot] = field(default_factory=list)
+    narrative: str = ""
+
+    @property
+    def all_citations(self) -> list[Citation]:
+        """Deduplicated list of all citations across timeline, causes, evolution."""
+        seen: set[str] = set()
+        result: list[Citation] = []
+        for event in self.timeline:
+            for c in event.citations:
+                if c.reference not in seen:
+                    seen.add(c.reference)
+                    result.append(c)
+        for claim in self.causes:
+            for c in claim.citations:
+                if c.reference not in seen:
+                    seen.add(c.reference)
+                    result.append(c)
+        for snap in self.evolution:
+            for c in snap.citations:
+                if c.reference not in seen:
+                    seen.add(c.reference)
+                    result.append(c)
+        return result
+
+    def to_markdown(self) -> str:
+        """Render result as a markdown report."""
+        lines: list[str] = [f"# Code Archaeology: {self.query}", ""]
+
+        if self.narrative:
+            lines.extend(["## Summary", self.narrative, ""])
+
+        if self.timeline:
+            lines.append("## Timeline")
+            for event in self.timeline:
+                date_str = event.timestamp.strftime("%Y-%m-%d %H:%M")
+                lines.append(f"- **{date_str}** [{event.source_type}]: {event.summary}")
+                for c in event.citations:
+                    lines.append(f"  - 📎 {c.reference}: {c.content_preview[:80]}")
+            lines.append("")
+
+        if self.causes:
+            lines.append("## Causal Chain")
+            for claim in self.causes:
+                verified = "✅" if claim.verified else "⚠️"
+                lines.append(
+                    f"- {verified} **{claim.cause}** → **{claim.effect}** "
+                    f"(confidence: {claim.confidence:.0%})"
+                )
+                if claim.reasoning:
+                    lines.append(f"  > {claim.reasoning}")
+                for c in claim.citations:
+                    lines.append(f"  - 📎 {c.reference}")
+            lines.append("")
+
+        if self.evolution:
+            lines.append("## Evolution History")
+            for snap in self.evolution:
+                date_str = snap.date.strftime("%Y-%m-%d")
+                lines.append(f"- **{date_str}** `{snap.version_hash[:8]}`: {snap.diff_summary}")
+                if snap.reason:
+                    lines.append(f"  > Why: {snap.reason}")
+            lines.append("")
+
+        all_cites = self.all_citations
+        if all_cites:
+            lines.append(f"## Citations ({len(all_cites)} sources)")
+            for i, c in enumerate(all_cites, 1):
+                lines.append(f"{i}. [{c.source_type}] {c.reference}")
+
+        return "\n".join(lines)
+
+
+@dataclass
+class SourceConfig:
+    """Configuration for archaeology data sources."""
+
+    repo_path: str = "."
+    include_git: bool = True
+    markdown_roots: list[str] = field(default_factory=list)
+    slack_bot_token: str | None = None
+    slack_channel_ids: list[str] = field(default_factory=list)
+    email_imap_server: str | None = None
+    email_address: str | None = None
+    email_password: str | None = None
+    email_folder: str = "INBOX"
+    mesh: Any | None = None  # Optional KnowledgeMesh instance
+    max_events: int = 200
+    min_citations_per_claim: int = 2

--- a/src/synapsekit/archaeology/types.py
+++ b/src/synapsekit/archaeology/types.py
@@ -37,7 +37,7 @@ class CausalClaim:
 
     cause: str
     effect: str
-    confidence: float  # 0.0–1.0
+    confidence: float  # 0.0-1.0
     citations: list[Citation] = field(default_factory=list)
     verified: bool = False  # True if NeuroSymbolicAgent plausibility check passed
     reasoning: str = ""

--- a/src/synapsekit/timetravel/evolution_index.py
+++ b/src/synapsekit/timetravel/evolution_index.py
@@ -154,6 +154,16 @@ class EvolutionIndex:
         self._entries = deduped
         return deduped
 
+    def ensure_built(self) -> list[EvolutionEntry]:
+        """Build entries if not already built, otherwise return the cached entries.
+
+        Lets callers share one `EvolutionIndex` across multiple consumers
+        without repeating the underlying `git log`/`git diff`/AST-parse walk.
+        """
+        if not self._entries:
+            self.build()
+        return self._entries
+
     def query(
         self,
         file_or_symbol: str,

--- a/tests/archaeology/__init__.py
+++ b/tests/archaeology/__init__.py
@@ -1,0 +1,1 @@
+"""Archaeology test package."""

--- a/tests/archaeology/test_archaeology.py
+++ b/tests/archaeology/test_archaeology.py
@@ -388,3 +388,47 @@ async def test_evolution_diff_trace_empty(git_repo: Path):
     assert isinstance(snapshots, list)
 
 
+from synapsekit.archaeology.agent import ArchaeologyAgent
+
+
+async def test_archaeology_agent_explain_git_only(git_repo: Path):
+    """Full integration test with git-only sources."""
+    llm = FakeLLM(response="AgentRegistry was created for dynamic agent dispatch.")
+    sources = SourceConfig(repo_path=str(git_repo), include_git=True, min_citations_per_claim=0)
+    agent = ArchaeologyAgent(sources=sources, llm=llm)
+    result = await agent.explain("Why does AgentRegistry exist?")
+
+    assert isinstance(result, ArchaeologyResult)
+    assert result.query == "Why does AgentRegistry exist?"
+    assert len(result.timeline) >= 1
+    assert len(result.evolution) >= 1
+    assert isinstance(result.narrative, str)
+    assert len(result.narrative) > 0
+
+
+async def test_archaeology_agent_no_llm(git_repo: Path):
+    """Agent works without LLM (causal linking and narrative disabled)."""
+    sources = SourceConfig(repo_path=str(git_repo))
+    agent = ArchaeologyAgent(sources=sources, llm=None)
+    # Force llm to None to test graceful degradation
+    agent.llm = None
+    agent.causal_linker = None
+    result = await agent.explain("AgentRegistry")
+
+    assert isinstance(result, ArchaeologyResult)
+    assert len(result.timeline) >= 1
+    assert result.narrative == ""
+    assert result.causes == []
+
+
+async def test_archaeology_agent_result_markdown(git_repo: Path):
+    """Verify the result can be rendered as markdown."""
+    llm = FakeLLM(response="Test narrative.")
+    sources = SourceConfig(repo_path=str(git_repo), min_citations_per_claim=0)
+    agent = ArchaeologyAgent(sources=sources, llm=llm)
+    result = await agent.explain("AgentRegistry")
+    md = result.to_markdown()
+    assert "# Code Archaeology:" in md
+
+
+

--- a/tests/archaeology/test_archaeology.py
+++ b/tests/archaeology/test_archaeology.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import subprocess
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -34,6 +34,31 @@ class FakeLLM(BaseLLM):
 
     async def stream(self, prompt: str, **kw) -> AsyncGenerator[str]:
         yield self.response
+
+
+class FakeLoader:
+    """Hand-written stand-in for a loader's `.aload()` boundary."""
+
+    def __init__(self, docs: list[Document]) -> None:
+        self._docs = docs
+
+    async def aload(self) -> list[Document]:
+        return self._docs
+
+
+@dataclass
+class FakeVerificationResult:
+    verified: bool
+
+
+class FakeVerifier:
+    """Hand-written stand-in for a NeuroSymbolicAgent-shaped verifier."""
+
+    def __init__(self, verified: bool) -> None:
+        self._verified = verified
+
+    async def solve(self, problem: str) -> FakeVerificationResult:
+        return FakeVerificationResult(verified=self._verified)
 
 
 def test_citation_construction():
@@ -233,52 +258,53 @@ async def test_timeline_empty_query(git_repo: Path):
     assert isinstance(events, list)
 
 
-async def test_timeline_slack_events(tmp_path: Path):
+async def test_timeline_slack_events(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     tr = TimelineReconstructor(repo_path=tmp_path)
-    mock_slack_doc = Document(
+    slack_doc = Document(
         text="Discussing why AgentRegistry was introduced in architecture review",
         metadata={"timestamp": "1700000000.0", "channel": "C123", "user": "U456"},
     )
-    with patch(
+    monkeypatch.setattr(
         "synapsekit.loaders.slack.SlackLoader.aload",
-        new=AsyncMock(return_value=[mock_slack_doc]),
-    ):
-        events = await tr.reconstruct(
-            "AgentRegistry",
-            include_git=False,
-            slack_bot_token="xoxb-fake",
-            slack_channel_ids=["C123"],
-        )
-        assert len(events) == 1
-        assert events[0].source_type == "slack"
-        assert "architecture review" in events[0].summary
+        FakeLoader([slack_doc]).aload,
+    )
+    events = await tr.reconstruct(
+        "AgentRegistry",
+        include_git=False,
+        slack_bot_token="xoxb-fake",
+        slack_channel_ids=["C123"],
+    )
+    assert len(events) == 1
+    assert events[0].source_type == "slack"
+    assert "architecture review" in events[0].summary
 
 
-async def test_timeline_email_events(tmp_path: Path):
+async def test_timeline_email_events(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     tr = TimelineReconstructor(repo_path=tmp_path)
-    mock_email_doc = Document(
+    email_doc = Document(
         text="AgentRegistry proposal thread body text",
         metadata={
             "subject": "Proposal: AgentRegistry",
             "from": "alice@synapsekit.dev",
-            "date": "2024-01-15T10:00:00+00:00",
+            "date": "Mon, 15 Jan 2024 10:00:00 +0000",
             "email_id": "101",
         },
     )
-    with patch(
+    monkeypatch.setattr(
         "synapsekit.loaders.email.EmailLoader.aload",
-        new=AsyncMock(return_value=[mock_email_doc]),
-    ):
-        events = await tr.reconstruct(
-            "AgentRegistry",
-            include_git=False,
-            email_imap_server="imap.fake.com",
-            email_address="me@fake.com",
-            email_password="fake",
-        )
-        assert len(events) == 1
-        assert events[0].source_type == "email"
-        assert "Proposal: AgentRegistry" in events[0].summary
+        FakeLoader([email_doc]).aload,
+    )
+    events = await tr.reconstruct(
+        "AgentRegistry",
+        include_git=False,
+        email_imap_server="imap.fake.com",
+        email_address="me@fake.com",
+        email_password="fake",
+    )
+    assert len(events) == 1
+    assert events[0].source_type == "email"
+    assert events[0].timestamp == datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+    assert "Proposal: AgentRegistry" in events[0].summary
 
 
 async def test_causal_linker_parses_claims():
@@ -352,12 +378,7 @@ async def test_causal_linker_with_verifier():
     )
     llm = FakeLLM(response=llm_response)
 
-    mock_verifier = MagicMock()
-    mock_result = MagicMock()
-    mock_result.verified = True
-    mock_verifier.solve = AsyncMock(return_value=mock_result)
-
-    linker = CausalLinker(llm, verifier=mock_verifier, min_citations=0)
+    linker = CausalLinker(llm, verifier=FakeVerifier(verified=True), min_citations=0)
     c = Citation(
         source_type="git",
         reference="commit abc",
@@ -387,7 +408,16 @@ async def test_evolution_diff_trace(git_repo: Path):
 async def test_evolution_diff_trace_empty(git_repo: Path):
     ed = EvolutionDiff(repo_path=git_repo)
     snapshots = await ed.trace("nonexistent_file.py")
-    assert isinstance(snapshots, list)
+    assert snapshots == []
+
+
+async def test_evolution_diff_trace_unmatched_nl_query_returns_empty(git_repo: Path):
+    """Regression: an unmatched natural-language query must not fall back to
+    returning the entire unfiltered repo history (the path ArchaeologyAgent.explain()
+    exercises for every query)."""
+    ed = EvolutionDiff(repo_path=git_repo)
+    snapshots = await ed.trace("why does something totally unrelated exist")
+    assert snapshots == []
 
 
 async def test_archaeology_agent_explain_git_only(git_repo: Path):

--- a/tests/archaeology/test_archaeology.py
+++ b/tests/archaeology/test_archaeology.py
@@ -370,3 +370,21 @@ async def test_causal_linker_with_verifier():
     assert len(claims) == 1
     assert claims[0].verified is True
 
+
+from synapsekit.archaeology.evolution_diff import EvolutionDiff
+
+
+async def test_evolution_diff_trace(git_repo: Path):
+    ed = EvolutionDiff(repo_path=git_repo)
+    snapshots = await ed.trace("agent.py")
+    assert len(snapshots) >= 1
+    assert all(isinstance(s, EvolutionSnapshot) for s in snapshots)
+    assert snapshots[0].version_hash
+
+
+async def test_evolution_diff_trace_empty(git_repo: Path):
+    ed = EvolutionDiff(repo_path=git_repo)
+    snapshots = await ed.trace("nonexistent_file.py")
+    assert isinstance(snapshots, list)
+
+

--- a/tests/archaeology/test_archaeology.py
+++ b/tests/archaeology/test_archaeology.py
@@ -3,22 +3,37 @@
 from __future__ import annotations
 
 import subprocess
+from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from synapsekit.archaeology.timeline_reconstructor import TimelineReconstructor
-from synapsekit.archaeology.types import (
+import synapsekit
+from synapsekit.archaeology import (
+    ArchaeologyAgent,
     ArchaeologyResult,
     CausalClaim,
+    CausalLinker,
     Citation,
+    EvolutionDiff,
     EvolutionSnapshot,
     SourceConfig,
     TimelineEvent,
+    TimelineReconstructor,
 )
+from synapsekit.llm.base import BaseLLM, LLMConfig
 from synapsekit.loaders.base import Document
+
+
+class FakeLLM(BaseLLM):
+    def __init__(self, response: str = "") -> None:
+        super().__init__(LLMConfig(model="fake", api_key="", provider="fake"))
+        self.response = response
+
+    async def stream(self, prompt: str, **kw) -> AsyncGenerator[str]:
+        yield self.response
 
 
 def test_citation_construction():
@@ -266,20 +281,6 @@ async def test_timeline_email_events(tmp_path: Path):
         assert "Proposal: AgentRegistry" in events[0].summary
 
 
-from collections.abc import AsyncGenerator
-from synapsekit.llm.base import BaseLLM, LLMConfig
-from synapsekit.archaeology.causal_linker import CausalLinker
-
-
-class FakeLLM(BaseLLM):
-    def __init__(self, response: str = "") -> None:
-        super().__init__(LLMConfig(model="fake", api_key="", provider="fake"))
-        self.response = response
-
-    async def stream(self, prompt: str, **kw) -> AsyncGenerator[str]:
-        yield self.response
-
-
 async def test_causal_linker_parses_claims():
     llm_response = (
         "CAUSE: PR #718 introduced AgentRegistry\n"
@@ -350,14 +351,18 @@ async def test_causal_linker_with_verifier():
         "---"
     )
     llm = FakeLLM(response=llm_response)
-    
+
     mock_verifier = MagicMock()
     mock_result = MagicMock()
     mock_result.verified = True
     mock_verifier.solve = AsyncMock(return_value=mock_result)
 
     linker = CausalLinker(llm, verifier=mock_verifier, min_citations=0)
-    c = Citation(source_type="git", reference="commit abc", content_preview="Issue #718 required dynamic agents")
+    c = Citation(
+        source_type="git",
+        reference="commit abc",
+        content_preview="Issue #718 required dynamic agents",
+    )
     events = [
         TimelineEvent(
             timestamp=datetime(2024, 1, 1, tzinfo=UTC),
@@ -369,9 +374,6 @@ async def test_causal_linker_with_verifier():
     claims = await linker.link(events, "AgentRegistry")
     assert len(claims) == 1
     assert claims[0].verified is True
-
-
-from synapsekit.archaeology.evolution_diff import EvolutionDiff
 
 
 async def test_evolution_diff_trace(git_repo: Path):
@@ -386,9 +388,6 @@ async def test_evolution_diff_trace_empty(git_repo: Path):
     ed = EvolutionDiff(repo_path=git_repo)
     snapshots = await ed.trace("nonexistent_file.py")
     assert isinstance(snapshots, list)
-
-
-from synapsekit.archaeology.agent import ArchaeologyAgent
 
 
 async def test_archaeology_agent_explain_git_only(git_repo: Path):
@@ -431,4 +430,15 @@ async def test_archaeology_agent_result_markdown(git_repo: Path):
     assert "# Code Archaeology:" in md
 
 
-
+def test_archaeology_exports():
+    """Verify archaeology classes are accessible from top-level synapsekit."""
+    assert hasattr(synapsekit, "ArchaeologyAgent")
+    assert hasattr(synapsekit, "ArchaeologyResult")
+    assert hasattr(synapsekit, "CausalClaim")
+    assert hasattr(synapsekit, "Citation")
+    assert hasattr(synapsekit, "TimelineEvent")
+    assert hasattr(synapsekit, "SourceConfig")
+    assert hasattr(synapsekit, "TimelineReconstructor")
+    assert hasattr(synapsekit, "EvolutionDiff")
+    assert hasattr(synapsekit, "EvolutionSnapshot")
+    assert hasattr(synapsekit.archaeology, "CausalLinker")

--- a/tests/archaeology/test_archaeology.py
+++ b/tests/archaeology/test_archaeology.py
@@ -1,0 +1,131 @@
+"""Unit tests for Code Archaeology Agent (Issue #744)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from synapsekit.archaeology.types import (
+    ArchaeologyResult,
+    CausalClaim,
+    Citation,
+    EvolutionSnapshot,
+    SourceConfig,
+    TimelineEvent,
+)
+
+
+def test_citation_construction():
+    c = Citation(
+        source_type="git",
+        reference="commit abc1234",
+        content_preview="Initial commit",
+        timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    assert c.source_type == "git"
+    assert c.reference == "commit abc1234"
+    assert c.timestamp is not None
+
+
+def test_timeline_event_construction():
+    c = Citation(source_type="git", reference="commit abc", content_preview="test")
+    event = TimelineEvent(
+        timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+        source_type="git",
+        summary="Added file.py",
+        citations=[c],
+    )
+    assert event.source_type == "git"
+    assert len(event.citations) == 1
+
+
+def test_causal_claim_construction():
+    claim = CausalClaim(
+        cause="PR #42 added caching",
+        effect="Response time improved 3x",
+        confidence=0.85,
+        verified=True,
+        reasoning="Commit message explicitly mentions perf improvement",
+    )
+    assert claim.verified is True
+    assert claim.confidence == 0.85
+
+
+def test_evolution_snapshot_construction():
+    snap = EvolutionSnapshot(
+        version_hash="abc1234",
+        date=datetime(2024, 6, 15, tzinfo=UTC),
+        diff_summary="modified agent.py [AgentRegistry] (+20/-5)",
+        reason="Add register method to AgentRegistry (#719)",
+    )
+    assert snap.version_hash == "abc1234"
+
+
+def test_archaeology_result_to_markdown():
+    c = Citation(source_type="git", reference="commit abc", content_preview="test commit")
+    result = ArchaeologyResult(
+        query="Why does AgentRegistry exist?",
+        timeline=[
+            TimelineEvent(
+                timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+                source_type="git",
+                summary="Created AgentRegistry",
+                citations=[c],
+            ),
+        ],
+        causes=[
+            CausalClaim(
+                cause="Need for dynamic agent dispatch",
+                effect="AgentRegistry was created",
+                confidence=0.9,
+                citations=[c],
+                verified=True,
+            ),
+        ],
+        evolution=[
+            EvolutionSnapshot(
+                version_hash="abc1234",
+                date=datetime(2024, 1, 1, tzinfo=UTC),
+                diff_summary="added agent_registry.py",
+                reason="Initial creation",
+                citations=[c],
+            ),
+        ],
+        narrative="AgentRegistry was created to enable dynamic agent dispatch.",
+    )
+    md = result.to_markdown()
+    assert "AgentRegistry" in md
+    assert "## Timeline" in md
+    assert "## Causal Chain" in md
+    assert "## Evolution History" in md
+    assert "## Citations" in md
+
+
+def test_archaeology_result_all_citations_deduplication():
+    c1 = Citation(source_type="git", reference="commit abc", content_preview="test")
+    c2 = Citation(source_type="slack", reference="slack://C1/123", content_preview="msg")
+    result = ArchaeologyResult(
+        query="test",
+        timeline=[
+            TimelineEvent(
+                timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+                source_type="git",
+                summary="test",
+                citations=[c1, c2],
+            ),
+        ],
+        causes=[
+            CausalClaim(cause="a", effect="b", confidence=0.5, citations=[c1]),
+        ],
+    )
+    all_cites = result.all_citations
+    assert len(all_cites) == 2  # c1 deduplicated
+
+
+def test_source_config_defaults():
+    cfg = SourceConfig()
+    assert cfg.repo_path == "."
+    assert cfg.include_git is True
+    assert cfg.min_citations_per_claim == 2
+    assert cfg.slack_bot_token is None

--- a/tests/archaeology/test_archaeology.py
+++ b/tests/archaeology/test_archaeology.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -264,3 +264,109 @@ async def test_timeline_email_events(tmp_path: Path):
         assert len(events) == 1
         assert events[0].source_type == "email"
         assert "Proposal: AgentRegistry" in events[0].summary
+
+
+from collections.abc import AsyncGenerator
+from synapsekit.llm.base import BaseLLM, LLMConfig
+from synapsekit.archaeology.causal_linker import CausalLinker
+
+
+class FakeLLM(BaseLLM):
+    def __init__(self, response: str = "") -> None:
+        super().__init__(LLMConfig(model="fake", api_key="", provider="fake"))
+        self.response = response
+
+    async def stream(self, prompt: str, **kw) -> AsyncGenerator[str]:
+        yield self.response
+
+
+async def test_causal_linker_parses_claims():
+    llm_response = (
+        "CAUSE: PR #718 introduced AgentRegistry\n"
+        "EFFECT: Agents could be dynamically dispatched\n"
+        "CONFIDENCE: 0.9\n"
+        "REASONING: Commit message explicitly states purpose\n"
+        "---\n"
+        "CAUSE: Feature request for multi-agent systems\n"
+        "EFFECT: AgentRegistry added register method\n"
+        "CONFIDENCE: 0.7\n"
+        "REASONING: Follow-up PR extended the class\n"
+        "---"
+    )
+    llm = FakeLLM(response=llm_response)
+    linker = CausalLinker(llm, min_citations=0)
+
+    c = Citation(source_type="git", reference="commit abc", content_preview="AgentRegistry")
+    events = [
+        TimelineEvent(
+            timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+            source_type="git",
+            summary="Created AgentRegistry (#718)",
+            citations=[c],
+        ),
+    ]
+    claims = await linker.link(events, "AgentRegistry")
+    assert len(claims) == 2
+    assert claims[0].cause == "PR #718 introduced AgentRegistry"
+    assert claims[0].confidence == 0.9
+
+
+async def test_causal_linker_min_citations_filter():
+    llm_response = (
+        "CAUSE: Unknown cause\n"
+        "EFFECT: Unknown effect\n"
+        "CONFIDENCE: 0.3\n"
+        "REASONING: Weak evidence\n"
+        "---"
+    )
+    llm = FakeLLM(response=llm_response)
+    linker = CausalLinker(llm, min_citations=2)
+
+    events = [
+        TimelineEvent(
+            timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+            source_type="git",
+            summary="Some event",
+            citations=[],
+        ),
+    ]
+    claims = await linker.link(events, "test")
+    assert len(claims) == 0  # Filtered out due to insufficient citations
+
+
+async def test_causal_linker_empty_events():
+    llm = FakeLLM()
+    linker = CausalLinker(llm)
+    claims = await linker.link([], "test")
+    assert claims == []
+
+
+async def test_causal_linker_with_verifier():
+    llm_response = (
+        "CAUSE: Issue #718 required dynamic agents\n"
+        "EFFECT: AgentRegistry was created\n"
+        "CONFIDENCE: 0.95\n"
+        "REASONING: Strong evidence from issue discussion\n"
+        "---"
+    )
+    llm = FakeLLM(response=llm_response)
+    
+    mock_verifier = MagicMock()
+    mock_result = MagicMock()
+    mock_result.verified = True
+    mock_verifier.solve = AsyncMock(return_value=mock_result)
+
+    linker = CausalLinker(llm, verifier=mock_verifier, min_citations=0)
+    c = Citation(source_type="git", reference="commit abc", content_preview="Issue #718 required dynamic agents")
+    events = [
+        TimelineEvent(
+            timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+            source_type="git",
+            summary="AgentRegistry created for #718",
+            citations=[c],
+        ),
+    ]
+    claims = await linker.link(events, "AgentRegistry")
+    assert len(claims) == 1
+    assert claims[0].verified is True
+

--- a/tests/archaeology/test_archaeology.py
+++ b/tests/archaeology/test_archaeology.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import subprocess
 from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from synapsekit.archaeology.timeline_reconstructor import TimelineReconstructor
 from synapsekit.archaeology.types import (
     ArchaeologyResult,
     CausalClaim,
@@ -14,6 +18,7 @@ from synapsekit.archaeology.types import (
     SourceConfig,
     TimelineEvent,
 )
+from synapsekit.loaders.base import Document
 
 
 def test_citation_construction():
@@ -129,3 +134,133 @@ def test_source_config_defaults():
     assert cfg.include_git is True
     assert cfg.min_citations_per_claim == 2
     assert cfg.slack_bot_token is None
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """Create a temporary git repository with multi-commit history."""
+    subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    (tmp_path / "agent.py").write_text(
+        "class AgentRegistry:\n    def __init__(self):\n        pass\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Initial AgentRegistry (#718)"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    (tmp_path / "agent.py").write_text(
+        "class AgentRegistry:\n    def __init__(self):\n        pass\n\n    def register(self):\n        pass\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add register method (#719)"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    return tmp_path
+
+
+async def test_timeline_git_events(git_repo: Path):
+    tr = TimelineReconstructor(repo_path=git_repo)
+    events = await tr.reconstruct("AgentRegistry", include_git=True)
+    assert len(events) >= 1
+    assert all(e.source_type == "git" for e in events)
+    assert any("AgentRegistry" in e.summary for e in events)
+
+
+async def test_timeline_events_sorted_chronologically(git_repo: Path):
+    tr = TimelineReconstructor(repo_path=git_repo)
+    events = await tr.reconstruct("AgentRegistry", include_git=True)
+    timestamps = [e.timestamp for e in events]
+    assert timestamps == sorted(timestamps)
+
+
+async def test_timeline_markdown_events(tmp_path: Path):
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    (notes_dir / "design.md").write_text(
+        "AgentRegistry was designed for dynamic dispatch",
+        encoding="utf-8",
+    )
+    tr = TimelineReconstructor(repo_path=tmp_path)
+    events = await tr.reconstruct(
+        "AgentRegistry",
+        include_git=False,
+        markdown_roots=[notes_dir],
+    )
+    assert len(events) >= 1
+    assert events[0].source_type == "markdown"
+
+
+async def test_timeline_empty_query(git_repo: Path):
+    tr = TimelineReconstructor(repo_path=git_repo)
+    events = await tr.reconstruct("xyznonexistent", include_git=True)
+    assert isinstance(events, list)
+
+
+async def test_timeline_slack_events(tmp_path: Path):
+    tr = TimelineReconstructor(repo_path=tmp_path)
+    mock_slack_doc = Document(
+        text="Discussing why AgentRegistry was introduced in architecture review",
+        metadata={"timestamp": "1700000000.0", "channel": "C123", "user": "U456"},
+    )
+    with patch(
+        "synapsekit.loaders.slack.SlackLoader.aload",
+        new=AsyncMock(return_value=[mock_slack_doc]),
+    ):
+        events = await tr.reconstruct(
+            "AgentRegistry",
+            include_git=False,
+            slack_bot_token="xoxb-fake",
+            slack_channel_ids=["C123"],
+        )
+        assert len(events) == 1
+        assert events[0].source_type == "slack"
+        assert "architecture review" in events[0].summary
+
+
+async def test_timeline_email_events(tmp_path: Path):
+    tr = TimelineReconstructor(repo_path=tmp_path)
+    mock_email_doc = Document(
+        text="AgentRegistry proposal thread body text",
+        metadata={
+            "subject": "Proposal: AgentRegistry",
+            "from": "alice@synapsekit.dev",
+            "date": "2024-01-15T10:00:00+00:00",
+            "email_id": "101",
+        },
+    )
+    with patch(
+        "synapsekit.loaders.email.EmailLoader.aload",
+        new=AsyncMock(return_value=[mock_email_doc]),
+    ):
+        events = await tr.reconstruct(
+            "AgentRegistry",
+            include_git=False,
+            email_imap_server="imap.fake.com",
+            email_address="me@fake.com",
+            email_password="fake",
+        )
+        assert len(events) == 1
+        assert events[0].source_type == "email"
+        assert "Proposal: AgentRegistry" in events[0].summary


### PR DESCRIPTION
Closes #744

## Summary
Implements the **Code Archaeology Agent** (issue #744) that fuses git log, markdown notes, and (opt-in) Slack/email archives to reconstruct *why* code exists in its current form.

## Components
- **ArchaeologyAgent** — orchestrates multi-source evidence extraction and narrative synthesis
- **TimelineReconstructor** — merges multi-source events chronologically across git, local markdown, Slack, and email
- **CausalLinker** — extracts and verifies causal claims using LLM + optional \NeuroSymbolicAgent\ for plausibility checks
- **EvolutionDiff** — tracks how code evolved with rationale extracted from commit context and diffs

## Design
- Reuses existing \	imetravel\ (\GitBackend\, \EvolutionIndex\), \loaders\ (\SlackLoader\, \EmailLoader\), and \symbolic\ (\NeuroSymbolicAgent\) modules
- Zero new hard dependencies (external loaders are behind existing optional extras)
- All public APIs are async-first with full type hints

## Testing
- Unit & integration tests in \	ests/archaeology/test_archaeology.py\ (23 tests, all passing)
- Full regression suite: 1986 passed, 63 skipped in test suite
- Ruff lint checks clean