### PR TITLE
feat: add sandboxed PC Twin for issue #747

### DIFF
--- a/docs/pc-sandbox.md
+++ b/docs/pc-sandbox.md
@@ -1,0 +1,99 @@
+# Sandboxed PC Twin
+
+`PCSandbox` provides a reviewable working copy for destructive agent tasks. The
+agent operates on the copy, while the original host tree remains unchanged
+until a diff has been evaluated and explicitly applied.
+
+## Basic flow
+
+```python
+from synapsekit.sandbox import CallableEvalGate, PCSandbox
+
+
+async with PCSandbox(base=".", backend="docker", network="none") as sandbox:
+    result = await sandbox.environment.exec(("python", "-c", "open('note.txt', 'w').write('ok')"))
+    diff = await sandbox.diff()
+    receipt = await sandbox.evaluate(
+        CallableEvalGate(lambda bundle, _environment: len(bundle.changes) == 1),
+        diff,
+    )
+    if receipt.passed:
+        await sandbox.apply(diff, receipt)
+```
+
+`PCSandbox.snapshot()` yields the environment directly. A process that needs
+to keep a session for CLI review can use `PCSandbox.start()` and later
+`PCSandbox.attach(session_id=...)`.
+
+## Safety properties
+
+- The default network policy is `none`; network access must be selected
+  explicitly.
+- Docker containers drop Linux capabilities, use a read-only root filesystem,
+  mount only the sandbox work tree read-write, apply a PID limit, and disable
+  privilege escalation.
+- Paths in a diff are normalized host-relative paths. Absolute paths,
+  traversal, duplicate operations, escaping symlinks, and unsupported special
+  files are rejected.
+- Applying a diff performs a preflight conflict check against the host, writes
+  through temporary files, creates a sibling journal/backups, verifies hashes,
+  and rolls back on an apply error.
+- `EvalReceipt` is bound to the exact diff digest. A receipt for another bundle
+  cannot authorize an apply.
+- Host credential locations are excluded from the copied tree by default
+  (`.ssh`, cloud credential directories, package-manager credential files,
+  `.env`, and `.synapsekit`). Use explicit include/exclude rules for a more
+  restricted task scope.
+
+## Marketplace agents and audit
+
+`PCSandbox` implements the marketplace `AgentSandbox` contract. Pass it to an
+installed agent and its verified source tree is copied into the sandbox's
+private `.synapsekit/agents` runtime area; it is never mounted directly from
+the host and is excluded from the host diff. The manifest entrypoint is run as
+`python -I ENTRYPOINT --prompt PROMPT` without a shell. It must therefore use
+that argv contract.
+
+Sandbox lifecycle calls, command results, and computer-use observation/action
+metadata are added to the environment's hash-chained audit trace. Typed text
+and screenshot bytes are not copied into those events. To export it:
+
+```python
+from synapsekit.audit import SigningPolicy
+
+path = sandbox.environment.export_audit_bundle(
+    "sandbox.audit.zip",
+    SigningPolicy.ed25519(),
+)
+```
+
+## Backends
+
+`docker` is the production backend when Docker is available. `orbstack` uses
+the Docker-compatible runtime on macOS. `fake` is intentionally a local
+process backend for deterministic tests and development only; it is not a
+security boundary.
+
+`lima` and `firecracker` probe for their host binaries but fail closed until a
+caller supplies the VM/kernel/rootfs/device policy required for a safe mount
+and network configuration. They must not silently fall back to an unisolated
+local process.
+
+The current filesystem overlay is a deterministic materialized copy. Backends
+report `native_cow=False` unless they provide a native copy-on-write layer, so
+the 50 GB / 30 second native-CoW acceptance target must be validated by the
+runtime-specific integration work rather than inferred from the generic copy.
+
+## CLI
+
+```text
+synapse sandbox spawn --base . --backend docker --network none
+synapse sandbox diff SESSION_ID --output changes.zip
+synapse sandbox apply changes.zip --receipt receipt.json --yes
+synapse sandbox discard SESSION_ID
+```
+
+`apply` requires both a receipt and `--yes`. Review the generated diff before
+authorizing it. The CLI stores session metadata under
+`~/.synapsekit/sandboxes` unless `--state-dir` is supplied.
+

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -150,6 +150,17 @@ from .agents import (
     requires_human_confirmation,
     tool,
 )
+from .archaeology import (
+    ArchaeologyAgent,
+    ArchaeologyResult,
+    CausalClaim,
+    Citation,
+    EvolutionDiff,
+    EvolutionSnapshot,
+    SourceConfig,
+    TimelineEvent,
+    TimelineReconstructor,
+)
 from .audit import (
     AuditMetrics,
     AuditRecord,
@@ -766,6 +777,16 @@ __all__ = [
     "EvolutionEntry",
     "EvolutionIndex",
     "GitBackend",
+    # Code Archaeology
+    "ArchaeologyAgent",
+    "ArchaeologyResult",
+    "CausalClaim",
+    "Citation",
+    "EvolutionDiff",
+    "EvolutionSnapshot",
+    "SourceConfig",
+    "TimelineEvent",
+    "TimelineReconstructor",
     # Cost intelligence
     "CostTracker",
     "CostRecord",

--- a/src/synapsekit/__init__.py
+++ b/src/synapsekit/__init__.py
@@ -1,5 +1,5 @@
 """
-SynapseKit — lightweight, async-first RAG framework.
+SynapseKit â€” lightweight, async-first RAG framework.
 
 3-line happy path:
 
@@ -1414,3 +1414,33 @@ def __getattr__(name: str):
         globals()[name] = cls
         return cls
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+_LAZY_IMPORTS.update(
+    {
+        "ApplyConflictError": "sandbox",
+        "BackendUnavailableError": "sandbox",
+        "CallableEvalGate": "sandbox",
+        "CommandEvalGate": "sandbox",
+        "DiffBundle": "sandbox",
+        "EvalReceipt": "sandbox",
+        "FsOverlay": "sandbox",
+        "PCSandbox": "sandbox",
+        "SandboxConfig": "sandbox",
+        "SandboxState": "sandbox",
+    }
+)
+__all__.extend(
+    [
+        "ApplyConflictError",
+        "BackendUnavailableError",
+        "CallableEvalGate",
+        "CommandEvalGate",
+        "DiffBundle",
+        "EvalReceipt",
+        "FsOverlay",
+        "PCSandbox",
+        "SandboxConfig",
+        "SandboxState",
+    ]
+)

--- a/src/synapsekit/agents/tools/python_repl.py
+++ b/src/synapsekit/agents/tools/python_repl.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import io
 import logging
 import math
 import multiprocessing
+import pickle
 import platform
+import queue
 import signal
 import sys
 from typing import Any
@@ -19,22 +22,40 @@ class _CodeTimeoutError(Exception):
     """Raised when code execution times out."""
 
 
+def _picklable_namespace(namespace: dict[str, Any]) -> dict[str, Any]:
+    """Keep only serializable user bindings for the Windows child-process result."""
+
+    result: dict[str, Any] = {}
+    for key, value in namespace.items():
+        if key == "__builtins__":
+            continue
+        try:
+            pickle.dumps(value)
+        except (pickle.PicklingError, TypeError, AttributeError):
+            continue
+        result[key] = value
+    return result
+
+
 def _exec_with_capture(code: str, namespace: dict, output_queue: multiprocessing.Queue) -> None:
     """Execute code in a subprocess and send results back via queue.
 
     Used for Windows timeout implementation with multiprocessing.
     """
+
     old_stdout = sys.stdout
     sys.stdout = buf = io.StringIO()
 
     try:
         exec(code, namespace)
         output = buf.getvalue()
-        # Send back (success, output, error, namespace)
-        output_queue.put((True, output, None, namespace))
+        # ``exec`` injects a large ``__builtins__`` mapping. Returning it
+        # through a multiprocessing queue can deadlock the child while the
+        # parent waits in ``join``; return only picklable user bindings.
+        output_queue.put((True, output, None, _picklable_namespace(namespace)))
     except Exception as e:
         error_msg = f"{type(e).__name__}: {e}"
-        output_queue.put((False, "", error_msg, namespace))
+        output_queue.put((False, "", error_msg, _picklable_namespace(namespace)))
     finally:
         sys.stdout = old_stdout
 
@@ -54,7 +75,7 @@ class PythonREPLTool(BaseTool):
     description = (
         "Execute Python code and return its output. "
         "Input: a Python code string. Use print() to produce output. "
-        "WARNING: executes real Python — only use in trusted environments."
+        "WARNING: executes real Python code; only use in trusted environments."
     )
     parameters = {
         "type": "object",
@@ -90,6 +111,7 @@ class PythonREPLTool(BaseTool):
 
     async def _run_unix(self, code: str) -> ToolResult:
         """Execute code with signal.SIGALRM timeout (Unix/Linux)."""
+
         old_stdout = sys.stdout
         sys.stdout = buf = io.StringIO()
 
@@ -115,47 +137,54 @@ class PythonREPLTool(BaseTool):
             signal.alarm(0)  # type: ignore[attr-defined]
 
     async def _run_windows(self, code: str) -> ToolResult:
-        """Execute code with multiprocessing timeout (Windows).
+        """Execute code with a child process and an enforced Windows timeout.
 
-        Note: Namespace persistence limited to picklable objects.
+        The parent drains the result queue before joining the child. Joining
+        first can deadlock when a Windows queue feeder is still flushing its
+        payload, which made even a simple print appear to time out.
         """
-        output_queue: multiprocessing.Queue = multiprocessing.Queue()
 
-        # Create process to execute code
+        output_queue: multiprocessing.Queue = multiprocessing.Queue()
         process = multiprocessing.Process(
             target=_exec_with_capture, args=(code, self._namespace.copy(), output_queue)
         )
-
         process.start()
-        process.join(timeout=self.timeout)
-
-        if process.is_alive():
-            # Timeout occurred
-            process.terminate()
-            process.join(timeout=1.0)  # Wait for graceful termination
+        # Windows uses spawn, so importing the interpreter and test environment
+        # can take longer than a short user-code timeout. Count that bounded
+        # startup cost separately from the requested execution budget.
+        wait_timeout = self.timeout + 5.0
+        try:
+            success, output, error, updated_namespace = await asyncio.to_thread(
+                output_queue.get,
+                True,
+                wait_timeout,
+            )
+        except queue.Empty:
             if process.is_alive():
-                process.kill()  # Force kill if still running
+                process.terminate()
+                process.join(timeout=1.0)
+                if process.is_alive():
+                    process.kill()
             return ToolResult(
                 output="", error=f"Code execution timed out after {self.timeout} seconds"
             )
+        finally:
+            if process.is_alive():
+                process.join(timeout=1.0)
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=1.0)
+            output_queue.close()
+            output_queue.join_thread()
 
-        # Process completed, get results
-        if not output_queue.empty():
-            success, output, error, updated_namespace = output_queue.get()
+        with contextlib.suppress(Exception):
+            self._namespace.update(updated_namespace)
 
-            # Update namespace with picklable objects from subprocess
-            # This allows persistence of basic types but not complex objects
-            with contextlib.suppress(Exception):
-                self._namespace.update(updated_namespace)
-
-            if success:
-                return ToolResult(output=output or "(no output)")
-            else:
-                return ToolResult(output="", error=error)
-        else:
-            # Process died without sending results
-            return ToolResult(output="", error="Code execution failed unexpectedly")
+        if success:
+            return ToolResult(output=output or "(no output)")
+        return ToolResult(output="", error=error)
 
     def reset(self) -> None:
         """Clear the persistent namespace between runs."""
+
         self._namespace.clear()

--- a/src/synapsekit/agents/tools/shell.py
+++ b/src/synapsekit/agents/tools/shell.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import shlex
 from typing import Any
 
@@ -10,6 +11,32 @@ from ..base import BaseTool, ToolResult
 # If any appear while an allow-list is enforced, the command is rejected rather
 # than executed, closing the ``echo hi & curl evil`` allow-list bypass.
 _SHELL_METACHARACTERS = ("&", "|", ";", "`", "$(", "${", ">", "<", "\n", "\r", "(", ")")
+
+
+def _portable_builtin(argv: list[str]) -> ToolResult | None:
+    """Implement the few POSIX shell builtins used as direct commands on Windows.
+
+    ``create_subprocess_exec`` deliberately avoids a shell, so Windows cannot
+    resolve ``echo``, ``true``, or ``false``. Emulating those commands keeps
+    direct execution and the allow-list boundary intact; no user-provided text
+    is ever passed to ``cmd.exe``.
+    """
+
+    if os.name != "nt":
+        return None
+    command = argv[0].casefold()
+    if command == "echo":
+        values = argv[1:]
+        newline = True
+        if values and values[0] == "-n":
+            values = values[1:]
+            newline = False
+        return ToolResult(output=" ".join(values) + ("\n" if newline else ""))
+    if command == "true":
+        return ToolResult(output="")
+    if command == "false":
+        return ToolResult(output="", error="Exit code 1:")
+    return None
 
 
 class ShellTool(BaseTool):
@@ -42,6 +69,7 @@ class ShellTool(BaseTool):
 
     async def run(self, command: str = "", **kwargs: Any) -> ToolResult:
         """Execute the shell command."""
+
         target = command or kwargs.get("input", "")
         if not target:
             return ToolResult(output="", error="No command provided.")
@@ -73,6 +101,10 @@ class ShellTool(BaseTool):
                         f"{metachar!r} while an allow-list is enforced."
                     ),
                 )
+
+        builtin_result = _portable_builtin(argv)
+        if builtin_result is not None:
+            return builtin_result
 
         try:
             # Always exec the parsed argv (never shell=True). This runs the

--- a/src/synapsekit/archaeology/__init__.py
+++ b/src/synapsekit/archaeology/__init__.py
@@ -1,5 +1,6 @@
 """Code Archaeology Agent — reconstruct why code decisions were made."""
 
+from .causal_linker import CausalLinker
 from .timeline_reconstructor import TimelineReconstructor
 from .types import (
     ArchaeologyResult,
@@ -13,6 +14,7 @@ from .types import (
 __all__ = [
     "ArchaeologyResult",
     "CausalClaim",
+    "CausalLinker",
     "Citation",
     "EvolutionSnapshot",
     "SourceConfig",

--- a/src/synapsekit/archaeology/__init__.py
+++ b/src/synapsekit/archaeology/__init__.py
@@ -1,5 +1,6 @@
 """Code Archaeology Agent — reconstruct why code decisions were made."""
 
+from .agent import ArchaeologyAgent
 from .causal_linker import CausalLinker
 from .evolution_diff import EvolutionDiff
 from .timeline_reconstructor import TimelineReconstructor
@@ -13,6 +14,7 @@ from .types import (
 )
 
 __all__ = [
+    "ArchaeologyAgent",
     "ArchaeologyResult",
     "CausalClaim",
     "CausalLinker",

--- a/src/synapsekit/archaeology/__init__.py
+++ b/src/synapsekit/archaeology/__init__.py
@@ -1,6 +1,7 @@
 """Code Archaeology Agent — reconstruct why code decisions were made."""
 
 from .causal_linker import CausalLinker
+from .evolution_diff import EvolutionDiff
 from .timeline_reconstructor import TimelineReconstructor
 from .types import (
     ArchaeologyResult,
@@ -16,6 +17,7 @@ __all__ = [
     "CausalClaim",
     "CausalLinker",
     "Citation",
+    "EvolutionDiff",
     "EvolutionSnapshot",
     "SourceConfig",
     "TimelineEvent",

--- a/src/synapsekit/archaeology/__init__.py
+++ b/src/synapsekit/archaeology/__init__.py
@@ -1,5 +1,6 @@
 """Code Archaeology Agent — reconstruct why code decisions were made."""
 
+from .timeline_reconstructor import TimelineReconstructor
 from .types import (
     ArchaeologyResult,
     CausalClaim,
@@ -16,4 +17,5 @@ __all__ = [
     "EvolutionSnapshot",
     "SourceConfig",
     "TimelineEvent",
+    "TimelineReconstructor",
 ]

--- a/src/synapsekit/archaeology/__init__.py
+++ b/src/synapsekit/archaeology/__init__.py
@@ -1,0 +1,19 @@
+"""Code Archaeology Agent — reconstruct why code decisions were made."""
+
+from .types import (
+    ArchaeologyResult,
+    CausalClaim,
+    Citation,
+    EvolutionSnapshot,
+    SourceConfig,
+    TimelineEvent,
+)
+
+__all__ = [
+    "ArchaeologyResult",
+    "CausalClaim",
+    "Citation",
+    "EvolutionSnapshot",
+    "SourceConfig",
+    "TimelineEvent",
+]

--- a/src/synapsekit/archaeology/agent.py
+++ b/src/synapsekit/archaeology/agent.py
@@ -1,0 +1,198 @@
+"""ArchaeologyAgent — reconstruct why code exists by fusing multi-source evidence."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ..llm._factory import make_llm
+from ..llm.base import BaseLLM
+from .causal_linker import CausalLinker
+from .evolution_diff import EvolutionDiff
+from .timeline_reconstructor import TimelineReconstructor
+from .types import ArchaeologyResult, SourceConfig
+
+if TYPE_CHECKING:
+    from ..symbolic.agent import NeuroSymbolicAgent
+
+logger = logging.getLogger(__name__)
+
+_NARRATIVE_PROMPT = """\
+You are a Code Archaeology expert. Based on the following evidence, write a
+clear, developer-friendly explanation answering: "{query}"
+
+## Timeline ({n_events} events from {n_sources} sources)
+{timeline_summary}
+
+## Causal Chain ({n_claims} causal links identified)
+{causal_summary}
+
+## Evolution History ({n_snapshots} versions)
+{evolution_summary}
+
+Write a concise but comprehensive narrative that:
+1. Explains WHY the code exists in its current form
+2. Traces the decision chain that led to this state
+3. Cites specific evidence (commits, PRs, messages, notes)
+4. Highlights any still-justified vs. potentially outdated decisions
+"""
+
+
+class ArchaeologyAgent:
+    """Agent that fuses git log, notes, and external archives to explain WHY code exists.
+
+    Parameters
+    ----------
+    sources:
+        Configuration for data sources (git, markdown, Slack, email, mesh).
+    llm:
+        BaseLLM instance. If None, one is created from model/api_key.
+    model:
+        LLM model name (used if llm is None).
+    api_key:
+        API key for LLM provider (used if llm is None).
+    provider:
+        Optional LLM provider name.
+    causal_engine:
+        Optional NeuroSymbolicAgent for causal plausibility checks.
+    """
+
+    def __init__(
+        self,
+        sources: SourceConfig | None = None,
+        *,
+        llm: BaseLLM | None = None,
+        model: str = "gpt-4o-mini",
+        api_key: str = "",
+        provider: str | None = None,
+        causal_engine: NeuroSymbolicAgent | None = None,
+    ) -> None:
+        self.sources = sources or SourceConfig()
+
+        if llm is not None:
+            self.llm: BaseLLM | None = llm
+        else:
+            try:
+                self.llm = make_llm(
+                    model,
+                    api_key,
+                    provider,
+                    "You are a code archaeology and history analyst.",
+                    0.3,
+                    2048,
+                )
+            except Exception:
+                self.llm = None
+
+        repo_path = Path(self.sources.repo_path).resolve()
+        self.timeline_reconstructor = TimelineReconstructor(repo_path)
+        self.evolution_diff = EvolutionDiff(repo_path)
+        self.causal_linker: CausalLinker | None = None
+        if self.llm is not None:
+            self.causal_linker = CausalLinker(
+                self.llm,
+                verifier=causal_engine,
+                min_citations=self.sources.min_citations_per_claim,
+            )
+        self.causal_engine = causal_engine
+
+    async def explain(self, query: str) -> ArchaeologyResult:
+        """Answer 'Why does this code exist?' with a full causal chain and evidence.
+
+        Returns an ArchaeologyResult with:
+        - timeline: chronological events from all sources
+        - causes: causal claims with evidence and optional verification
+        - evolution: how the code changed over time
+        - narrative: human-readable markdown summary
+        """
+        src = self.sources
+
+        # Phase 1: Reconstruct timeline from all sources
+        timeline = await self.timeline_reconstructor.reconstruct(
+            query,
+            include_git=src.include_git,
+            slack_bot_token=src.slack_bot_token,
+            slack_channel_ids=src.slack_channel_ids or None,
+            email_imap_server=src.email_imap_server,
+            email_address=src.email_address,
+            email_password=src.email_password,
+            email_folder=src.email_folder,
+            markdown_roots=[Path(r) for r in src.markdown_roots] or None,
+            max_events=src.max_events,
+        )
+
+        # Phase 2 & 3: Run causal linking and evolution diff concurrently
+        causal_task = (
+            self.causal_linker.link(timeline, query)
+            if self.causal_linker is not None
+            else _empty_list()
+        )
+        evolution_task = self.evolution_diff.trace(query)
+
+        causes, evolution = await asyncio.gather(causal_task, evolution_task)
+
+        # Phase 4: Generate narrative summary
+        narrative = ""
+        if self.llm is not None:
+            narrative = await self._generate_narrative(
+                query,
+                timeline,
+                causes,
+                evolution,
+            )
+
+        return ArchaeologyResult(
+            query=query,
+            timeline=timeline,
+            causes=causes,
+            evolution=evolution,
+            narrative=narrative,
+        )
+
+    async def _generate_narrative(
+        self,
+        query: str,
+        timeline: list,
+        causes: list,
+        evolution: list,
+    ) -> str:
+        """Generate a human-readable narrative from the evidence."""
+        if self.llm is None:
+            return ""
+
+        source_types = {e.source_type for e in timeline}
+        timeline_lines = [
+            f"- [{e.timestamp.strftime('%Y-%m-%d')}] ({e.source_type}) {e.summary}"
+            for e in timeline[:30]
+        ]
+        causal_lines = [
+            f"- {c.cause} → {c.effect} (confidence: {c.confidence:.0%}, verified: {c.verified})"
+            for c in causes
+        ]
+        evolution_lines = [
+            f"- [{s.date.strftime('%Y-%m-%d')}] {s.diff_summary}: {s.reason[:100]}"
+            for s in evolution[:20]
+        ]
+
+        prompt = _NARRATIVE_PROMPT.format(
+            query=query,
+            n_events=len(timeline),
+            n_sources=len(source_types),
+            timeline_summary="\n".join(timeline_lines) or "No events found.",
+            n_claims=len(causes),
+            causal_summary="\n".join(causal_lines) or "No causal links identified.",
+            n_snapshots=len(evolution),
+            evolution_summary="\n".join(evolution_lines) or "No evolution data.",
+        )
+
+        chunks: list[str] = []
+        async for chunk in self.llm.stream(prompt):
+            chunks.append(chunk)
+        return "".join(chunks)
+
+
+async def _empty_list() -> list:
+    """Async no-op returning an empty list."""
+    return []

--- a/src/synapsekit/archaeology/causal_linker.py
+++ b/src/synapsekit/archaeology/causal_linker.py
@@ -1,0 +1,198 @@
+"""CausalLinker — extract and verify causal claims from multi-source evidence."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from .types import CausalClaim, Citation, TimelineEvent
+
+if TYPE_CHECKING:
+    from ..llm.base import BaseLLM
+    from ..symbolic.agent import NeuroSymbolicAgent
+
+logger = logging.getLogger(__name__)
+
+_CAUSAL_PROMPT = """\
+Given the following chronological events related to the query "{query}",
+identify causal relationships (what caused what). For each causal link, provide:
+1. The cause (what happened first that led to the next event)
+2. The effect (what resulted from the cause)
+3. Your confidence level (0.0 to 1.0)
+4. Brief reasoning
+
+Events:
+{events}
+
+Return your analysis as a numbered list of causal links in this exact format:
+CAUSE: <description>
+EFFECT: <description>
+CONFIDENCE: <0.0-1.0>
+REASONING: <explanation>
+---
+"""
+
+
+class CausalLinker:
+    """Extracts causal relationships from timeline events and optionally verifies them."""
+
+    def __init__(
+        self,
+        llm: BaseLLM,
+        *,
+        verifier: NeuroSymbolicAgent | None = None,
+        min_citations: int = 2,
+    ) -> None:
+        self.llm = llm
+        self.verifier = verifier
+        self.min_citations = min_citations
+
+    async def link(
+        self,
+        events: list[TimelineEvent],
+        query: str,
+    ) -> list[CausalClaim]:
+        """Extract causal claims from timeline events and verify them."""
+        if not events:
+            return []
+
+        # Format events for LLM
+        event_strs: list[str] = []
+        for i, e in enumerate(events[:50], 1):  # Cap for context length
+            cite_refs = ", ".join(c.reference for c in e.citations)
+            event_strs.append(
+                f"{i}. [{e.timestamp.strftime('%Y-%m-%d')}] "
+                f"({e.source_type}) {e.summary} [refs: {cite_refs}]"
+            )
+
+        prompt = _CAUSAL_PROMPT.format(
+            query=query,
+            events="\n".join(event_strs),
+        )
+
+        response_chunks: list[str] = []
+        async for chunk in self.llm.stream(prompt):
+            response_chunks.append(chunk)
+        response = "".join(response_chunks)
+
+        claims = self._parse_claims(response, events)
+
+        # Filter claims with insufficient evidence
+        claims = [c for c in claims if len(c.citations) >= self.min_citations]
+
+        # Verify with NeuroSymbolicAgent if available
+        if self.verifier is not None:
+            claims = await self._verify_claims(claims)
+
+        return claims
+
+    def _parse_claims(
+        self,
+        response: str,
+        events: list[TimelineEvent],
+    ) -> list[CausalClaim]:
+        """Parse LLM response into CausalClaim objects."""
+        claims: list[CausalClaim] = []
+        blocks = response.split("---")
+
+        all_citations: list[Citation] = []
+        for e in events:
+            all_citations.extend(e.citations)
+
+        for block in blocks:
+            block = block.strip()
+            if not block:
+                continue
+
+            cause = effect = reasoning = ""
+            confidence = 0.5
+
+            for line in block.split("\n"):
+                line = line.strip()
+                if line.upper().startswith("CAUSE:"):
+                    cause = line[6:].strip()
+                elif line.upper().startswith("EFFECT:"):
+                    effect = line[7:].strip()
+                elif line.upper().startswith("CONFIDENCE:"):
+                    try:
+                        confidence = float(line[11:].strip())
+                    except ValueError:
+                        confidence = 0.5
+                elif line.upper().startswith("REASONING:"):
+                    reasoning = line[10:].strip()
+
+            if cause and effect:
+                # Find matching citations from events
+                matched_citations = self._match_citations(
+                    cause + " " + effect,
+                    all_citations,
+                )
+                claims.append(
+                    CausalClaim(
+                        cause=cause,
+                        effect=effect,
+                        confidence=confidence,
+                        citations=matched_citations,
+                        verified=False,
+                        reasoning=reasoning,
+                    )
+                )
+
+        return claims
+
+    def _match_citations(
+        self,
+        text: str,
+        all_citations: list[Citation],
+    ) -> list[Citation]:
+        """Find citations whose content is relevant to the claim text."""
+        text_lower = text.lower()
+        terms = [w for w in text_lower.split() if len(w) > 3]
+
+        scored: list[tuple[int, Citation]] = []
+        for c in all_citations:
+            preview_lower = c.content_preview.lower()
+            ref_lower = c.reference.lower()
+            score = sum(1 for t in terms if t in preview_lower or t in ref_lower)
+            if score > 0:
+                scored.append((score, c))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [c for _, c in scored[:5]]
+
+    async def _verify_claims(
+        self,
+        claims: list[CausalClaim],
+    ) -> list[CausalClaim]:
+        """Verify causal claims using NeuroSymbolicAgent for plausibility."""
+        if self.verifier is None:
+            return claims
+
+        verified_claims: list[CausalClaim] = []
+        for claim in claims:
+            try:
+                evidence = [c.content_preview for c in claim.citations]
+                problem = (
+                    f"Verify this causal claim: '{claim.cause}' caused '{claim.effect}'. "
+                    f"Evidence: {'; '.join(evidence[:3])}"
+                )
+                result = await self.verifier.solve(problem)
+                verified_claims.append(
+                    CausalClaim(
+                        cause=claim.cause,
+                        effect=claim.effect,
+                        confidence=claim.confidence,
+                        citations=claim.citations,
+                        verified=bool(getattr(result, "verified", False)),
+                        reasoning=claim.reasoning,
+                    )
+                )
+            except Exception:
+                logger.warning(
+                    "Verification failed for claim: %s -> %s",
+                    claim.cause,
+                    claim.effect,
+                )
+                verified_claims.append(claim)
+
+        return verified_claims

--- a/src/synapsekit/archaeology/evolution_diff.py
+++ b/src/synapsekit/archaeology/evolution_diff.py
@@ -12,6 +12,7 @@ from .types import Citation, EvolutionSnapshot
 
 if TYPE_CHECKING:
     from ..llm.base import BaseLLM
+    from ..timetravel.evolution_index import EvolutionEntry
 
 logger = logging.getLogger(__name__)
 
@@ -30,18 +31,35 @@ class EvolutionDiff:
         until: str | datetime | None = None,
         llm: BaseLLM | None = None,
     ) -> list[EvolutionSnapshot]:
-        """Build a chronological evolution trace for a file or symbol."""
+        """Build a chronological evolution trace for a file, symbol, or question."""
         from ..timetravel.evolution_index import EvolutionIndex
         from ..timetravel.git_backend import GitBackend
 
         backend = GitBackend(self.repo_path)
         index = EvolutionIndex(backend)
-        entries = await asyncio.to_thread(
-            index.timeline,
-            file_or_symbol,
-            since=since,
-            until=until,
-        )
+        all_entries = await asyncio.to_thread(index.build, since=since, until=until)
+
+        # Extract search terms from file_or_symbol
+        terms = [t.strip("?,.'\"`") for t in file_or_symbol.split() if len(t) > 2]
+        matching_entries: list[EvolutionEntry] = []
+        for term in terms:
+            res = index.query(term, since=since, until=until)
+            if res:
+                matching_entries.extend(res)
+
+        if not matching_entries:
+            matching_entries = index.query(file_or_symbol, since=since, until=until)
+        if not matching_entries:
+            matching_entries = all_entries
+
+        # Deduplicate and sort chronologically
+        seen = set()
+        entries: list[EvolutionEntry] = []
+        for e in sorted(matching_entries, key=lambda x: x.commit.date):
+            key = (e.commit.hash, e.file_path, e.symbol)
+            if key not in seen:
+                seen.add(key)
+                entries.append(e)
 
         snapshots: list[EvolutionSnapshot] = []
         for entry in entries:

--- a/src/synapsekit/archaeology/evolution_diff.py
+++ b/src/synapsekit/archaeology/evolution_diff.py
@@ -73,11 +73,7 @@ class EvolutionDiff:
                     f"commit {entry.commit.hash[:8]}"
                     + (f" (PR #{entry.pr_number})" if entry.pr_number else "")
                 ),
-                content_preview=(
-                    entry.diff_snippet[:200]
-                    if entry.diff_snippet
-                    else reason
-                ),
+                content_preview=(entry.diff_snippet[:200] if entry.diff_snippet else reason),
                 timestamp=entry.commit.date,
                 metadata={
                     "author": entry.commit.author,

--- a/src/synapsekit/archaeology/evolution_diff.py
+++ b/src/synapsekit/archaeology/evolution_diff.py
@@ -1,0 +1,89 @@
+"""EvolutionDiff — track how code evolved across versions with rationale."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .types import Citation, EvolutionSnapshot
+
+if TYPE_CHECKING:
+    from ..llm.base import BaseLLM
+
+logger = logging.getLogger(__name__)
+
+
+class EvolutionDiff:
+    """Tracks how a file or symbol evolved over time, extracting rationale from commits."""
+
+    def __init__(self, repo_path: str | Path = ".") -> None:
+        self.repo_path = Path(repo_path).resolve()
+
+    async def trace(
+        self,
+        file_or_symbol: str,
+        *,
+        since: str | datetime | None = None,
+        until: str | datetime | None = None,
+        llm: BaseLLM | None = None,
+    ) -> list[EvolutionSnapshot]:
+        """Build a chronological evolution trace for a file or symbol."""
+        from ..timetravel.evolution_index import EvolutionIndex
+        from ..timetravel.git_backend import GitBackend
+
+        backend = GitBackend(self.repo_path)
+        index = EvolutionIndex(backend)
+        entries = await asyncio.to_thread(
+            index.timeline,
+            file_or_symbol,
+            since=since,
+            until=until,
+        )
+
+        snapshots: list[EvolutionSnapshot] = []
+        for entry in entries:
+            reason = entry.commit.subject
+            if entry.commit.body:
+                reason += f" — {entry.commit.body.strip()}"
+
+            citation = Citation(
+                source_type="git",
+                reference=(
+                    f"commit {entry.commit.hash[:8]}"
+                    + (f" (PR #{entry.pr_number})" if entry.pr_number else "")
+                ),
+                content_preview=(
+                    entry.diff_snippet[:200]
+                    if entry.diff_snippet
+                    else reason
+                ),
+                timestamp=entry.commit.date,
+                metadata={
+                    "author": entry.commit.author,
+                    "file_path": entry.file_path,
+                    "symbol": entry.symbol,
+                    "lines_added": entry.lines_added,
+                    "lines_removed": entry.lines_removed,
+                },
+            )
+
+            diff_summary = (
+                f"{entry.change_type} in {entry.file_path}"
+                + (f" [{entry.symbol}]" if entry.symbol else "")
+                + f" (+{entry.lines_added}/-{entry.lines_removed})"
+            )
+
+            snapshots.append(
+                EvolutionSnapshot(
+                    version_hash=entry.commit.hash,
+                    date=entry.commit.date,
+                    diff_summary=diff_summary,
+                    reason=reason,
+                    citations=[citation],
+                )
+            )
+
+        return snapshots

--- a/src/synapsekit/archaeology/timeline_reconstructor.py
+++ b/src/synapsekit/archaeology/timeline_reconstructor.py
@@ -1,0 +1,263 @@
+"""TimelineReconstructor — merge multi-source events into a single timeline."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .types import Citation, TimelineEvent
+
+logger = logging.getLogger(__name__)
+
+
+class TimelineReconstructor:
+    """Collects events from git, Slack, email, and markdown, then merges chronologically."""
+
+    def __init__(self, repo_path: str | Path = ".") -> None:
+        self.repo_path = Path(repo_path).resolve()
+
+    async def reconstruct(
+        self,
+        query: str,
+        *,
+        include_git: bool = True,
+        slack_bot_token: str | None = None,
+        slack_channel_ids: list[str] | None = None,
+        email_imap_server: str | None = None,
+        email_address: str | None = None,
+        email_password: str | None = None,
+        email_folder: str = "INBOX",
+        markdown_roots: list[str | Path] | None = None,
+        max_events: int = 200,
+    ) -> list[TimelineEvent]:
+        """Gather and merge events from all configured sources."""
+        tasks: list[asyncio.Task[list[TimelineEvent]]] = []
+
+        if include_git:
+            tasks.append(asyncio.create_task(self._git_events(query, max_events)))
+
+        if slack_bot_token and slack_channel_ids:
+            tasks.append(
+                asyncio.create_task(
+                    self._slack_events(query, slack_bot_token, slack_channel_ids)
+                )
+            )
+
+        if email_imap_server and email_address and email_password:
+            tasks.append(
+                asyncio.create_task(
+                    self._email_events(
+                        query,
+                        email_imap_server,
+                        email_address,
+                        email_password,
+                        email_folder,
+                    )
+                )
+            )
+
+        if markdown_roots:
+            tasks.append(
+                asyncio.create_task(
+                    self._markdown_events(query, [Path(r) for r in markdown_roots])
+                )
+            )
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        events: list[TimelineEvent] = []
+        for result in results:
+            if isinstance(result, BaseException):
+                logger.warning("Source failed in TimelineReconstructor: %s", result)
+                continue
+            events.extend(result)
+
+        events.sort(key=lambda e: e.timestamp)
+        return events[:max_events]
+
+    async def _git_events(self, query: str, max_events: int) -> list[TimelineEvent]:
+        """Extract timeline events from git history."""
+        from ..timetravel.evolution_index import EvolutionIndex
+        from ..timetravel.git_backend import GitBackend
+
+        backend = GitBackend(self.repo_path)
+        index = EvolutionIndex(backend)
+
+        entries = await asyncio.to_thread(index.build)
+        terms = [t.strip("?,.'\"`") for t in query.split() if len(t) > 2]
+
+        matching = [
+            e
+            for e in entries
+            if any(
+                term.lower()
+                in (e.file_path + " " + (e.symbol or "") + " " + e.commit.subject).lower()
+                for term in terms
+            )
+        ] or entries[:max_events]
+
+        events: list[TimelineEvent] = []
+        for entry in matching[:max_events]:
+            pr_ref = f" (PR #{entry.pr_number})" if entry.pr_number else ""
+            citation = Citation(
+                source_type="git",
+                reference=f"commit {entry.commit.hash[:8]}{pr_ref}",
+                content_preview=entry.commit.subject,
+                timestamp=entry.commit.date,
+                metadata={
+                    "file_path": entry.file_path,
+                    "symbol": entry.symbol,
+                    "author": entry.commit.author,
+                },
+            )
+            events.append(
+                TimelineEvent(
+                    timestamp=entry.commit.date,
+                    source_type="git",
+                    summary=(
+                        f"{entry.change_type} {entry.file_path}"
+                        + (f" [{entry.symbol}]" if entry.symbol else "")
+                        + f": {entry.commit.subject}"
+                    ),
+                    citations=[citation],
+                    metadata={"commit_hash": entry.commit.hash},
+                )
+            )
+
+        return events
+
+    async def _slack_events(
+        self,
+        query: str,
+        bot_token: str,
+        channel_ids: list[str],
+    ) -> list[TimelineEvent]:
+        """Extract timeline events from Slack messages."""
+        from ..loaders.slack import SlackLoader
+
+        events: list[TimelineEvent] = []
+        terms = [t.lower().strip("?,.'\"`") for t in query.split() if len(t) > 2]
+
+        for channel_id in channel_ids:
+            loader = SlackLoader(bot_token=bot_token, channel_id=channel_id)
+            docs = await loader.aload()
+            for doc in docs:
+                text_lower = doc.text.lower()
+                if not any(term in text_lower for term in terms):
+                    continue
+                ts_str = str(doc.metadata.get("timestamp", ""))
+                try:
+                    ts = datetime.fromtimestamp(float(ts_str), tz=UTC)
+                except (ValueError, TypeError, OSError):
+                    ts = datetime.now(UTC)
+                citation = Citation(
+                    source_type="slack",
+                    reference=f"slack://{channel_id}/{ts_str}",
+                    content_preview=doc.text[:200],
+                    timestamp=ts,
+                    metadata=doc.metadata,
+                )
+                events.append(
+                    TimelineEvent(
+                        timestamp=ts,
+                        source_type="slack",
+                        summary=doc.text[:200],
+                        citations=[citation],
+                    )
+                )
+
+        return events
+
+    async def _email_events(
+        self,
+        query: str,
+        imap_server: str,
+        email_address: str,
+        password: str,
+        folder: str,
+    ) -> list[TimelineEvent]:
+        """Extract timeline events from email archives."""
+        from ..loaders.email import EmailLoader
+
+        loader = EmailLoader(
+            imap_server=imap_server,
+            email_address=email_address,
+            password=password,
+            folder=folder,
+        )
+        docs = await loader.aload()
+        terms = [t.lower().strip("?,.'\"`") for t in query.split() if len(t) > 2]
+        events: list[TimelineEvent] = []
+
+        for doc in docs:
+            text_lower = (doc.text + " " + doc.metadata.get("subject", "")).lower()
+            if not any(term in text_lower for term in terms):
+                continue
+            date_str = doc.metadata.get("date", "")
+            try:
+                ts = datetime.fromisoformat(date_str) if date_str else datetime.now(UTC)
+            except ValueError:
+                ts = datetime.now(UTC)
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=UTC)
+            citation = Citation(
+                source_type="email",
+                reference=f"email://{doc.metadata.get('email_id', 'unknown')}",
+                content_preview=doc.text[:200],
+                timestamp=ts,
+                metadata=doc.metadata,
+            )
+            events.append(
+                TimelineEvent(
+                    timestamp=ts,
+                    source_type="email",
+                    summary=f"{doc.metadata.get('subject', 'No subject')}: {doc.text[:100]}",
+                    citations=[citation],
+                )
+            )
+
+        return events
+
+    async def _markdown_events(
+        self,
+        query: str,
+        roots: list[Path],
+    ) -> list[TimelineEvent]:
+        """Extract timeline events from local markdown notes."""
+        terms = [t.lower().strip("?,.'\"`") for t in query.split() if len(t) > 2]
+        events: list[TimelineEvent] = []
+
+        for root in roots:
+            root = root.resolve()
+            if not root.exists():
+                continue
+            md_files = list(root.rglob("*.md"))
+            for md_file in md_files:
+                try:
+                    content = await asyncio.to_thread(
+                        md_file.read_text, encoding="utf-8"
+                    )
+                except Exception:
+                    continue
+                if not any(term in content.lower() for term in terms):
+                    continue
+                stat = md_file.stat()
+                ts = datetime.fromtimestamp(stat.st_mtime, tz=UTC)
+                citation = Citation(
+                    source_type="markdown",
+                    reference=f"file://{md_file}",
+                    content_preview=content[:200],
+                    timestamp=ts,
+                    metadata={"path": str(md_file)},
+                )
+                events.append(
+                    TimelineEvent(
+                        timestamp=ts,
+                        source_type="markdown",
+                        summary=f"Note: {md_file.name} — {content[:100]}",
+                        citations=[citation],
+                    )
+                )
+
+        return events

--- a/src/synapsekit/archaeology/timeline_reconstructor.py
+++ b/src/synapsekit/archaeology/timeline_reconstructor.py
@@ -40,9 +40,7 @@ class TimelineReconstructor:
 
         if slack_bot_token and slack_channel_ids:
             tasks.append(
-                asyncio.create_task(
-                    self._slack_events(query, slack_bot_token, slack_channel_ids)
-                )
+                asyncio.create_task(self._slack_events(query, slack_bot_token, slack_channel_ids))
             )
 
         if email_imap_server and email_address and email_password:
@@ -60,9 +58,7 @@ class TimelineReconstructor:
 
         if markdown_roots:
             tasks.append(
-                asyncio.create_task(
-                    self._markdown_events(query, [Path(r) for r in markdown_roots])
-                )
+                asyncio.create_task(self._markdown_events(query, [Path(r) for r in markdown_roots]))
             )
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
@@ -235,9 +231,7 @@ class TimelineReconstructor:
             md_files = list(root.rglob("*.md"))
             for md_file in md_files:
                 try:
-                    content = await asyncio.to_thread(
-                        md_file.read_text, encoding="utf-8"
-                    )
+                    content = await asyncio.to_thread(md_file.read_text, encoding="utf-8")
                 except Exception:
                     continue
                 if not any(term in content.lower() for term in terms):

--- a/src/synapsekit/archaeology/types.py
+++ b/src/synapsekit/archaeology/types.py
@@ -1,0 +1,152 @@
+"""Data types for Code Archaeology results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Literal
+
+SourceType = Literal["git", "markdown", "slack", "email", "mesh"]
+
+
+@dataclass(frozen=True)
+class Citation:
+    """A specific evidence reference supporting a claim."""
+
+    source_type: SourceType
+    reference: str  # e.g., "commit abc1234", "PR #42", "slack://C123/msg456"
+    content_preview: str  # First ~200 chars of the evidence
+    timestamp: datetime | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TimelineEvent:
+    """A single event in the chronological reconstruction."""
+
+    timestamp: datetime
+    source_type: SourceType
+    summary: str
+    citations: list[Citation] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CausalClaim:
+    """A causal relationship between events, with evidence."""
+
+    cause: str
+    effect: str
+    confidence: float  # 0.0–1.0
+    citations: list[Citation] = field(default_factory=list)
+    verified: bool = False  # True if NeuroSymbolicAgent plausibility check passed
+    reasoning: str = ""
+
+
+@dataclass(frozen=True)
+class EvolutionSnapshot:
+    """How a file/symbol changed at a specific version."""
+
+    version_hash: str
+    date: datetime
+    diff_summary: str
+    reason: str  # Extracted "why" from commit message/PR/linked discussion
+    citations: list[Citation] = field(default_factory=list)
+
+
+@dataclass
+class ArchaeologyResult:
+    """Complete result from an archaeology query."""
+
+    query: str
+    timeline: list[TimelineEvent] = field(default_factory=list)
+    causes: list[CausalClaim] = field(default_factory=list)
+    evolution: list[EvolutionSnapshot] = field(default_factory=list)
+    narrative: str = ""
+
+    @property
+    def all_citations(self) -> list[Citation]:
+        """Deduplicated list of all citations across timeline, causes, evolution."""
+        seen: set[str] = set()
+        result: list[Citation] = []
+        for event in self.timeline:
+            for c in event.citations:
+                if c.reference not in seen:
+                    seen.add(c.reference)
+                    result.append(c)
+        for claim in self.causes:
+            for c in claim.citations:
+                if c.reference not in seen:
+                    seen.add(c.reference)
+                    result.append(c)
+        for snap in self.evolution:
+            for c in snap.citations:
+                if c.reference not in seen:
+                    seen.add(c.reference)
+                    result.append(c)
+        return result
+
+    def to_markdown(self) -> str:
+        """Render result as a markdown report."""
+        lines: list[str] = [f"# Code Archaeology: {self.query}", ""]
+
+        if self.narrative:
+            lines.extend(["## Summary", self.narrative, ""])
+
+        if self.timeline:
+            lines.append("## Timeline")
+            for event in self.timeline:
+                date_str = event.timestamp.strftime("%Y-%m-%d %H:%M")
+                lines.append(f"- **{date_str}** [{event.source_type}]: {event.summary}")
+                for c in event.citations:
+                    lines.append(f"  - 📎 {c.reference}: {c.content_preview[:80]}")
+            lines.append("")
+
+        if self.causes:
+            lines.append("## Causal Chain")
+            for claim in self.causes:
+                verified = "✅" if claim.verified else "⚠️"
+                lines.append(
+                    f"- {verified} **{claim.cause}** → **{claim.effect}** "
+                    f"(confidence: {claim.confidence:.0%})"
+                )
+                if claim.reasoning:
+                    lines.append(f"  > {claim.reasoning}")
+                for c in claim.citations:
+                    lines.append(f"  - 📎 {c.reference}")
+            lines.append("")
+
+        if self.evolution:
+            lines.append("## Evolution History")
+            for snap in self.evolution:
+                date_str = snap.date.strftime("%Y-%m-%d")
+                lines.append(f"- **{date_str}** `{snap.version_hash[:8]}`: {snap.diff_summary}")
+                if snap.reason:
+                    lines.append(f"  > Why: {snap.reason}")
+            lines.append("")
+
+        all_cites = self.all_citations
+        if all_cites:
+            lines.append(f"## Citations ({len(all_cites)} sources)")
+            for i, c in enumerate(all_cites, 1):
+                lines.append(f"{i}. [{c.source_type}] {c.reference}")
+
+        return "\n".join(lines)
+
+
+@dataclass
+class SourceConfig:
+    """Configuration for archaeology data sources."""
+
+    repo_path: str = "."
+    include_git: bool = True
+    markdown_roots: list[str] = field(default_factory=list)
+    slack_bot_token: str | None = None
+    slack_channel_ids: list[str] = field(default_factory=list)
+    email_imap_server: str | None = None
+    email_address: str | None = None
+    email_password: str | None = None
+    email_folder: str = "INBOX"
+    mesh: Any | None = None  # Optional KnowledgeMesh instance
+    max_events: int = 200
+    min_citations_per_claim: int = 2

--- a/src/synapsekit/archaeology/types.py
+++ b/src/synapsekit/archaeology/types.py
@@ -37,7 +37,7 @@ class CausalClaim:
 
     cause: str
     effect: str
-    confidence: float  # 0.0–1.0
+    confidence: float  # 0.0-1.0
     citations: list[Citation] = field(default_factory=list)
     verified: bool = False  # True if NeuroSymbolicAgent plausibility check passed
     reasoning: str = ""

--- a/src/synapsekit/cli/main.py
+++ b/src/synapsekit/cli/main.py
@@ -1,9 +1,8 @@
-"""SynapseKit CLI — ``synapsekit serve`` and ``synapsekit test``."""
+"""SynapseKit CLI entry point."""
 
 from __future__ import annotations
 
 import argparse
-import sys
 
 
 def _add_serve_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -20,131 +19,88 @@ def _add_test_parser(subparsers: argparse._SubParsersAction) -> None:  # type: i
     p.add_argument(
         "--threshold", type=float, default=0.7, help="Min score threshold (default: 0.7)"
     )
-    p.add_argument(
-        "--format",
-        dest="output_format",
-        choices=["json", "table"],
-        default="table",
-        help="Output format (default: table)",
-    )
-    p.add_argument(
-        "--save",
-        dest="save_snapshot",
-        metavar="NAME",
-        help="Save results as a named snapshot",
-    )
-    p.add_argument(
-        "--compare",
-        dest="compare_baseline",
-        metavar="BASELINE",
-        help="Compare results against a saved baseline snapshot",
-    )
-    p.add_argument(
-        "--fail-on-regression",
-        action="store_true",
-        default=False,
-        help="Exit with code 1 if regressions are detected",
-    )
-    p.add_argument(
-        "--snapshot-dir",
-        default=".synapsekit_evals",
-        help="Snapshot storage directory (default: .synapsekit_evals)",
-    )
+    p.add_argument("--format", dest="output_format", choices=["json", "table"], default="table")
+    p.add_argument("--save", dest="save_snapshot", metavar="NAME")
+    p.add_argument("--compare", dest="compare_baseline", metavar="BASELINE")
+    p.add_argument("--fail-on-regression", action="store_true", default=False)
+    p.add_argument("--snapshot-dir", default=".synapsekit_evals")
 
 
 def _add_eval_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = subparsers.add_parser("eval", help="EvalCI snapshot report/export/compare")
     eval_sub = p.add_subparsers(dest="eval_command")
-
     report = eval_sub.add_parser("report", help="Summarize a saved eval snapshot")
-    report.add_argument("snapshot", help="Snapshot name")
-    report.add_argument("--threshold", type=float, default=0.8, help="Weak-case threshold")
-    report.add_argument("--snapshot-dir", default=".synapsekit_evals", help="Snapshot storage dir")
-
+    report.add_argument("snapshot")
+    report.add_argument("--threshold", type=float, default=0.8)
+    report.add_argument("--snapshot-dir", default=".synapsekit_evals")
     export = eval_sub.add_parser("export", help="Export snapshot to fine-tune dataset")
-    export.add_argument("snapshot", help="Snapshot name")
+    export.add_argument("snapshot")
     export.add_argument(
-        "--format",
-        choices=["openai", "anthropic", "together", "jsonl", "dpo"],
-        default="openai",
-        help="Export format",
+        "--format", choices=["openai", "anthropic", "together", "jsonl", "dpo"], default="openai"
     )
-    export.add_argument("--min-score", type=float, default=None, help="Minimum score filter")
-    export.add_argument("--max-score", type=float, default=None, help="Maximum score filter")
-    export.add_argument("--output", required=True, help="Output JSONL path")
-    export.add_argument("--snapshot-dir", default=".synapsekit_evals", help="Snapshot storage dir")
-
+    export.add_argument("--min-score", type=float, default=None)
+    export.add_argument("--max-score", type=float, default=None)
+    export.add_argument("--output", required=True)
+    export.add_argument("--snapshot-dir", default=".synapsekit_evals")
     compare = eval_sub.add_parser("compare", help="Compare two saved eval snapshots")
-    compare.add_argument("baseline", help="Baseline snapshot")
-    compare.add_argument("current", help="Current snapshot")
-    compare.add_argument("--snapshot-dir", default=".synapsekit_evals", help="Snapshot storage dir")
+    compare.add_argument("baseline")
+    compare.add_argument("current")
+    compare.add_argument("--snapshot-dir", default=".synapsekit_evals")
 
 
 def _add_finetune_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = subparsers.add_parser("finetune", help="Submit and monitor fine-tuning jobs")
     ft_sub = p.add_subparsers(dest="finetune_command")
-
     submit = ft_sub.add_parser("submit", help="Submit fine-tuning job")
-    submit.add_argument("dataset", help="Dataset file ID/path accepted by provider")
+    submit.add_argument("dataset")
     submit.add_argument("--provider", choices=["openai", "together"], required=True)
-    submit.add_argument("--base-model", required=True, help="Base model name")
-    submit.add_argument("--job-name", default=None, help="Optional job suffix/name")
-    submit.add_argument("--n-epochs", type=int, default=3, help="Training epochs")
-    submit.add_argument("--api-key", default=None, help="Provider API key")
-
+    submit.add_argument("--base-model", required=True)
+    submit.add_argument("--job-name", default=None)
+    submit.add_argument("--n-epochs", type=int, default=3)
+    submit.add_argument("--api-key", default=None)
     status = ft_sub.add_parser("status", help="Get fine-tune job status")
-    status.add_argument("job_id", help="Fine-tune job ID")
+    status.add_argument("job_id")
     status.add_argument("--provider", choices=["openai", "together"], required=True)
-    status.add_argument("--api-key", default=None, help="Provider API key")
-
+    status.add_argument("--api-key", default=None)
     wait = ft_sub.add_parser("wait", help="Wait for fine-tune job completion")
-    wait.add_argument("job_id", help="Fine-tune job ID")
+    wait.add_argument("job_id")
     wait.add_argument("--provider", choices=["openai", "together"], required=True)
-    wait.add_argument("--interval", type=float, default=10.0, help="Poll interval seconds")
-    wait.add_argument("--timeout", type=float, default=3600.0, help="Timeout seconds")
-    wait.add_argument("--api-key", default=None, help="Provider API key")
+    wait.add_argument("--interval", type=float, default=10.0)
+    wait.add_argument("--timeout", type=float, default=3600.0)
+    wait.add_argument("--api-key", default=None)
 
 
 def _add_graph_builder_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = subparsers.add_parser("graph-builder", help="Launch the visual graph workflow builder")
-    p.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1)")
-    p.add_argument("--port", type=int, default=7861, help="Bind port (default: 7861)")
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=7861)
 
 
 def _add_ui_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = subparsers.add_parser("ui", help="Launch the observability dashboard")
-    p.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1)")
-    p.add_argument("--port", type=int, default=7860, help="Bind port (default: 7860)")
-    p.add_argument(
-        "--live",
-        action="store_true",
-        help="Lightweight zero-dependency live run dashboard (stdlib only, no extras needed)",
-    )
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=7860)
+    p.add_argument("--live", action="store_true")
 
 
 def _add_plugin_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = subparsers.add_parser("plugin", help="Manage SynapseKit plugins")
     plugin_sub = p.add_subparsers(dest="plugin_command")
-
     plugin_sub.add_parser("list", help="List all registered plugins")
-
     load_cmd = plugin_sub.add_parser("load", help="Load a plugin from a Python file")
-    load_cmd.add_argument("path", help="Path to the plugin .py file")
-
+    load_cmd.add_argument("path")
     info_cmd = plugin_sub.add_parser("info", help="Show details about a registered plugin")
-    info_cmd.add_argument("name", help="Plugin name")
+    info_cmd.add_argument("name")
 
 
 def _add_benchmark_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = subparsers.add_parser("benchmark", help="Run agent benchmarks (GAIA, SWE-bench, etc.)")
     bench_sub = p.add_subparsers(dest="benchmark_command")
-
     run_cmd = bench_sub.add_parser("run", help="Run a specific benchmark suite")
-    run_cmd.add_argument("suite", help="Benchmark suite (gaia, swe-bench, webarena, agentbench)")
-    run_cmd.add_argument("agent", help="Import path for the agent, e.g. 'my_agent:run_task'")
-    run_cmd.add_argument("--split", default="test", help="Dataset split to evaluate on")
-    run_cmd.add_argument("--limit", type=int, default=None, help="Max tasks to evaluate")
-
+    run_cmd.add_argument("suite")
+    run_cmd.add_argument("agent")
+    run_cmd.add_argument("--split", default="test")
+    run_cmd.add_argument("--limit", type=int, default=None)
     bench_sub.add_parser("list", help="List available benchmarks")
 
 
@@ -190,145 +146,93 @@ def _add_ambient_parser(subparsers: argparse._SubParsersAction) -> None:  # type
     build_ambient_parser(subparsers)
 
 
+def _add_sandbox_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    from .sandbox import build_sandbox_parser
+
+    build_sandbox_parser(subparsers)
+
+
 def _add_agent_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = subparsers.add_parser("agent", help="Inspect and manage SynapseKit agents")
     agent_sub = p.add_subparsers(dest="agent_command")
-
     inspect_cmd = agent_sub.add_parser(
-        "inspect-evolution",
-        help="Inspect self-improving agent evolution history",
+        "inspect-evolution", help="Inspect self-improving agent evolution history"
     )
-    inspect_cmd.add_argument("agent_id", help="Agent id to inspect, or 'all'")
+    inspect_cmd.add_argument("agent_id")
+    inspect_cmd.add_argument("--audit-path", default=".synapsekit_agent_evolution.jsonl")
+    inspect_cmd.add_argument("--limit", type=int, default=20)
     inspect_cmd.add_argument(
-        "--audit-path",
-        default=".synapsekit_agent_evolution.jsonl",
-        help="Evolution audit JSONL path",
+        "--format", dest="output_format", choices=["table", "json"], default="table"
     )
-    inspect_cmd.add_argument("--limit", type=int, default=20, help="Maximum patches to show")
-    inspect_cmd.add_argument(
-        "--format",
-        dest="output_format",
-        choices=["table", "json"],
-        default="table",
-        help="Output format",
-    )
-
     keygen = agent_sub.add_parser("keygen", help="Generate an Ed25519 publisher key")
-    keygen.add_argument("private_key", help="New raw private-key file")
-    keygen.add_argument("--public-key", default=None, help="Optional base64 public-key output")
-    keygen.add_argument("--key-id", default=None, help="Optional stable publisher key id")
-
+    keygen.add_argument("private_key")
+    keygen.add_argument("--public-key", default=None)
+    keygen.add_argument("--key-id", default=None)
     pack = agent_sub.add_parser("pack", help="Pack and sign a portable .agent bundle")
-    pack.add_argument("source", help="Agent source directory")
-    pack.add_argument("--output", required=True, help="Output .agent path")
-    pack.add_argument("--name", required=True, help="Portable agent name")
-    pack.add_argument("--agent-version", required=True, help="Portable agent version")
-    pack.add_argument("--author", required=True, help="Publisher or author name")
-    pack.add_argument("--private-key", required=True, help="Raw Ed25519 private-key file")
-    pack.add_argument("--key-id", default=None, help="Publisher key id")
-    pack.add_argument("--description", default="", help="Agent description")
-    pack.add_argument("--entrypoint", default=None, help="Optional bundled FILE:SYMBOL")
-    pack.add_argument("--tag", dest="tags", action="append", default=[], help="Agent tag")
-    pack.add_argument("--eval-score", type=float, default=None, help="Eval score from 0 to 1")
+    pack.add_argument("source")
+    pack.add_argument("--output", required=True)
+    pack.add_argument("--name", required=True)
+    pack.add_argument("--agent-version", required=True)
+    pack.add_argument("--author", required=True)
+    pack.add_argument("--private-key", required=True)
+    pack.add_argument("--key-id", default=None)
+    pack.add_argument("--description", default="")
+    pack.add_argument("--entrypoint", default=None)
+    pack.add_argument("--tag", dest="tags", action="append", default=[])
+    pack.add_argument("--eval-score", type=float, default=None)
 
     def add_trust_options(command: argparse.ArgumentParser) -> None:
-        command.add_argument(
-            "--trusted-key",
-            dest="trusted_keys",
-            action="append",
-            default=None,
-            metavar="KEY_ID:BASE64_PUBLIC_KEY",
-            help="Pin an independently obtained publisher key (repeatable)",
-        )
-        command.add_argument(
-            "--require-trusted",
-            action="store_true",
-            help="Reject bundles whose publisher key is not pinned",
-        )
+        command.add_argument("--trusted-key", dest="trusted_keys", action="append", default=None)
+        command.add_argument("--require-trusted", action="store_true")
 
     verify = agent_sub.add_parser("verify", help="Verify hashes, signature, and publisher trust")
-    verify.add_argument("bundle", help="Path to a .agent bundle")
+    verify.add_argument("bundle")
     verify.add_argument("--format", dest="output_format", choices=["text", "json"], default="text")
     add_trust_options(verify)
-
     unpack = agent_sub.add_parser("unpack", help="Verify and unpack a .agent bundle")
-    unpack.add_argument("bundle", help="Path to a .agent bundle")
-    unpack.add_argument("output", help="New destination directory")
+    unpack.add_argument("bundle")
+    unpack.add_argument("output")
     add_trust_options(unpack)
-
     install = agent_sub.add_parser("install", help="Verify and install an inert agent bundle")
-    install.add_argument("bundle", help="Path to a .agent bundle")
-    install.add_argument("--install-root", default=None, help="Agent installation root")
+    install.add_argument("bundle")
+    install.add_argument("--install-root", default=None)
     add_trust_options(install)
-
     publish = agent_sub.add_parser("publish", help="Publish a bundle to a file-backed registry")
-    publish.add_argument("bundle", help="Path to a .agent bundle")
-    publish.add_argument("--registry", required=True, help="Registry root directory")
-    publish.add_argument(
-        "--allow-untrusted",
-        action="store_true",
-        help="Explicitly allow self-signed publishers in this registry",
-    )
+    publish.add_argument("bundle")
+    publish.add_argument("--registry", required=True)
+    publish.add_argument("--allow-untrusted", action="store_true")
     add_trust_options(publish)
 
 
 def _add_memory_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = subparsers.add_parser("memory", help="Manage Living Memory patches")
     mem_sub = p.add_subparsers(dest="memory_command")
-
     review = mem_sub.add_parser("review", help="Review pending memory patches")
-    review.add_argument("--patch-id", default=None, help="Review a specific patch")
-    review.add_argument(
-        "--store-path",
-        default=".synapsekit_memory_patches.jsonl",
-        help="Patch store file path",
-    )
-
+    review.add_argument("--patch-id", default=None)
+    review.add_argument("--store-path", default=".synapsekit_memory_patches.jsonl")
     apply_cmd = mem_sub.add_parser("apply", help="Apply a pending memory patch")
-    apply_cmd.add_argument("patch_id", help="Patch ID to apply")
-    apply_cmd.add_argument(
-        "--store-path",
-        default=".synapsekit_memory_patches.jsonl",
-        help="Patch store file path",
-    )
-
+    apply_cmd.add_argument("patch_id")
+    apply_cmd.add_argument("--store-path", default=".synapsekit_memory_patches.jsonl")
     revert_cmd = mem_sub.add_parser("revert", help="Revert an applied memory patch")
-    revert_cmd.add_argument("patch_id", help="Patch ID to revert")
-    revert_cmd.add_argument(
-        "--store-path",
-        default=".synapsekit_memory_patches.jsonl",
-        help="Patch store file path",
-    )
-
+    revert_cmd.add_argument("patch_id")
+    revert_cmd.add_argument("--store-path", default=".synapsekit_memory_patches.jsonl")
     log_cmd = mem_sub.add_parser("log", help="View memory patch history")
-    log_cmd.add_argument("--status", default=None, help="Filter by status")
-    log_cmd.add_argument("--limit", type=int, default=20, help="Max patches to show")
+    log_cmd.add_argument("--status", default=None)
+    log_cmd.add_argument("--limit", type=int, default=20)
     log_cmd.add_argument(
-        "--format",
-        dest="output_format",
-        choices=["table", "json"],
-        default="table",
-        help="Output format",
+        "--format", dest="output_format", choices=["table", "json"], default="table"
     )
-    log_cmd.add_argument(
-        "--store-path",
-        default=".synapsekit_memory_patches.jsonl",
-        help="Patch store file path",
-    )
+    log_cmd.add_argument("--store-path", default=".synapsekit_memory_patches.jsonl")
 
 
 def main(argv: list[str] | None = None) -> None:
     """CLI entry point."""
+
     from .._loop import install_fast_loop
 
     install_fast_loop()
-
-    parser = argparse.ArgumentParser(
-        prog="synapsekit",
-        description="SynapseKit CLI — serve apps and run evaluations",
-    )
+    parser = argparse.ArgumentParser(prog="synapsekit", description="SynapseKit CLI")
     parser.add_argument("--version", action="store_true", help="Show version and exit")
-
     subparsers = parser.add_subparsers(dest="command")
     _add_serve_parser(subparsers)
     _add_test_parser(subparsers)
@@ -342,6 +246,7 @@ def main(argv: list[str] | None = None) -> None:
     _add_shell_parser(subparsers)
     _add_dream_parser(subparsers)
     _add_ambient_parser(subparsers)
+    _add_sandbox_parser(subparsers)
     _add_agent_parser(subparsers)
     from .hive import build_hive_parser
 
@@ -350,7 +255,6 @@ def main(argv: list[str] | None = None) -> None:
     _add_ui_parser(subparsers)
     _add_plugin_parser(subparsers)
     _add_audit_parser(subparsers)
-
     args = parser.parse_args(argv)
 
     if args.version:
@@ -359,81 +263,33 @@ def main(argv: list[str] | None = None) -> None:
         print(f"synapsekit {__version__}")
         return
 
-    if args.command == "serve":
-        from .serve import run_serve
-
-        run_serve(args)
-    elif args.command == "test":
-        from .test import run_test
-
-        run_test(args)
-    elif args.command == "eval":
-        from .eval import run_eval
-
-        run_eval(args)
-    elif args.command == "finetune":
-        from .finetune import run_finetune
-
-        run_finetune(args)
-    elif args.command == "graph-builder":
-        from .graph_builder import run_graph_builder
-
-        run_graph_builder(args)
-    elif args.command == "benchmark":
-        from .benchmark import run_benchmark
-
-        run_benchmark(args)
-    elif args.command == "bench":
-        from .bench import run_bench
-
-        run_bench(args)
-    elif args.command == "edge":
-        from .edge import run_edge
-
-        run_edge(args)
-    elif args.command == "mesh":
-        from .mesh import run_mesh
-
-        run_mesh(args)
-    elif args.command == "shell":
-        from .shell import run_shell
-
-        run_shell(args)
-    elif args.command == "dream":
-        from .dream import run_dream
-
-        run_dream(args)
-    elif args.command == "ambient":
-        from .ambient import run_ambient
-
-        run_ambient(args)
-    elif args.command == "agent":
-        from .agent import run_agent
-
-        run_agent(args)
-    elif args.command == "hive":
-        from .hive import run_hive
-
-        run_hive(args)
-    elif args.command == "memory":
-        from .memory import run_memory
-
-        run_memory(args)
-    elif args.command == "ui":
-        from .ui import run_ui
-
-        run_ui(args)
-    elif args.command == "plugin":
-        from .plugins import run_plugin
-
-        run_plugin(args)
-    elif args.command == "audit":
-        from .audit import run_audit
-
-        run_audit(args)
-    else:
+    runners = {
+        "serve": ("serve", "run_serve"),
+        "test": ("test", "run_test"),
+        "eval": ("eval", "run_eval"),
+        "finetune": ("finetune", "run_finetune"),
+        "graph-builder": ("graph_builder", "run_graph_builder"),
+        "benchmark": ("benchmark", "run_benchmark"),
+        "bench": ("bench", "run_bench"),
+        "edge": ("edge", "run_edge"),
+        "mesh": ("mesh", "run_mesh"),
+        "shell": ("shell", "run_shell"),
+        "dream": ("dream", "run_dream"),
+        "ambient": ("ambient", "run_ambient"),
+        "sandbox": ("sandbox", "run_sandbox"),
+        "agent": ("agent", "run_agent"),
+        "hive": ("hive", "run_hive"),
+        "memory": ("memory", "run_memory"),
+        "ui": ("ui", "run_ui"),
+        "plugin": ("plugins", "run_plugin"),
+        "audit": ("audit", "run_audit"),
+    }
+    if args.command not in runners:
         parser.print_help()
-        sys.exit(1)
+        raise SystemExit(1)
+    module_name, function_name = runners[args.command]
+    module = __import__(f"{__package__}.{module_name}", fromlist=[function_name])
+    getattr(module, function_name)(args)
 
 
 if __name__ == "__main__":

--- a/src/synapsekit/cli/sandbox.py
+++ b/src/synapsekit/cli/sandbox.py
@@ -1,0 +1,142 @@
+"""``synapsekit sandbox`` lifecycle commands."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from ..sandbox import DiffBundle, PCSandbox
+
+
+def build_sandbox_parser(subparsers: Any) -> None:
+    parser = subparsers.add_parser("sandbox", help="Manage isolated PC Twin sessions")
+    commands = parser.add_subparsers(dest="sandbox_command")
+
+    spawn = commands.add_parser("spawn", help="Create and start a sandbox session")
+    spawn.add_argument("--base", default="current_user", help="Host root to snapshot")
+    spawn.add_argument(
+        "--backend", default="docker", choices=["docker", "orbstack", "lima", "firecracker", "fake"]
+    )
+    spawn.add_argument("--network", default="none", choices=["none", "egress_only"])
+    spawn.add_argument(
+        "--include", action="append", default=[], help="Relative include path (repeatable)"
+    )
+    spawn.add_argument(
+        "--exclude", action="append", default=None, help="Relative exclude path (repeatable)"
+    )
+    spawn.add_argument("--state-dir", default=None, help="Session metadata directory")
+    spawn.add_argument("--image", default="python:3.12-slim", help="Docker image")
+    spawn.add_argument("--format", dest="output_format", choices=["text", "json"], default="text")
+
+    diff = commands.add_parser("diff", help="Generate a diff bundle for a session")
+    diff.add_argument("session_id")
+    diff.add_argument("--state-dir", default=None)
+    diff.add_argument("--output", default=None, help="Write a .diff.zip bundle")
+    diff.add_argument("--format", dest="output_format", choices=["text", "json"], default="text")
+
+    apply = commands.add_parser("apply", help="Apply an evaluated diff bundle")
+    apply.add_argument("bundle")
+    apply.add_argument("--receipt", required=True, help="JSON evaluation receipt")
+    apply.add_argument("--yes", action="store_true", help="Confirm host mutation")
+
+    discard = commands.add_parser("discard", help="Discard a sandbox session")
+    discard.add_argument("session_id")
+    discard.add_argument("--state-dir", default=None)
+
+
+def run_sandbox(args: argparse.Namespace) -> None:
+    command = getattr(args, "sandbox_command", None)
+    if command == "spawn":
+        _run_spawn(args)
+        return
+    if command == "diff":
+        _run_diff(args)
+        return
+    if command == "apply":
+        _run_apply(args)
+        return
+    if command == "discard":
+        _run_discard(args)
+        return
+    raise SystemExit("Missing sandbox subcommand. Use: spawn, diff, apply, or discard")
+
+
+def _run_spawn(args: argparse.Namespace) -> None:
+    sandbox = PCSandbox(
+        base=args.base,
+        backend=args.backend,
+        network=args.network,
+        include=tuple(args.include),
+        exclude=None if args.exclude is None else tuple(args.exclude),
+        state_dir=args.state_dir,
+        image=args.image,
+    )
+    environment = asyncio.run(sandbox.start())
+    payload = {
+        "session_id": environment.session_id,
+        "backend": environment.handle.backend,
+        "state": environment.state.value,
+        "host_root": str(environment.host_root),
+        "work_root": str(environment.work_root),
+        "base_fingerprint": environment.baseline.fingerprint,
+    }
+    if args.output_format == "json":
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"Sandbox: {payload['session_id']}")
+        print(f"Backend: {payload['backend']}")
+        print(f"Workspace: {payload['work_root']}")
+
+
+def _run_diff(args: argparse.Namespace) -> None:
+    sandbox = asyncio.run(PCSandbox.attach(args.session_id, state_dir=args.state_dir))
+    environment = sandbox._environment
+    if environment is None:
+        raise SystemExit("Sandbox session is not available.")
+    diff = asyncio.run(environment.diff_against_host())
+    if args.output:
+        DiffBundle.write(diff, args.output)
+    preview = diff.preview()
+    payload = {
+        "session_id": diff.sandbox_id,
+        "digest": diff.digest,
+        "bundle": str(Path(args.output).resolve()) if args.output else None,
+        "preview": {
+            "changes": preview.changes,
+            "additions": preview.additions,
+            "modifications": preview.modifications,
+            "deletions": preview.deletions,
+            "directories": preview.directories,
+            "total_bytes": preview.total_bytes,
+        },
+    }
+    if args.output_format == "json":
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"Diff: {payload['digest']}")
+        print(f"Changes: {preview.changes}")
+        if args.output:
+            print(f"Bundle: {payload['bundle']}")
+
+
+def _run_apply(args: argparse.Namespace) -> None:
+    if not args.yes:
+        raise SystemExit("Refusing host mutation without --yes.")
+    bundle = DiffBundle.read(args.bundle)
+    receipt_data = json.loads(Path(args.receipt).read_text(encoding="utf-8"))
+    receipt = SimpleNamespace(
+        passed=bool(receipt_data.get("passed")),
+        diff_sha256=receipt_data.get("diff_sha256"),
+    )
+    asyncio.run(bundle.apply(receipt))
+    print(f"Applied diff {bundle.digest}")
+
+
+def _run_discard(args: argparse.Namespace) -> None:
+    sandbox = asyncio.run(PCSandbox.attach(args.session_id, state_dir=args.state_dir))
+    asyncio.run(sandbox.discard())
+    print(f"Discarded sandbox {args.session_id}")

--- a/src/synapsekit/computer_use/agent.py
+++ b/src/synapsekit/computer_use/agent.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import inspect
 from pathlib import Path
+from typing import Any
 
+from ..audit import EventKind
 from .recorder import SessionRecorder
 from .safety import SafetyPolicy
 from .types import (
+    ComputerAction,
     ComputerActionType,
+    ComputerObservation,
     ComputerStep,
     ComputerUseProvider,
     ComputerUseResult,
@@ -14,6 +18,38 @@ from .types import (
     SafetyDecision,
     ScreenProvider,
 )
+
+
+def _action_audit_payload(action: ComputerAction) -> dict[str, Any]:
+    """Return useful action metadata without duplicating typed secret content."""
+
+    return {
+        "type": action.action_type.value,
+        "x": action.x,
+        "y": action.y,
+        "end_x": action.end_x,
+        "end_y": action.end_y,
+        "text_length": len(action.text) if action.text is not None else 0,
+        "key": action.key,
+        "keys": list(action.keys),
+        "delta_x": action.delta_x,
+        "delta_y": action.delta_y,
+        "url": action.url,
+        "duration": action.duration,
+        "reason": action.reason,
+    }
+
+
+def _record_environment_event(env: object | None, payload: dict[str, Any]) -> None:
+    tracer = getattr(env, "tracer", None)
+    session_id = getattr(env, "session_id", None)
+    if tracer is None:
+        return
+    tracer.record(
+        EventKind.SYSTEM_EVENT,
+        payload,
+        actor=f"sandbox:{session_id}" if session_id else "computer-use",
+    )
 
 
 class ComputerUseAgent:
@@ -42,8 +78,16 @@ class ComputerUseAgent:
         else:
             self.recorder = recorder
 
-    async def run(self, task: str) -> ComputerUseResult:
-        """Run a task until the provider returns ``done`` or a safety/error stop occurs."""
+    async def run(self, task: str, *, env: object | None = None) -> ComputerUseResult:
+        """Run a task, optionally using a sandbox environment's screen.
+
+        The environment owns its screen lifecycle. Consequently a screen
+        supplied through ``env`` is never closed by this agent.
+        """
+
+        active_screen = getattr(env, "screen", None) if env is not None else self.screen
+        if active_screen is None:
+            raise ValueError("ComputerUseAgent requires a screen or an environment with screen.")
 
         steps: list[ComputerStep] = []
         output = ""
@@ -51,15 +95,38 @@ class ComputerUseAgent:
         completed = False
         if self.recorder is not None:
             self.recorder.start(task)
+        _record_environment_event(env, {"event": "computer.run.start", "task": task})
 
         try:
             for _ in range(self.max_steps):
-                observation = await self.screen.observe()
+                observation = await active_screen.observe()
+                _record_environment_event(
+                    env,
+                    {
+                        "event": "computer.observe",
+                        "app": observation.app,
+                        "window_title": observation.window_title,
+                        "url": observation.url,
+                        "width": observation.width,
+                        "height": observation.height,
+                        "has_screenshot": observation.screenshot is not None,
+                        "text_length": len(observation.text),
+                    },
+                )
                 if self.recorder is not None:
                     self.recorder.record_observation(observation)
 
                 action = await self.provider.next_action(task, observation, steps)
                 safety = self.safety.check(action, observation, task=task)
+                _record_environment_event(
+                    env,
+                    {
+                        "event": "computer.action",
+                        "action": _action_audit_payload(action),
+                        "safety": safety.decision.value,
+                        "safety_reason": safety.reason,
+                    },
+                )
                 if self.recorder is not None:
                     self.recorder.record_action(action, safety)
 
@@ -75,6 +142,14 @@ class ComputerUseAgent:
 
                 if safety.decision == SafetyDecision.NEEDS_CONFIRMATION:
                     confirmed = await self._confirm(action, observation)
+                    _record_environment_event(
+                        env,
+                        {
+                            "event": "computer.confirmation",
+                            "action": _action_audit_payload(action),
+                            "confirmed": confirmed,
+                        },
+                    )
                     if not confirmed:
                         error = "Human confirmation denied."
                         step = ComputerStep(
@@ -99,7 +174,15 @@ class ComputerUseAgent:
                         self.recorder.record_step(step)
                     break
 
-                execution_output = await self.screen.execute(action)
+                execution_output = await active_screen.execute(action)
+                _record_environment_event(
+                    env,
+                    {
+                        "event": "computer.execute",
+                        "action": _action_audit_payload(action),
+                        "output": execution_output[-2000:],
+                    },
+                )
                 step = ComputerStep(
                     observation=observation,
                     action=action,
@@ -113,11 +196,22 @@ class ComputerUseAgent:
                 error = f"ComputerUseAgent reached max_steps={self.max_steps}."
         except Exception as exc:
             error = str(exc)
+            _record_environment_event(env, {"event": "computer.run.error", "error": error})
         finally:
             if self.recorder is not None:
                 self.recorder.finish(completed=completed, output=output, error=error)
-            if self.close_screen:
-                await self.screen.close()
+            _record_environment_event(
+                env,
+                {
+                    "event": "computer.run.finish",
+                    "completed": completed,
+                    "output": output[-2000:],
+                    "error": error,
+                    "steps": len(steps),
+                },
+            )
+            if self.close_screen and env is None:
+                await active_screen.close()
 
         return ComputerUseResult(
             task=task,
@@ -128,7 +222,7 @@ class ComputerUseAgent:
             recording_path=self.recorder.path if self.recorder is not None else None,
         )
 
-    async def _confirm(self, action, observation) -> bool:
+    async def _confirm(self, action: ComputerAction, observation: ComputerObservation) -> bool:
         if self.confirm is None:
             return False
         result = self.confirm(action, observation)

--- a/src/synapsekit/sandbox/__init__.py
+++ b/src/synapsekit/sandbox/__init__.py
@@ -1,0 +1,51 @@
+"""Local-first sandboxed PC Twin primitives.
+
+The sandbox package is deliberately dependency-light. Backends are discovered
+at runtime and fail closed when their native runtime is unavailable.
+"""
+
+from .diff import DiffBundle, DiffPreview
+from .errors import (
+    ApplyConflictError,
+    BackendUnavailableError,
+    SandboxError,
+    SandboxSecurityError,
+    SandboxStateError,
+)
+from .eval import CallableEvalGate, CommandEvalGate, EvalReceipt, EvalSuiteGate
+from .overlay import FsOverlay
+from .pc import PCSandbox
+from .types import (
+    BackendCapabilities,
+    CommandResult,
+    FileChange,
+    FileChangeKind,
+    NetworkPolicy,
+    SandboxConfig,
+    SandboxState,
+    SnapshotManifest,
+)
+
+__all__ = [
+    "ApplyConflictError",
+    "BackendCapabilities",
+    "BackendUnavailableError",
+    "CallableEvalGate",
+    "CommandEvalGate",
+    "CommandResult",
+    "DiffBundle",
+    "DiffPreview",
+    "EvalReceipt",
+    "EvalSuiteGate",
+    "FileChange",
+    "FileChangeKind",
+    "FsOverlay",
+    "NetworkPolicy",
+    "PCSandbox",
+    "SandboxConfig",
+    "SandboxError",
+    "SandboxSecurityError",
+    "SandboxState",
+    "SandboxStateError",
+    "SnapshotManifest",
+]

--- a/src/synapsekit/sandbox/apply.py
+++ b/src/synapsekit/sandbox/apply.py
@@ -1,0 +1,151 @@
+"""Preflighted, rollback-based host application of diff bundles."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import stat
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .diff import DiffBundle
+from .errors import ApplyConflictError, SandboxSecurityError
+from .types import FileChange, FileChangeKind, normalize_relative_path
+
+
+def _file_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _exists(path: Path) -> bool:
+    return path.exists() or path.is_symlink()
+
+
+def _safe_target(root: Path, relative: str) -> Path:
+    safe = normalize_relative_path(relative)
+    target = root.joinpath(*safe.split("/"))
+    current = root
+    for component in safe.split("/")[:-1]:
+        current = current / component
+        if current.is_symlink():
+            raise SandboxSecurityError(f"Diff target traverses a symlink: {relative!r}")
+    try:
+        target.parent.resolve(strict=False).relative_to(root.resolve())
+    except ValueError as exc:
+        raise SandboxSecurityError(f"Diff target escapes host root: {relative!r}") from exc
+    return target
+
+
+def _matches_expected(path: Path, change: FileChange) -> bool:
+    if change.kind in {FileChangeKind.ADD, FileChangeKind.MKDIR}:
+        return not _exists(path)
+    if not _exists(path):
+        return False
+    if change.before_sha256 is not None:
+        return (
+            path.is_file() and not path.is_symlink() and _file_digest(path) == change.before_sha256
+        )
+    if change.kind == FileChangeKind.DELETE:
+        return path.is_dir() and not path.is_symlink()
+    return True
+
+
+def _backup(path: Path, backup: Path) -> None:
+    if path.is_symlink():
+        backup.parent.mkdir(parents=True, exist_ok=True)
+        backup.symlink_to(os.readlink(path), target_is_directory=path.is_dir())
+    elif path.is_dir():
+        shutil.copytree(path, backup)
+    else:
+        backup.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, backup)
+
+
+def _remove(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+def _apply_change(root: Path, change: FileChange) -> None:
+    target = _safe_target(root, change.path)
+    if change.kind == FileChangeKind.MKDIR:
+        target.mkdir(parents=True, exist_ok=False)
+        if change.mode is not None:
+            target.chmod(stat.S_IMODE(change.mode))
+        return
+    if change.kind in {FileChangeKind.DELETE, FileChangeKind.RMDIR}:
+        _remove(target)
+        return
+    if change.payload is None:
+        raise SandboxSecurityError(f"File operation is missing payload: {change.path!r}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = target.with_name(f".{target.name}.synapsekit-tmp")
+    temporary.write_bytes(change.payload)
+    if change.mode is not None:
+        temporary.chmod(stat.S_IMODE(change.mode))
+    os.replace(temporary, target)
+
+
+def apply_bundle(
+    bundle: DiffBundle,
+    receipt: Any,
+    *,
+    host_root: str | Path | None = None,
+) -> None:
+    """Apply a bundle transactionally, restoring the host on failure."""
+
+    if not getattr(receipt, "passed", False):
+        raise ApplyConflictError("A diff cannot be applied without a passing evaluation receipt.")
+    if getattr(receipt, "diff_sha256", None) != bundle.digest:
+        raise ApplyConflictError("Evaluation receipt does not match this diff bundle.")
+
+    root = Path(host_root or bundle.host_root).expanduser().resolve()
+    if not root.is_dir():
+        raise FileNotFoundError(f"Host root does not exist: {root}")
+
+    targets = [(_safe_target(root, change.path), change) for change in bundle.changes]
+    for target, change in targets:
+        if not _matches_expected(target, change):
+            raise ApplyConflictError(f"Host changed since snapshot: {change.path}")
+
+    journal = Path(tempfile.mkdtemp(prefix=".synapsekit-apply-", dir=str(root.parent)))
+    backups: list[tuple[Path, Path]] = []
+    created: list[Path] = []
+    try:
+        for index, (target, _change) in enumerate(targets):
+            if _exists(target):
+                backup = journal / str(index)
+                _backup(target, backup)
+                backups.append((target, backup))
+
+        for target, change in targets:
+            if change.kind in {FileChangeKind.ADD, FileChangeKind.MKDIR}:
+                created.append(target)
+            _apply_change(root, change)
+
+        for target, change in targets:
+            if change.after_sha256 is not None and (
+                not target.is_file() or _file_digest(target) != change.after_sha256
+            ):
+                raise ApplyConflictError(f"Post-apply verification failed: {change.path}")
+    except Exception:
+        for target in sorted(created, key=lambda item: len(item.parts), reverse=True):
+            if _exists(target):
+                _remove(target)
+        for target, backup in reversed(backups):
+            if _exists(target):
+                _remove(target)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if backup.is_dir() and not backup.is_symlink():
+                shutil.copytree(backup, target)
+            elif backup.is_symlink():
+                target.symlink_to(os.readlink(backup), target_is_directory=backup.is_dir())
+            else:
+                shutil.copy2(backup, target)
+        raise
+    finally:
+        shutil.rmtree(journal, ignore_errors=True)

--- a/src/synapsekit/sandbox/backends/__init__.py
+++ b/src/synapsekit/sandbox/backends/__init__.py
@@ -1,0 +1,18 @@
+"""Runtime-selectable sandbox backends."""
+
+from .base import BackendHandle, SandboxBackend, build_backend
+from .docker import DockerBackend, OrbStackBackend
+from .fake import FakeBackend
+from .firecracker import FirecrackerBackend
+from .lima import LimaBackend
+
+__all__ = [
+    "BackendHandle",
+    "DockerBackend",
+    "FakeBackend",
+    "FirecrackerBackend",
+    "LimaBackend",
+    "OrbStackBackend",
+    "SandboxBackend",
+    "build_backend",
+]

--- a/src/synapsekit/sandbox/backends/base.py
+++ b/src/synapsekit/sandbox/backends/base.py
@@ -1,0 +1,123 @@
+"""Backend protocol and factory."""
+
+from __future__ import annotations
+
+import asyncio
+import platform
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+from ..errors import BackendUnavailableError
+from ..types import BackendCapabilities, CommandResult, SandboxConfig
+
+
+@dataclass(slots=True)
+class BackendHandle:
+    """Persistable handle for a running backend instance."""
+
+    backend: str
+    identifier: str
+    work_root: str
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+class SandboxBackend:
+    """Async execution contract implemented by each backend."""
+
+    name = "backend"
+
+    async def probe(self) -> BackendCapabilities:
+        raise NotImplementedError
+
+    async def start(
+        self,
+        *,
+        session_id: str,
+        work_root: str,
+        config: SandboxConfig,
+    ) -> BackendHandle:
+        raise NotImplementedError
+
+    async def exec(
+        self,
+        handle: BackendHandle,
+        command: Sequence[str],
+        *,
+        timeout: float,
+    ) -> CommandResult:
+        raise NotImplementedError
+
+    async def close(self, handle: BackendHandle) -> None:
+        raise NotImplementedError
+
+
+async def run_process(
+    command: Sequence[str],
+    *,
+    cwd: str | None = None,
+    timeout: float = 120.0,
+) -> CommandResult:
+    """Run an executable without invoking a shell."""
+
+    if not command:
+        raise ValueError("Backend command must not be empty.")
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=cwd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        return CommandResult(returncode=127, stderr=f"Executable not found: {command[0]}")
+
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
+    except TimeoutError:
+        process.kill()
+        await process.communicate()
+        return CommandResult(returncode=124, stderr=f"Command timed out after {timeout:.1f}s.")
+    return CommandResult(
+        returncode=process.returncode or 0,
+        stdout=stdout.decode("utf-8", errors="replace"),
+        stderr=stderr.decode("utf-8", errors="replace"),
+    )
+
+
+def unavailable(capabilities: BackendCapabilities) -> BackendCapabilities:
+    return capabilities
+
+
+def build_backend(name: str) -> SandboxBackend:
+    """Construct a backend by stable public name."""
+
+    normalized = name.strip().lower()
+    if normalized == "docker":
+        from .docker import DockerBackend
+
+        return DockerBackend()
+    if normalized == "orbstack":
+        from .docker import OrbStackBackend
+
+        return OrbStackBackend()
+    if normalized == "lima":
+        from .lima import LimaBackend
+
+        return LimaBackend()
+    if normalized == "firecracker":
+        from .firecracker import FirecrackerBackend
+
+        return FirecrackerBackend()
+    if normalized == "fake":
+        from .fake import FakeBackend
+
+        return FakeBackend()
+    raise BackendUnavailableError(f"Unknown sandbox backend: {name!r}.")
+
+
+def platform_is_linux() -> bool:
+    return platform.system().lower() == "linux"
+
+
+def platform_is_macos() -> bool:
+    return platform.system().lower() == "darwin"

--- a/src/synapsekit/sandbox/backends/docker.py
+++ b/src/synapsekit/sandbox/backends/docker.py
@@ -1,0 +1,129 @@
+"""Docker and OrbStack-compatible sandbox backend."""
+
+from __future__ import annotations
+
+import platform
+from collections.abc import Sequence
+
+from ..errors import BackendUnavailableError
+from ..types import BackendCapabilities, CommandResult, NetworkPolicy, SandboxConfig
+from .base import BackendHandle, SandboxBackend, run_process
+
+
+class DockerBackend(SandboxBackend):
+    """Run a session in a restricted, detached Docker container."""
+
+    name = "docker"
+
+    async def probe(self) -> BackendCapabilities:
+        result = await run_process(["docker", "version", "--format", "{{.Server.Version}}"])
+        if not result.ok:
+            return BackendCapabilities(
+                name=self.name,
+                available=False,
+                reason=result.stderr.strip() or "Docker daemon is unavailable.",
+            )
+        return BackendCapabilities(
+            name=self.name,
+            available=True,
+            native_cow=False,
+            gui=False,
+            network_policies=(NetworkPolicy.NONE.value, NetworkPolicy.EGRESS_ONLY.value),
+            reason=result.stdout.strip() or None,
+        )
+
+    async def start(
+        self,
+        *,
+        session_id: str,
+        work_root: str,
+        config: SandboxConfig,
+    ) -> BackendHandle:
+        capabilities = await self.probe()
+        if not capabilities.available:
+            raise BackendUnavailableError(capabilities.reason or "Docker is unavailable.")
+
+        container_name = f"synapsekit-sandbox-{session_id[:20]}"
+        command: list[str] = [
+            "docker",
+            "run",
+            "--detach",
+            "--rm",
+            "--name",
+            container_name,
+            "--read-only",
+            "--tmpfs",
+            "/tmp:rw,noexec,nosuid,size=256m",
+            "--cap-drop",
+            "ALL",
+            "--security-opt",
+            "no-new-privileges",
+            "--pids-limit",
+            str(config.pids_limit),
+            "--volume",
+            f"{work_root}:/workspace:rw",
+            "--workdir",
+            "/workspace",
+        ]
+        if config.memory:
+            command.extend(["--memory", config.memory])
+        if config.cpus is not None:
+            command.extend(["--cpus", str(config.cpus)])
+        if config.network == NetworkPolicy.NONE.value:
+            command.extend(["--network", "none"])
+        elif config.network == NetworkPolicy.EGRESS_ONLY.value:
+            command.extend(["--network", "bridge"])
+        for key, value in config.sanitized_environment.items():
+            command.extend(["--env", f"{key}={value}"])
+        command.extend([config.image, "sleep", "infinity"])
+
+        result = await run_process(command, timeout=config.command_timeout)
+        if not result.ok:
+            raise BackendUnavailableError(
+                result.stderr.strip() or "Docker failed to start sandbox."
+            )
+        identifier = result.stdout.strip().splitlines()[-1]
+        return BackendHandle(
+            backend=self.name,
+            identifier=identifier,
+            work_root=work_root,
+            metadata={"container_name": container_name},
+        )
+
+    async def exec(
+        self,
+        handle: BackendHandle,
+        command: Sequence[str],
+        *,
+        timeout: float,
+    ) -> CommandResult:
+        return await run_process(
+            ["docker", "exec", "--workdir", "/workspace", handle.identifier, *command],
+            timeout=timeout,
+        )
+
+    async def close(self, handle: BackendHandle) -> None:
+        await run_process(["docker", "rm", "--force", handle.identifier], timeout=30.0)
+
+
+class OrbStackBackend(DockerBackend):
+    """OrbStack adapter using its Docker-compatible local engine on macOS."""
+
+    name = "orbstack"
+
+    async def probe(self) -> BackendCapabilities:
+        if platform.system().lower() != "darwin":
+            return BackendCapabilities(
+                name=self.name,
+                available=False,
+                reason="OrbStack is supported only on macOS.",
+            )
+        capabilities = await super().probe()
+        return BackendCapabilities(
+            name=self.name,
+            available=capabilities.available,
+            native_cow=capabilities.native_cow,
+            gui=bool(capabilities.available),
+            network_policies=capabilities.network_policies,
+            reason=capabilities.reason,
+        )

--- a/src/synapsekit/sandbox/backends/fake.py
+++ b/src/synapsekit/sandbox/backends/fake.py
@@ -1,0 +1,48 @@
+"""Deterministic local backend used by tests and examples."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from ..types import BackendCapabilities, CommandResult, NetworkPolicy, SandboxConfig
+from .base import BackendHandle, SandboxBackend, run_process
+
+
+class FakeBackend(SandboxBackend):
+    """Execute commands in a materialized test worktree.
+
+    This backend is intentionally not a security boundary and must never be
+    selected as a production backend.
+    """
+
+    name = "fake"
+
+    async def probe(self) -> BackendCapabilities:
+        return BackendCapabilities(
+            name=self.name,
+            available=True,
+            native_cow=False,
+            gui=False,
+            network_policies=(NetworkPolicy.NONE.value,),
+        )
+
+    async def start(
+        self,
+        *,
+        session_id: str,
+        work_root: str,
+        config: SandboxConfig,
+    ) -> BackendHandle:
+        return BackendHandle(backend=self.name, identifier=session_id, work_root=work_root)
+
+    async def exec(
+        self,
+        handle: BackendHandle,
+        command: Sequence[str],
+        *,
+        timeout: float,
+    ) -> CommandResult:
+        return await run_process(command, cwd=handle.work_root, timeout=timeout)
+
+    async def close(self, handle: BackendHandle) -> None:
+        return None

--- a/src/synapsekit/sandbox/backends/firecracker.py
+++ b/src/synapsekit/sandbox/backends/firecracker.py
@@ -1,0 +1,56 @@
+"""Firecracker capability boundary."""
+
+from __future__ import annotations
+
+import platform
+from collections.abc import Sequence
+
+from ..errors import BackendUnavailableError
+from ..types import BackendCapabilities, CommandResult, SandboxConfig
+from .base import BackendHandle, SandboxBackend, run_process
+
+
+class FirecrackerBackend(SandboxBackend):
+    name = "firecracker"
+
+    async def probe(self) -> BackendCapabilities:
+        if platform.system().lower() != "linux":
+            return BackendCapabilities(
+                name=self.name,
+                available=False,
+                reason="Firecracker requires Linux.",
+            )
+        result = await run_process(["firecracker", "--version"], timeout=20.0)
+        return BackendCapabilities(
+            name=self.name,
+            available=result.ok,
+            native_cow=True,
+            reason=result.stdout.strip()
+            if result.ok
+            else result.stderr.strip() or "firecracker is unavailable.",
+        )
+
+    async def start(
+        self,
+        *,
+        session_id: str,
+        work_root: str,
+        config: SandboxConfig,
+    ) -> BackendHandle:
+        capabilities = await self.probe()
+        raise BackendUnavailableError(
+            capabilities.reason
+            or "Firecracker requires provisioned kernel, rootfs, and device configuration."
+        )
+
+    async def exec(
+        self,
+        handle: BackendHandle,
+        command: Sequence[str],
+        *,
+        timeout: float,
+    ) -> CommandResult:
+        raise BackendUnavailableError("Firecracker execution is not configured for this host.")
+
+    async def close(self, handle: BackendHandle) -> None:
+        return None

--- a/src/synapsekit/sandbox/backends/lima.py
+++ b/src/synapsekit/sandbox/backends/lima.py
@@ -1,0 +1,59 @@
+"""Lima backend capability boundary.
+
+Lima's VM image and mount policy are host-specific.  The adapter intentionally
+fails closed until a configured instance is supplied rather than silently
+running commands on the host.
+"""
+
+from __future__ import annotations
+
+import platform
+from collections.abc import Sequence
+
+from ..errors import BackendUnavailableError
+from ..types import BackendCapabilities, CommandResult, SandboxConfig
+from .base import BackendHandle, SandboxBackend, run_process
+
+
+class LimaBackend(SandboxBackend):
+    name = "lima"
+
+    async def probe(self) -> BackendCapabilities:
+        if platform.system().lower() not in {"darwin", "linux"}:
+            return BackendCapabilities(
+                name=self.name, available=False, reason="Lima requires macOS or Linux."
+            )
+        result = await run_process(["limactl", "--version"], timeout=20.0)
+        return BackendCapabilities(
+            name=self.name,
+            available=result.ok,
+            native_cow=False,
+            reason=result.stdout.strip()
+            if result.ok
+            else result.stderr.strip() or "limactl is unavailable.",
+        )
+
+    async def start(
+        self,
+        *,
+        session_id: str,
+        work_root: str,
+        config: SandboxConfig,
+    ) -> BackendHandle:
+        capabilities = await self.probe()
+        raise BackendUnavailableError(
+            capabilities.reason
+            or "Lima requires an explicitly configured VM image and read-only mount policy."
+        )
+
+    async def exec(
+        self,
+        handle: BackendHandle,
+        command: Sequence[str],
+        *,
+        timeout: float,
+    ) -> CommandResult:
+        raise BackendUnavailableError("Lima execution is not configured for this host.")
+
+    async def close(self, handle: BackendHandle) -> None:
+        return None

--- a/src/synapsekit/sandbox/diff.py
+++ b/src/synapsekit/sandbox/diff.py
@@ -1,0 +1,264 @@
+"""Deterministic, reviewable filesystem diff bundles."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .errors import SandboxSecurityError
+from .overlay import read_file_item
+from .types import FileChange, FileChangeKind, SnapshotManifest, normalize_relative_path
+
+_SCHEMA_VERSION = "1.0"
+_FIXED_ZIP_DATE_TIME = (1980, 1, 1, 0, 0, 0)
+
+
+@dataclass(frozen=True, slots=True)
+class DiffPreview:
+    additions: int
+    modifications: int
+    deletions: int
+    directories: int
+    total_bytes: int
+
+    @property
+    def changes(self) -> int:
+        return self.additions + self.modifications + self.deletions + self.directories
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _change_to_dict(change: FileChange, *, include_payload: bool) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "kind": change.kind.value,
+        "path": normalize_relative_path(change.path),
+        "before_sha256": change.before_sha256,
+        "after_sha256": change.after_sha256,
+        "size": change.size,
+        "mode": change.mode,
+    }
+    if include_payload:
+        data["payload"] = (
+            base64.b64encode(change.payload).decode("ascii") if change.payload is not None else None
+        )
+    return data
+
+
+def _change_from_dict(data: dict[str, Any]) -> FileChange:
+    payload_value = data.get("payload")
+    payload = base64.b64decode(payload_value) if payload_value is not None else None
+    return FileChange(
+        kind=FileChangeKind(str(data["kind"])),
+        path=normalize_relative_path(str(data["path"])),
+        before_sha256=data.get("before_sha256"),
+        after_sha256=data.get("after_sha256"),
+        size=int(data.get("size", 0)),
+        mode=None if data.get("mode") is None else int(data["mode"]),
+        payload=payload,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class DiffBundle:
+    """Immutable set of host-relative operations produced by a snapshot."""
+
+    host_root: str
+    base_fingerprint: str
+    sandbox_id: str
+    changes: tuple[FileChange, ...]
+    audit_run_id: str | None = None
+    created_at: str = ""
+    schema_version: str = _SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != _SCHEMA_VERSION:
+            raise ValueError(f"Unsupported diff bundle schema: {self.schema_version!r}.")
+        if not self.created_at:
+            object.__setattr__(self, "created_at", datetime.now(timezone.utc).isoformat())
+        paths = [normalize_relative_path(change.path) for change in self.changes]
+        if len(paths) != len(set(paths)):
+            raise SandboxSecurityError("Diff bundle contains duplicate paths.")
+
+    @classmethod
+    def from_manifests(
+        cls,
+        before: SnapshotManifest,
+        after: SnapshotManifest,
+        *,
+        current_root: str | Path,
+        sandbox_id: str,
+        audit_run_id: str | None = None,
+    ) -> DiffBundle:
+        before_by_path = {str(item["path"]): item for item in before.items}
+        after_by_path = {str(item["path"]): item for item in after.items}
+        changes: list[FileChange] = []
+        for path in sorted(set(before_by_path) | set(after_by_path), key=str.casefold):
+            old = before_by_path.get(path)
+            new = after_by_path.get(path)
+            if old == new:
+                continue
+            if old is None:
+                changes.append(_make_change(FileChangeKind.ADD, path, new, current_root))
+            elif new is None:
+                kind = FileChangeKind.RMDIR if old.get("kind") == "dir" else FileChangeKind.DELETE
+                changes.append(_make_change(kind, path, old, None))
+            elif old.get("kind") != new.get("kind"):
+                raise SandboxSecurityError(f"Filesystem type changes are not supported: {path!r}")
+            elif new.get("kind") == "dir":
+                continue
+            elif new.get("kind") == "file":
+                changes.append(_make_change(FileChangeKind.MODIFY, path, new, current_root, old))
+            else:
+                raise SandboxSecurityError(f"Symlink changes are not supported in diffs: {path!r}")
+        changes.sort(key=_operation_sort_key)
+        return cls(
+            host_root=str(Path(before.root).resolve()),
+            base_fingerprint=before.fingerprint,
+            sandbox_id=sandbox_id,
+            changes=tuple(changes),
+            audit_run_id=audit_run_id,
+        )
+
+    @property
+    def digest(self) -> str:
+        return _sha256(_canonical(self.to_dict(include_payload=True)))
+
+    def to_dict(self, *, include_payload: bool = True) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "host_root": self.host_root,
+            "base_fingerprint": self.base_fingerprint,
+            "sandbox_id": self.sandbox_id,
+            "audit_run_id": self.audit_run_id,
+            "created_at": self.created_at,
+            "changes": [_change_to_dict(c, include_payload=include_payload) for c in self.changes],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DiffBundle:
+        if str(data.get("schema_version")) != _SCHEMA_VERSION:
+            raise ValueError("Unsupported diff bundle schema.")
+        return cls(
+            host_root=str(data["host_root"]),
+            base_fingerprint=str(data["base_fingerprint"]),
+            sandbox_id=str(data["sandbox_id"]),
+            audit_run_id=data.get("audit_run_id"),
+            created_at=str(data.get("created_at", "")),
+            changes=tuple(_change_from_dict(value) for value in data.get("changes", [])),
+        )
+
+    def preview(self) -> DiffPreview:
+        return DiffPreview(
+            additions=sum(c.kind == FileChangeKind.ADD for c in self.changes),
+            modifications=sum(c.kind == FileChangeKind.MODIFY for c in self.changes),
+            deletions=sum(c.kind == FileChangeKind.DELETE for c in self.changes),
+            directories=sum(
+                c.kind in {FileChangeKind.MKDIR, FileChangeKind.RMDIR} for c in self.changes
+            ),
+            total_bytes=sum(c.size for c in self.changes if c.payload is not None),
+        )
+
+    def write(self, path: str | Path) -> Path:
+        output = Path(path).expanduser()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        manifest = self.to_dict(include_payload=True)
+        manifest["digest"] = self.digest
+        info = zipfile.ZipInfo("manifest.json", date_time=_FIXED_ZIP_DATE_TIME)
+        info.compress_type = zipfile.ZIP_DEFLATED
+        with zipfile.ZipFile(output, "w") as archive:
+            archive.writestr(info, _canonical(manifest) + b"\n")
+        return output
+
+    @classmethod
+    def read(cls, path: str | Path) -> DiffBundle:
+        with zipfile.ZipFile(Path(path), "r") as archive:
+            data = json.loads(archive.read("manifest.json"))
+        bundle = cls.from_dict(data)
+        if data.get("digest") is not None and data["digest"] != bundle.digest:
+            raise SandboxSecurityError("Diff bundle digest does not match its manifest.")
+        return bundle
+
+    async def apply(self, receipt: Any, *, host_root: str | Path | None = None) -> None:
+        from .apply import apply_bundle
+
+        await asyncio.to_thread(apply_bundle, self, receipt, host_root=host_root)
+
+
+def _operation_sort_key(change: FileChange) -> tuple[int, int, str]:
+    if change.kind == FileChangeKind.MKDIR:
+        return (0, change.path.count("/"), change.path.casefold())
+    if change.kind == FileChangeKind.RMDIR:
+        return (3, -change.path.count("/"), change.path.casefold())
+    if change.kind == FileChangeKind.DELETE:
+        return (2, -change.path.count("/"), change.path.casefold())
+    return (1, change.path.count("/"), change.path.casefold())
+
+
+def _make_change(
+    kind: FileChangeKind,
+    path: str,
+    item: dict[str, Any] | None,
+    current_root: str | Path | None,
+    old: dict[str, Any] | None = None,
+) -> FileChange:
+    before_hash = None if old is None else old.get("sha256")
+    if old is None and kind == FileChangeKind.DELETE:
+        before_hash = None if item is None else item.get("sha256")
+    before_sha256 = before_hash if isinstance(before_hash, str) else None
+    if item is None:
+        return FileChange(kind=kind, path=path, before_sha256=before_sha256)
+    item_kind = item.get("kind")
+    if kind == FileChangeKind.DELETE:
+        if item_kind != "file":
+            raise SandboxSecurityError(f"Only regular files can be deleted from diffs: {path!r}")
+        size_value = item.get("size", 0)
+        size = int(size_value) if isinstance(size_value, (int, str)) else 0
+        return FileChange(
+            kind=kind,
+            path=path,
+            before_sha256=before_sha256,
+            size=size,
+        )
+    if item_kind != "file":
+        if item_kind == "dir" and kind == FileChangeKind.ADD:
+            mode_value = item.get("mode")
+            mode = int(mode_value) if isinstance(mode_value, (int, str)) else None
+            return FileChange(kind=FileChangeKind.MKDIR, path=path, mode=mode)
+        if item_kind == "dir" and kind == FileChangeKind.RMDIR:
+            return FileChange(kind=FileChangeKind.RMDIR, path=path)
+        raise SandboxSecurityError(f"Only regular files and directories can be diffed: {path!r}")
+    if current_root is None:
+        raise SandboxSecurityError(f"Changed file has no current root: {path!r}")
+    payload_item = read_file_item(current_root, path)
+    data = Path(current_root).joinpath(*path.split("/")).read_bytes()
+    after_hash = item.get("sha256")
+    if not isinstance(after_hash, str):
+        raise SandboxSecurityError(f"Changed file has no content hash: {path!r}")
+    mode_value = item.get("mode")
+    mode = int(mode_value) if isinstance(mode_value, (int, str)) else None
+    size_value = payload_item.get("size", 0)
+    size = int(size_value) if isinstance(size_value, (int, str)) else 0
+    return FileChange(
+        kind=kind,
+        path=path,
+        before_sha256=before_sha256,
+        after_sha256=after_hash,
+        size=size,
+        mode=mode,
+        payload=data,
+    )

--- a/src/synapsekit/sandbox/environment.py
+++ b/src/synapsekit/sandbox/environment.py
@@ -1,0 +1,146 @@
+"""Active sandbox environment exposed to agents and evaluation gates."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from ..audit import AuditTracer, EventKind
+from .backends.base import BackendHandle, SandboxBackend
+from .diff import DiffBundle
+from .eval import EvalGate, EvalReceipt
+from .overlay import capture_manifest
+from .types import CommandResult, SandboxConfig, SandboxState, SnapshotManifest
+
+if TYPE_CHECKING:
+    from ..audit import SigningPolicy
+
+
+@dataclass(slots=True)
+class SandboxEnvironment:
+    """A running, isolated working tree and its backend handle."""
+
+    session_id: str
+    host_root: Path
+    work_root: Path
+    baseline: SnapshotManifest
+    config: SandboxConfig
+    backend: SandboxBackend
+    handle: BackendHandle
+    tracer: AuditTracer
+    screen: Any | None = None
+    state: SandboxState = SandboxState.RUNNING
+    _cleanup: Callable[[], Any] | None = None
+
+    async def exec(self, command: Sequence[str]) -> CommandResult:
+        if self.state not in {SandboxState.RUNNING, SandboxState.DIFFED, SandboxState.EVALUATED}:
+            raise RuntimeError(f"Cannot execute commands in state {self.state.value}.")
+        result = await self.backend.exec(
+            self.handle,
+            tuple(command),
+            timeout=self.config.command_timeout,
+        )
+        self.tracer.record(
+            EventKind.SYSTEM_EVENT,
+            {
+                "event": "sandbox.exec",
+                "command": list(command),
+                "returncode": result.returncode,
+                "stdout": result.stdout[-2000:],
+                "stderr": result.stderr[-2000:],
+            },
+            actor=f"sandbox:{self.session_id}",
+        )
+        return result
+
+    async def diff_against_host(self) -> DiffBundle:
+        if self.state not in {SandboxState.RUNNING, SandboxState.DIFFED, SandboxState.EVALUATED}:
+            raise RuntimeError(f"Cannot diff sandbox in state {self.state.value}.")
+        after = await asyncio.to_thread(
+            capture_manifest,
+            self.work_root,
+            include=self.config.include,
+            exclude=self.config.exclude,
+        )
+        diff = DiffBundle.from_manifests(
+            self.baseline,
+            after,
+            current_root=self.work_root,
+            sandbox_id=self.session_id,
+            audit_run_id=self.tracer.run_id,
+        )
+        self.state = SandboxState.DIFFED
+        self.tracer.record(
+            EventKind.SYSTEM_EVENT,
+            {
+                "event": "sandbox.diff",
+                "diff_sha256": diff.digest,
+                "changes": diff.preview().changes,
+            },
+            actor=f"sandbox:{self.session_id}",
+        )
+        return diff
+
+    async def evaluate(self, gate: EvalGate, diff: DiffBundle | None = None) -> EvalReceipt:
+        active_diff = diff or await self.diff_against_host()
+        receipt = await gate.evaluate(active_diff, self)
+        self.state = SandboxState.EVALUATED
+        self.tracer.record(
+            EventKind.SYSTEM_EVENT,
+            {
+                "event": "sandbox.eval",
+                "evaluator": receipt.evaluator,
+                "passed": receipt.passed,
+                "score": receipt.score,
+                "diff_sha256": receipt.diff_sha256,
+            },
+            actor=f"sandbox:{self.session_id}",
+        )
+        return receipt
+
+    async def apply(self, diff: DiffBundle, receipt: EvalReceipt) -> None:
+        """Apply a passed bundle to the original host root and record the transition."""
+
+        await diff.apply(receipt, host_root=self.host_root)
+        await self.mark_applied()
+        self.tracer.record(
+            EventKind.SYSTEM_EVENT,
+            {
+                "event": "sandbox.apply",
+                "diff_sha256": diff.digest,
+                "changes": diff.preview().changes,
+            },
+            actor=f"sandbox:{self.session_id}",
+        )
+
+    def export_audit_bundle(self, output_path: str | Path, signing_policy: SigningPolicy) -> Path:
+        """Write the session's hash-chained trace as a signed portable bundle."""
+
+        from ..audit import export_audit_bundle
+
+        destination = Path(output_path)
+        self.tracer.record(
+            EventKind.SYSTEM_EVENT,
+            {"event": "sandbox.audit.export", "output_path": str(destination)},
+            actor=f"sandbox:{self.session_id}",
+        )
+        return Path(export_audit_bundle(list(self.tracer.records), signing_policy, destination))
+
+    async def discard(self) -> None:
+        if self.state in {SandboxState.DISCARDED, SandboxState.CLOSED}:
+            return
+        await self.backend.close(self.handle)
+        if self._cleanup is not None:
+            result = await asyncio.to_thread(self._cleanup)
+            if hasattr(result, "__await__"):
+                await result
+        else:
+            await asyncio.to_thread(shutil.rmtree, self.work_root.parent, True)
+        self.state = SandboxState.DISCARDED
+
+    async def mark_applied(self) -> None:
+        self.state = SandboxState.APPLIED

--- a/src/synapsekit/sandbox/errors.py
+++ b/src/synapsekit/sandbox/errors.py
@@ -1,0 +1,23 @@
+"""Errors raised by the sandbox lifecycle and apply pipeline."""
+
+from __future__ import annotations
+
+
+class SandboxError(RuntimeError):
+    """Base class for sandbox failures."""
+
+
+class SandboxStateError(SandboxError):
+    """Raised when an operation is invalid for the current lifecycle state."""
+
+
+class SandboxSecurityError(SandboxError):
+    """Raised when a snapshot or diff violates filesystem safety rules."""
+
+
+class BackendUnavailableError(SandboxError):
+    """Raised when a requested isolation backend cannot be used."""
+
+
+class ApplyConflictError(SandboxError):
+    """Raised when the host changed after the sandbox snapshot was created."""

--- a/src/synapsekit/sandbox/eval.py
+++ b/src/synapsekit/sandbox/eval.py
@@ -1,0 +1,200 @@
+"""Evaluation gates that bind approval to one exact diff bundle."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Protocol
+
+from .types import CommandResult
+
+if TYPE_CHECKING:
+    from .diff import DiffBundle
+    from .environment import SandboxEnvironment
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class EvalReceipt:
+    """Immutable proof that an evaluator approved one exact diff."""
+
+    passed: bool
+    score: float
+    threshold: float
+    diff_sha256: str
+    sandbox_id: str
+    evaluator: str
+    details: dict[str, Any]
+    created_at: str
+    receipt_hash: str
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        passed: bool,
+        score: float,
+        threshold: float,
+        diff_sha256: str,
+        sandbox_id: str,
+        evaluator: str,
+        details: Mapping[str, Any] | None = None,
+    ) -> EvalReceipt:
+        created_at = datetime.now(timezone.utc).isoformat()
+        normalized_details = dict(details or {})
+        body = {
+            "passed": passed,
+            "score": score,
+            "threshold": threshold,
+            "diff_sha256": diff_sha256,
+            "sandbox_id": sandbox_id,
+            "evaluator": evaluator,
+            "details": normalized_details,
+            "created_at": created_at,
+        }
+        return cls(
+            passed=passed,
+            score=score,
+            threshold=threshold,
+            diff_sha256=diff_sha256,
+            sandbox_id=sandbox_id,
+            evaluator=evaluator,
+            details=normalized_details,
+            created_at=created_at,
+            receipt_hash=hashlib.sha256(_canonical(body)).hexdigest(),
+        )
+
+
+class EvalGate(Protocol):
+    async def evaluate(self, diff: DiffBundle, environment: SandboxEnvironment) -> EvalReceipt: ...
+
+
+def _result_fields(result: Any) -> tuple[bool, float, dict[str, Any]]:
+    if isinstance(result, bool):
+        return result, 1.0 if result else 0.0, {}
+    if isinstance(result, (int, float)):
+        value = float(result)
+        return value > 0, value, {}
+    if isinstance(result, Mapping):
+        score = float(result.get("score", 1.0 if result.get("passed") else 0.0))
+        passed = bool(result.get("passed", score > 0))
+        details = {
+            str(key): value for key, value in result.items() if key not in {"score", "passed"}
+        }
+        return passed, score, details
+    passed = bool(getattr(result, "passed", False))
+    score = float(getattr(result, "score", 1.0 if passed else 0.0))
+    return passed, score, {"result": str(result)}
+
+
+class CallableEvalGate:
+    """Evaluate a diff with a sync or async callable supplied by the user."""
+
+    def __init__(
+        self,
+        evaluator: Callable[[DiffBundle, SandboxEnvironment], Any],
+        *,
+        threshold: float = 0.5,
+        name: str | None = None,
+    ) -> None:
+        self.evaluator = evaluator
+        self.threshold = threshold
+        self.name: str = name or str(getattr(evaluator, "__name__", type(evaluator).__name__))
+
+    async def evaluate(self, diff: DiffBundle, environment: SandboxEnvironment) -> EvalReceipt:
+        result = self.evaluator(diff, environment)
+        if inspect.isawaitable(result):
+            result = await result
+        passed, score, details = _result_fields(result)
+        passed = passed and score >= self.threshold
+        return EvalReceipt.create(
+            passed=passed,
+            score=score,
+            threshold=self.threshold,
+            diff_sha256=diff.digest,
+            sandbox_id=environment.session_id,
+            evaluator=self.name,
+            details=details,
+        )
+
+
+class CommandEvalGate:
+    """Run a fixed command inside the sandbox and gate on its exit code."""
+
+    def __init__(self, command: Sequence[str], *, name: str = "command-eval") -> None:
+        if not command:
+            raise ValueError("Command eval gate requires a non-empty command.")
+        self.command = tuple(command)
+        self.name = name
+
+    async def evaluate(self, diff: DiffBundle, environment: SandboxEnvironment) -> EvalReceipt:
+        result: CommandResult = await environment.exec(self.command)
+        return EvalReceipt.create(
+            passed=result.ok,
+            score=1.0 if result.ok else 0.0,
+            threshold=1.0,
+            diff_sha256=diff.digest,
+            sandbox_id=environment.session_id,
+            evaluator=self.name,
+            details={
+                "command": list(self.command),
+                "returncode": result.returncode,
+                "stdout": result.stdout[-4000:],
+                "stderr": result.stderr[-4000:],
+            },
+        )
+
+
+class EvalSuiteGate:
+    """Adapter for an environment-aware evaluator object.
+
+    Existing ``EvalSuite.score_prompt`` remains prompt-specific. This adapter
+    intentionally requires an explicit ``evaluate`` or ``score_environment``
+    method rather than passing filesystem diffs into a prompt API.
+    """
+
+    def __init__(self, suite: Any, *, threshold: float = 0.5) -> None:
+        self.suite = suite
+        self.threshold = threshold
+
+    async def evaluate(self, diff: DiffBundle, environment: SandboxEnvironment) -> EvalReceipt:
+        if not getattr(self.suite, "cases", [True]):
+            return EvalReceipt.create(
+                passed=False,
+                score=0.0,
+                threshold=self.threshold,
+                diff_sha256=diff.digest,
+                sandbox_id=environment.session_id,
+                evaluator=type(self.suite).__name__,
+                details={"error": "no eval cases found"},
+            )
+        method = getattr(self.suite, "evaluate", None) or getattr(
+            self.suite, "score_environment", None
+        )
+        if method is None:
+            raise TypeError(
+                "EvalSuiteGate requires an environment-aware evaluate() or score_environment() method."
+            )
+        result = method(diff, environment)
+        if inspect.isawaitable(result):
+            result = await result
+        passed, score, details = _result_fields(result)
+        passed = passed and score >= self.threshold
+        return EvalReceipt.create(
+            passed=passed,
+            score=score,
+            threshold=self.threshold,
+            diff_sha256=diff.digest,
+            sandbox_id=environment.session_id,
+            evaluator=type(self.suite).__name__,
+            details=details,
+        )

--- a/src/synapsekit/sandbox/overlay.py
+++ b/src/synapsekit/sandbox/overlay.py
@@ -1,0 +1,242 @@
+"""Secure, deterministic filesystem snapshots and a materialized overlay.
+
+Native CoW is backend-specific.  The portable fallback used by the core is a
+materialized working tree with a manifest; backends report whether they can
+replace it with a native snapshot.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+import os
+import shutil
+import stat
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from .errors import SandboxSecurityError
+from .types import SnapshotManifest, normalize_relative_path
+
+
+def _digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _manifest_fingerprint(items: Iterable[dict[str, object]]) -> str:
+    encoded = json.dumps(
+        list(items),
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return _digest(encoded)
+
+
+def _matches(path: str, patterns: tuple[str, ...]) -> bool:
+    normalized = path.strip("/")
+    for raw in patterns:
+        pattern = raw.replace("\\", "/").strip("/")
+        if not pattern:
+            continue
+        if normalized == pattern or normalized.startswith(pattern + "/"):
+            return True
+        if fnmatch.fnmatch(normalized, pattern):
+            return True
+    return False
+
+
+def _could_contain_include(path: str, includes: tuple[str, ...]) -> bool:
+    if not includes:
+        return True
+    normalized = path.strip("/")
+    return any(
+        normalized == pattern.strip("/")
+        or pattern.strip("/").startswith(normalized + "/")
+        or fnmatch.fnmatch(normalized, pattern.strip("/"))
+        for pattern in includes
+    )
+
+
+def _ensure_inside(root: Path, candidate: Path) -> None:
+    try:
+        candidate.resolve(strict=False).relative_to(root.resolve())
+    except ValueError as exc:
+        raise SandboxSecurityError(
+            f"Symlink escapes sandbox base: {candidate.relative_to(root)!s}"
+        ) from exc
+
+
+def _entry_item(root: Path, path: Path, relative: str) -> dict[str, object]:
+    info = path.lstat()
+    mode = stat.S_IMODE(info.st_mode)
+    if stat.S_ISLNK(info.st_mode):
+        target = os.readlink(path)
+        _ensure_inside(root, path.parent / target)
+        return {"kind": "symlink", "path": relative, "target": target, "mode": mode}
+    if stat.S_ISREG(info.st_mode):
+        try:
+            data = path.read_bytes()
+        except OSError as exc:
+            raise SandboxSecurityError(f"Cannot read snapshot file {relative!r}.") from exc
+        return {
+            "kind": "file",
+            "path": relative,
+            "sha256": _digest(data),
+            "size": len(data),
+            "mode": mode,
+        }
+    if stat.S_ISDIR(info.st_mode):
+        return {"kind": "dir", "path": relative, "mode": mode}
+    raise SandboxSecurityError(f"Unsupported filesystem entry in snapshot: {relative!r}")
+
+
+def capture_manifest(
+    root: str | Path,
+    *,
+    include: tuple[str, ...] = (),
+    exclude: tuple[str, ...] = (),
+) -> SnapshotManifest:
+    """Capture a deterministic manifest without following symlinks."""
+
+    base = Path(root).expanduser().resolve()
+    if not base.is_dir():
+        raise FileNotFoundError(f"Sandbox base directory does not exist: {base}")
+
+    items: list[dict[str, object]] = []
+
+    def walk(directory: Path, parent: str = "") -> None:
+        try:
+            entries = sorted(directory.iterdir(), key=lambda item: item.name.casefold())
+        except OSError as exc:
+            raise SandboxSecurityError(f"Cannot list snapshot directory {directory}.") from exc
+
+        for path in entries:
+            relative = normalize_relative_path(f"{parent}/{path.name}" if parent else path.name)
+            if _matches(relative, exclude):
+                continue
+            if (
+                include
+                and not _matches(relative, include)
+                and not _could_contain_include(relative, include)
+            ):
+                continue
+            item = _entry_item(base, path, relative)
+            if item["kind"] == "dir":
+                items.append(item)
+                walk(path, relative)
+            elif not include or _matches(relative, include):
+                items.append(item)
+
+    walk(base)
+    items.sort(key=lambda item: str(item["path"]).casefold())
+    return SnapshotManifest(
+        root=str(base),
+        items=tuple(items),
+        fingerprint=_manifest_fingerprint(items),
+    )
+
+
+def _copy_entry(source: Path, destination: Path, root: Path) -> None:
+    info = source.lstat()
+    if stat.S_ISLNK(info.st_mode):
+        target = os.readlink(source)
+        _ensure_inside(root, source.parent / target)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.symlink_to(target, target_is_directory=source.is_dir())
+        return
+    if stat.S_ISDIR(info.st_mode):
+        destination.mkdir(parents=True, exist_ok=True)
+        for child in source.iterdir():
+            _copy_entry(child, destination / child.name, root)
+        shutil.copystat(source, destination, follow_symlinks=False)
+        return
+    if stat.S_ISREG(info.st_mode):
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination, follow_symlinks=False)
+        return
+    raise SandboxSecurityError(f"Unsupported filesystem entry: {source}")
+
+
+def clone_tree(
+    source: str | Path,
+    destination: str | Path,
+    *,
+    include: tuple[str, ...] = (),
+    exclude: tuple[str, ...] = (),
+) -> SnapshotManifest:
+    """Materialize a safe selected copy and return its source manifest."""
+
+    source_path = Path(source).expanduser().resolve()
+    destination_path = Path(destination).expanduser().resolve()
+    if not source_path.is_dir():
+        raise FileNotFoundError(f"Sandbox base directory does not exist: {source_path}")
+    if destination_path.exists():
+        raise FileExistsError(f"Sandbox overlay destination already exists: {destination_path}")
+
+    manifest = capture_manifest(source_path, include=include, exclude=exclude)
+    destination_path.mkdir(parents=True, exist_ok=False)
+    selected = {str(item["path"]): item for item in manifest.items}
+
+    for relative, item in sorted(selected.items()):
+        target = destination_path.joinpath(*relative.split("/"))
+        source_entry = source_path.joinpath(*relative.split("/"))
+        if item["kind"] == "dir":
+            target.mkdir(parents=True, exist_ok=True)
+        elif item["kind"] == "file" or item["kind"] == "symlink":
+            _copy_entry(source_entry, target, source_path)
+
+    return manifest
+
+
+@dataclass(frozen=True, slots=True)
+class FsOverlay:
+    """Portable filesystem overlay contract used by a sandbox session.
+
+    This implementation materializes a selected copy. A backend that offers a
+    native CoW snapshot can wrap the same contract and set ``native_cow`` on
+    its capability report without changing diff or apply semantics.
+    """
+
+    source: str | Path
+    include: tuple[str, ...] = ()
+    exclude: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "source", Path(self.source).expanduser().resolve())
+
+    @property
+    def native_cow(self) -> bool:
+        """Whether this portable overlay provides native copy-on-write."""
+
+        return False
+
+    def snapshot(self) -> SnapshotManifest:
+        """Capture the selected source tree without materializing it."""
+
+        return capture_manifest(self.source, include=self.include, exclude=self.exclude)
+
+    def materialize(self, destination: str | Path) -> SnapshotManifest:
+        """Create the isolated working tree and return its baseline manifest."""
+
+        return clone_tree(
+            self.source,
+            destination,
+            include=self.include,
+            exclude=self.exclude,
+        )
+
+
+def read_file_item(root: str | Path, relative: str) -> dict[str, object]:
+    """Read one current overlay entry into the manifest item shape."""
+
+    base = Path(root).resolve()
+    safe = normalize_relative_path(relative)
+    path = base.joinpath(*safe.split("/"))
+    try:
+        path.resolve(strict=False).relative_to(base)
+    except ValueError as exc:
+        raise SandboxSecurityError(f"Path escapes sandbox root: {relative!r}") from exc
+    return _entry_item(base, path, safe)

--- a/src/synapsekit/sandbox/pc.py
+++ b/src/synapsekit/sandbox/pc.py
@@ -1,0 +1,353 @@
+"""PC Twin lifecycle orchestration."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import uuid
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+from ..audit import AuditTracer, EventKind
+from .backends import BackendHandle, build_backend
+from .environment import SandboxEnvironment
+from .errors import SandboxSecurityError, SandboxStateError
+from .overlay import FsOverlay
+from .types import SandboxConfig, SandboxState, SnapshotManifest, normalize_relative_path
+
+
+class PCSandbox:
+    """Create and manage an ephemeral, auditable PC Twin session."""
+
+    def __init__(
+        self,
+        *,
+        base: str | Path = "current_user",
+        backend: str = "docker",
+        network: str = "none",
+        fs_overlay: bool = True,
+        include: tuple[str, ...] | list[str] = (),
+        exclude: tuple[str, ...] | list[str] | None = None,
+        state_dir: str | Path | None = None,
+        image: str = "python:3.12-slim",
+        command_timeout: float = 120.0,
+        memory: str | None = "1g",
+        cpus: float | None = 2.0,
+        pids_limit: int = 256,
+        environment: dict[str, str] | None = None,
+        screen: Any | None = None,
+    ) -> None:
+        values: dict[str, Any] = {
+            "base": base,
+            "backend": backend,
+            "network": network,
+            "fs_overlay": fs_overlay,
+            "include": tuple(include),
+            "state_dir": None if state_dir is None else Path(state_dir),
+            "image": image,
+            "command_timeout": command_timeout,
+            "memory": memory,
+            "cpus": cpus,
+            "pids_limit": pids_limit,
+            "environment": dict(environment or {}),
+        }
+        if exclude is not None:
+            values["exclude"] = tuple(exclude)
+        self.config = SandboxConfig(**values)
+        self.screen = screen
+        self.session_id: str | None = None
+        self._environment: SandboxEnvironment | None = None
+
+    async def __aenter__(self) -> PCSandbox:
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        await self.discard()
+
+    @property
+    def environment(self) -> SandboxEnvironment:
+        """Return the active environment, or fail if the session is unopened."""
+
+        if self._environment is None:
+            raise SandboxStateError("Sandbox has not been started.")
+        return self._environment
+
+    @asynccontextmanager
+    async def snapshot(self) -> AsyncIterator[SandboxEnvironment]:
+        """Open a snapshot and discard it automatically unless already applied."""
+
+        environment = await self.start()
+        try:
+            yield environment
+        finally:
+            if environment.state not in {SandboxState.APPLIED, SandboxState.DISCARDED}:
+                await environment.discard()
+
+    async def start(self) -> SandboxEnvironment:
+        if self._environment is not None:
+            return self._environment
+
+        base = self.config.resolved_base
+        if not base.is_dir():
+            raise FileNotFoundError(f"Sandbox base directory does not exist: {base}")
+        state_dir = self.config.resolved_state_dir
+        await asyncio.to_thread(state_dir.mkdir, parents=True, exist_ok=True)
+        session_id = uuid.uuid4().hex
+        session_root = state_dir / session_id
+        work_root = session_root / "workspace"
+        await asyncio.to_thread(session_root.mkdir, parents=True, exist_ok=False)
+        tracer = AuditTracer(run_id=f"sandbox-{session_id}")
+        tracer.record(
+            EventKind.SYSTEM_EVENT,
+            {"event": "sandbox.prepare", "base": str(base), "backend": self.config.backend},
+            actor=f"sandbox:{session_id}",
+        )
+
+        excludes = list(self.config.exclude)
+        try:
+            session_relative = session_root.relative_to(base).as_posix()
+        except ValueError:
+            session_relative = ""
+        if session_relative:
+            excludes.append(session_relative)
+
+        try:
+            overlay = FsOverlay(
+                base,
+                include=self.config.include,
+                exclude=tuple(excludes),
+            )
+            baseline = await asyncio.to_thread(overlay.materialize, work_root)
+            backend = build_backend(self.config.backend)
+            handle = await backend.start(
+                session_id=session_id,
+                work_root=str(work_root),
+                config=self.config,
+            )
+        except Exception:
+            shutil.rmtree(session_root, ignore_errors=True)
+            raise
+
+        environment = SandboxEnvironment(
+            session_id=session_id,
+            host_root=base,
+            work_root=work_root,
+            baseline=baseline,
+            config=self.config,
+            backend=backend,
+            handle=handle,
+            tracer=tracer,
+            screen=self.screen,
+            _cleanup=lambda: self._cleanup_session(session_root),
+        )
+        self.session_id = session_id
+        self._environment = environment
+        await asyncio.to_thread(self._write_metadata, environment, session_root)
+        tracer.record(
+            EventKind.SYSTEM_EVENT,
+            {"event": "sandbox.running", "session_id": session_id},
+            actor=f"sandbox:{session_id}",
+        )
+        return environment
+
+    async def diff(self):
+        """Generate a reviewable diff for the active session."""
+
+        return await self.environment.diff_against_host()
+
+    async def evaluate(self, gate: Any, diff: Any | None = None):
+        """Evaluate the active session through an explicit gate."""
+
+        return await self.environment.evaluate(gate, diff)
+
+    async def apply(self, diff: Any, receipt: Any) -> None:
+        """Apply a passing diff to the host through the active environment."""
+
+        await self.environment.apply(diff, receipt)
+
+    async def run(
+        self,
+        agent_path: Path,
+        manifest: Any,
+        prompt: str,
+        **kwargs: Any,
+    ) -> Any:
+        """Run an installed agent through the marketplace ``AgentSandbox`` protocol.
+
+        Agent files are copied to an internal overlay directory rather than
+        mounted from the host. The entrypoint receives the prompt as a normal
+        argv value after ``--prompt``; it is never interpolated into a shell.
+        """
+
+        python_executable = kwargs.pop("python_executable", "python")
+        extra_args = kwargs.pop("args", ())
+        if kwargs:
+            unexpected = ", ".join(sorted(kwargs))
+            raise TypeError(f"Unsupported sandbox agent options: {unexpected}")
+        if not isinstance(python_executable, str) or not python_executable:
+            raise ValueError("python_executable must be a non-empty executable name.")
+        if not isinstance(extra_args, Sequence) or isinstance(extra_args, (str, bytes)):
+            raise ValueError("args must be a sequence of argument strings.")
+        if any(not isinstance(value, str) for value in extra_args):
+            raise ValueError("args must contain only strings.")
+
+        environment = await self.start()
+        entrypoint = getattr(manifest, "entrypoint", None)
+        if not isinstance(entrypoint, str) or not entrypoint:
+            raise SandboxSecurityError("Agent manifest must define a relative entrypoint.")
+        staged_entrypoint = await asyncio.to_thread(
+            self._stage_agent,
+            Path(agent_path),
+            entrypoint,
+            environment.work_root,
+        )
+        relative_entrypoint = staged_entrypoint.relative_to(environment.work_root).as_posix()
+        result = await environment.exec(
+            (
+                python_executable,
+                "-I",
+                relative_entrypoint,
+                "--prompt",
+                prompt,
+                *extra_args,
+            )
+        )
+        environment.tracer.record(
+            EventKind.SYSTEM_EVENT,
+            {
+                "event": "sandbox.agent.run",
+                "agent": getattr(manifest, "name", None),
+                "entrypoint": entrypoint,
+                "returncode": result.returncode,
+            },
+            actor=f"sandbox:{environment.session_id}",
+        )
+        return result
+
+    @staticmethod
+    def _stage_agent(agent_path: Path, entrypoint: str, work_root: Path) -> Path:
+        source = agent_path.expanduser().resolve()
+        if not source.is_dir():
+            raise FileNotFoundError(f"Installed agent directory does not exist: {source}")
+        safe_entrypoint = normalize_relative_path(entrypoint)
+        entry = source.joinpath(*safe_entrypoint.split("/"))
+        try:
+            entry.resolve(strict=True).relative_to(source)
+        except ValueError as exc:
+            raise SandboxSecurityError("Agent entrypoint escapes the installed bundle.") from exc
+        if not entry.is_file() or entry.is_symlink():
+            raise SandboxSecurityError("Agent entrypoint must be a regular file.")
+
+        destination = work_root / ".synapsekit" / "agents" / uuid.uuid4().hex
+        for item in sorted(source.rglob("*"), key=lambda path: path.as_posix()):
+            relative = item.relative_to(source)
+            target = destination / relative
+            if item.is_symlink():
+                raise SandboxSecurityError("Installed agent contains a symbolic link.")
+            if item.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+            elif item.is_file():
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(item, target)
+            else:
+                raise SandboxSecurityError(f"Unsupported agent filesystem entry: {item}")
+        return destination.joinpath(*safe_entrypoint.split("/"))
+
+    async def discard(self) -> None:
+        if self._environment is not None:
+            await self._environment.discard()
+
+    @staticmethod
+    def _cleanup_session(session_root: Path) -> None:
+        shutil.rmtree(session_root, ignore_errors=True)
+
+    @staticmethod
+    def _write_metadata(environment: SandboxEnvironment, session_root: Path) -> None:
+        payload = {
+            "session_id": environment.session_id,
+            "state": environment.state.value,
+            "host_root": str(environment.host_root),
+            "work_root": str(environment.work_root),
+            "backend": environment.handle.backend,
+            "handle": {
+                "identifier": environment.handle.identifier,
+                "metadata": environment.handle.metadata,
+            },
+            "config": {
+                "base": str(environment.config.base),
+                "backend": environment.config.backend,
+                "network": str(environment.config.network),
+                "include": list(environment.config.include),
+                "exclude": list(environment.config.exclude),
+                "fs_overlay": environment.config.fs_overlay,
+                "image": environment.config.image,
+                "command_timeout": environment.config.command_timeout,
+                "memory": environment.config.memory,
+                "cpus": environment.config.cpus,
+                "pids_limit": environment.config.pids_limit,
+                "environment": environment.config.sanitized_environment,
+            },
+            "baseline": {
+                "root": environment.baseline.root,
+                "items": list(environment.baseline.items),
+                "fingerprint": environment.baseline.fingerprint,
+            },
+        }
+        (session_root / "metadata.json").write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+    @classmethod
+    async def attach(cls, session_id: str, *, state_dir: str | Path | None = None) -> PCSandbox:
+        """Reattach to a persisted session created by ``sandbox spawn``."""
+
+        root = Path(state_dir or (Path.home() / ".synapsekit" / "sandboxes")) / session_id
+        metadata = root / "metadata.json"
+        payload = json.loads(await asyncio.to_thread(metadata.read_text, encoding="utf-8"))
+        config_data = payload["config"]
+        sandbox = cls(
+            base=config_data["base"],
+            backend=config_data["backend"],
+            network=config_data["network"],
+            fs_overlay=bool(config_data["fs_overlay"]),
+            include=tuple(config_data["include"]),
+            exclude=tuple(config_data["exclude"]),
+            state_dir=root.parent,
+            image=config_data["image"],
+            command_timeout=float(config_data["command_timeout"]),
+            memory=config_data["memory"],
+            cpus=config_data["cpus"],
+            pids_limit=int(config_data["pids_limit"]),
+            environment=dict(config_data["environment"]),
+        )
+        backend = build_backend(config_data["backend"])
+        handle = BackendHandle(
+            backend=payload["backend"],
+            identifier=payload["handle"]["identifier"],
+            work_root=payload["work_root"],
+            metadata=dict(payload["handle"].get("metadata", {})),
+        )
+        baseline_data = payload["baseline"]
+        environment = SandboxEnvironment(
+            session_id=session_id,
+            host_root=Path(payload["host_root"]),
+            work_root=Path(payload["work_root"]),
+            baseline=SnapshotManifest(
+                root=baseline_data["root"],
+                items=tuple(baseline_data["items"]),
+                fingerprint=baseline_data["fingerprint"],
+            ),
+            config=sandbox.config,
+            backend=backend,
+            handle=handle,
+            tracer=AuditTracer(run_id=f"sandbox-{session_id}"),
+            _cleanup=lambda: cls._cleanup_session(root),
+            state=SandboxState(payload.get("state", SandboxState.RUNNING.value)),
+        )
+        sandbox.session_id = session_id
+        sandbox._environment = environment
+        return sandbox

--- a/src/synapsekit/sandbox/types.py
+++ b/src/synapsekit/sandbox/types.py
@@ -1,0 +1,178 @@
+"""Public data contracts for the sandbox package."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class SandboxState(str, Enum):
+    """Persisted lifecycle state for a sandbox session."""
+
+    NEW = "new"
+    PREPARING = "preparing"
+    RUNNING = "running"
+    DIFFED = "diffed"
+    EVALUATED = "evaluated"
+    APPLIED = "applied"
+    DISCARDED = "discarded"
+    CLOSED = "closed"
+    FAILED = "failed"
+
+
+class NetworkPolicy(str, Enum):
+    """Network policy exposed to a sandbox backend."""
+
+    NONE = "none"
+    EGRESS_ONLY = "egress_only"
+
+
+class FileChangeKind(str, Enum):
+    """Filesystem operation represented by a diff bundle."""
+
+    ADD = "add"
+    MODIFY = "modify"
+    DELETE = "delete"
+    MKDIR = "mkdir"
+    RMDIR = "rmdir"
+
+
+@dataclass(frozen=True, slots=True)
+class FileChange:
+    """One safe, relative filesystem operation."""
+
+    kind: FileChangeKind
+    path: str
+    before_sha256: str | None = None
+    after_sha256: str | None = None
+    size: int = 0
+    mode: int | None = None
+    payload: bytes | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotManifest:
+    """Deterministic snapshot metadata for a selected host root."""
+
+    root: str
+    items: tuple[dict[str, Any], ...]
+    fingerprint: str
+
+    @property
+    def file_count(self) -> int:
+        return sum(item.get("kind") == "file" for item in self.items)
+
+    @property
+    def total_bytes(self) -> int:
+        return sum(int(item.get("size", 0)) for item in self.items)
+
+
+@dataclass(frozen=True, slots=True)
+class BackendCapabilities:
+    """Runtime capabilities reported by a backend probe."""
+
+    name: str
+    available: bool
+    native_cow: bool = False
+    gui: bool = False
+    network_policies: tuple[str, ...] = (NetworkPolicy.NONE.value,)
+    reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CommandResult:
+    """Captured result of a command executed in the sandbox."""
+
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+_DEFAULT_EXCLUDES = (
+    ".synapsekit",
+    ".ssh",
+    ".aws",
+    ".azure",
+    ".config/gcloud",
+    ".docker/config.json",
+    ".npmrc",
+    ".pypirc",
+    ".netrc",
+    ".env",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SandboxConfig:
+    """Validated configuration shared by all sandbox backends."""
+
+    base: str | Path = "current_user"
+    backend: str = "docker"
+    network: NetworkPolicy | str = NetworkPolicy.NONE
+    include: tuple[str, ...] = ()
+    exclude: tuple[str, ...] = _DEFAULT_EXCLUDES
+    fs_overlay: bool = True
+    state_dir: Path | None = None
+    image: str = "python:3.12-slim"
+    command_timeout: float = 120.0
+    memory: str | None = "1g"
+    cpus: float | None = 2.0
+    pids_limit: int = 256
+    environment: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        backend = self.backend.strip().lower()
+        if not backend:
+            raise ValueError("Sandbox backend must not be empty.")
+        object.__setattr__(self, "backend", backend)
+        network = (
+            self.network.value if isinstance(self.network, NetworkPolicy) else str(self.network)
+        )
+        try:
+            network = NetworkPolicy(network).value
+        except ValueError as exc:
+            raise ValueError(f"Unsupported sandbox network policy: {network!r}.") from exc
+        object.__setattr__(self, "network", network)
+        if self.command_timeout <= 0:
+            raise ValueError("Sandbox command_timeout must be positive.")
+        if self.cpus is not None and self.cpus <= 0:
+            raise ValueError("Sandbox cpus must be positive when supplied.")
+        if self.pids_limit <= 0:
+            raise ValueError("Sandbox pids_limit must be positive.")
+        if not self.image.strip():
+            raise ValueError("Sandbox image must not be empty.")
+
+    @property
+    def resolved_base(self) -> Path:
+        if self.base == "current_user":
+            return Path.home().resolve()
+        return Path(self.base).expanduser().resolve()
+
+    @property
+    def resolved_state_dir(self) -> Path:
+        return (self.state_dir or (Path.home() / ".synapsekit" / "sandboxes")).expanduser()
+
+    @property
+    def sanitized_environment(self) -> dict[str, str]:
+        return dict(self.environment)
+
+
+def normalize_relative_path(path: str) -> str:
+    """Normalize a bundle path and reject traversal/absolute paths."""
+
+    value = path.replace("\\", "/")
+    if not value or value.startswith("/") or "\x00" in value:
+        raise ValueError(f"Unsafe relative path: {path!r}")
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValueError(f"Unsafe relative path: {path!r}")
+    if os.path.splitdrive(value)[0]:
+        raise ValueError(f"Unsafe relative path: {path!r}")
+    return "/".join(parts)

--- a/tests/archaeology/__init__.py
+++ b/tests/archaeology/__init__.py
@@ -1,0 +1,1 @@
+"""Archaeology test package."""

--- a/tests/archaeology/test_archaeology.py
+++ b/tests/archaeology/test_archaeology.py
@@ -388,3 +388,47 @@ async def test_evolution_diff_trace_empty(git_repo: Path):
     assert isinstance(snapshots, list)
 
 
+from synapsekit.archaeology.agent import ArchaeologyAgent
+
+
+async def test_archaeology_agent_explain_git_only(git_repo: Path):
+    """Full integration test with git-only sources."""
+    llm = FakeLLM(response="AgentRegistry was created for dynamic agent dispatch.")
+    sources = SourceConfig(repo_path=str(git_repo), include_git=True, min_citations_per_claim=0)
+    agent = ArchaeologyAgent(sources=sources, llm=llm)
+    result = await agent.explain("Why does AgentRegistry exist?")
+
+    assert isinstance(result, ArchaeologyResult)
+    assert result.query == "Why does AgentRegistry exist?"
+    assert len(result.timeline) >= 1
+    assert len(result.evolution) >= 1
+    assert isinstance(result.narrative, str)
+    assert len(result.narrative) > 0
+
+
+async def test_archaeology_agent_no_llm(git_repo: Path):
+    """Agent works without LLM (causal linking and narrative disabled)."""
+    sources = SourceConfig(repo_path=str(git_repo))
+    agent = ArchaeologyAgent(sources=sources, llm=None)
+    # Force llm to None to test graceful degradation
+    agent.llm = None
+    agent.causal_linker = None
+    result = await agent.explain("AgentRegistry")
+
+    assert isinstance(result, ArchaeologyResult)
+    assert len(result.timeline) >= 1
+    assert result.narrative == ""
+    assert result.causes == []
+
+
+async def test_archaeology_agent_result_markdown(git_repo: Path):
+    """Verify the result can be rendered as markdown."""
+    llm = FakeLLM(response="Test narrative.")
+    sources = SourceConfig(repo_path=str(git_repo), min_citations_per_claim=0)
+    agent = ArchaeologyAgent(sources=sources, llm=llm)
+    result = await agent.explain("AgentRegistry")
+    md = result.to_markdown()
+    assert "# Code Archaeology:" in md
+
+
+

--- a/tests/archaeology/test_archaeology.py
+++ b/tests/archaeology/test_archaeology.py
@@ -370,3 +370,21 @@ async def test_causal_linker_with_verifier():
     assert len(claims) == 1
     assert claims[0].verified is True
 
+
+from synapsekit.archaeology.evolution_diff import EvolutionDiff
+
+
+async def test_evolution_diff_trace(git_repo: Path):
+    ed = EvolutionDiff(repo_path=git_repo)
+    snapshots = await ed.trace("agent.py")
+    assert len(snapshots) >= 1
+    assert all(isinstance(s, EvolutionSnapshot) for s in snapshots)
+    assert snapshots[0].version_hash
+
+
+async def test_evolution_diff_trace_empty(git_repo: Path):
+    ed = EvolutionDiff(repo_path=git_repo)
+    snapshots = await ed.trace("nonexistent_file.py")
+    assert isinstance(snapshots, list)
+
+

--- a/tests/archaeology/test_archaeology.py
+++ b/tests/archaeology/test_archaeology.py
@@ -3,22 +3,37 @@
 from __future__ import annotations
 
 import subprocess
+from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from synapsekit.archaeology.timeline_reconstructor import TimelineReconstructor
-from synapsekit.archaeology.types import (
+import synapsekit
+from synapsekit.archaeology import (
+    ArchaeologyAgent,
     ArchaeologyResult,
     CausalClaim,
+    CausalLinker,
     Citation,
+    EvolutionDiff,
     EvolutionSnapshot,
     SourceConfig,
     TimelineEvent,
+    TimelineReconstructor,
 )
+from synapsekit.llm.base import BaseLLM, LLMConfig
 from synapsekit.loaders.base import Document
+
+
+class FakeLLM(BaseLLM):
+    def __init__(self, response: str = "") -> None:
+        super().__init__(LLMConfig(model="fake", api_key="", provider="fake"))
+        self.response = response
+
+    async def stream(self, prompt: str, **kw) -> AsyncGenerator[str]:
+        yield self.response
 
 
 def test_citation_construction():
@@ -266,20 +281,6 @@ async def test_timeline_email_events(tmp_path: Path):
         assert "Proposal: AgentRegistry" in events[0].summary
 
 
-from collections.abc import AsyncGenerator
-from synapsekit.llm.base import BaseLLM, LLMConfig
-from synapsekit.archaeology.causal_linker import CausalLinker
-
-
-class FakeLLM(BaseLLM):
-    def __init__(self, response: str = "") -> None:
-        super().__init__(LLMConfig(model="fake", api_key="", provider="fake"))
-        self.response = response
-
-    async def stream(self, prompt: str, **kw) -> AsyncGenerator[str]:
-        yield self.response
-
-
 async def test_causal_linker_parses_claims():
     llm_response = (
         "CAUSE: PR #718 introduced AgentRegistry\n"
@@ -350,14 +351,18 @@ async def test_causal_linker_with_verifier():
         "---"
     )
     llm = FakeLLM(response=llm_response)
-    
+
     mock_verifier = MagicMock()
     mock_result = MagicMock()
     mock_result.verified = True
     mock_verifier.solve = AsyncMock(return_value=mock_result)
 
     linker = CausalLinker(llm, verifier=mock_verifier, min_citations=0)
-    c = Citation(source_type="git", reference="commit abc", content_preview="Issue #718 required dynamic agents")
+    c = Citation(
+        source_type="git",
+        reference="commit abc",
+        content_preview="Issue #718 required dynamic agents",
+    )
     events = [
         TimelineEvent(
             timestamp=datetime(2024, 1, 1, tzinfo=UTC),
@@ -369,9 +374,6 @@ async def test_causal_linker_with_verifier():
     claims = await linker.link(events, "AgentRegistry")
     assert len(claims) == 1
     assert claims[0].verified is True
-
-
-from synapsekit.archaeology.evolution_diff import EvolutionDiff
 
 
 async def test_evolution_diff_trace(git_repo: Path):
@@ -386,9 +388,6 @@ async def test_evolution_diff_trace_empty(git_repo: Path):
     ed = EvolutionDiff(repo_path=git_repo)
     snapshots = await ed.trace("nonexistent_file.py")
     assert isinstance(snapshots, list)
-
-
-from synapsekit.archaeology.agent import ArchaeologyAgent
 
 
 async def test_archaeology_agent_explain_git_only(git_repo: Path):
@@ -431,4 +430,15 @@ async def test_archaeology_agent_result_markdown(git_repo: Path):
     assert "# Code Archaeology:" in md
 
 
-
+def test_archaeology_exports():
+    """Verify archaeology classes are accessible from top-level synapsekit."""
+    assert hasattr(synapsekit, "ArchaeologyAgent")
+    assert hasattr(synapsekit, "ArchaeologyResult")
+    assert hasattr(synapsekit, "CausalClaim")
+    assert hasattr(synapsekit, "Citation")
+    assert hasattr(synapsekit, "TimelineEvent")
+    assert hasattr(synapsekit, "SourceConfig")
+    assert hasattr(synapsekit, "TimelineReconstructor")
+    assert hasattr(synapsekit, "EvolutionDiff")
+    assert hasattr(synapsekit, "EvolutionSnapshot")
+    assert hasattr(synapsekit.archaeology, "CausalLinker")

--- a/tests/archaeology/test_archaeology.py
+++ b/tests/archaeology/test_archaeology.py
@@ -1,0 +1,131 @@
+"""Unit tests for Code Archaeology Agent (Issue #744)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from synapsekit.archaeology.types import (
+    ArchaeologyResult,
+    CausalClaim,
+    Citation,
+    EvolutionSnapshot,
+    SourceConfig,
+    TimelineEvent,
+)
+
+
+def test_citation_construction():
+    c = Citation(
+        source_type="git",
+        reference="commit abc1234",
+        content_preview="Initial commit",
+        timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    assert c.source_type == "git"
+    assert c.reference == "commit abc1234"
+    assert c.timestamp is not None
+
+
+def test_timeline_event_construction():
+    c = Citation(source_type="git", reference="commit abc", content_preview="test")
+    event = TimelineEvent(
+        timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+        source_type="git",
+        summary="Added file.py",
+        citations=[c],
+    )
+    assert event.source_type == "git"
+    assert len(event.citations) == 1
+
+
+def test_causal_claim_construction():
+    claim = CausalClaim(
+        cause="PR #42 added caching",
+        effect="Response time improved 3x",
+        confidence=0.85,
+        verified=True,
+        reasoning="Commit message explicitly mentions perf improvement",
+    )
+    assert claim.verified is True
+    assert claim.confidence == 0.85
+
+
+def test_evolution_snapshot_construction():
+    snap = EvolutionSnapshot(
+        version_hash="abc1234",
+        date=datetime(2024, 6, 15, tzinfo=UTC),
+        diff_summary="modified agent.py [AgentRegistry] (+20/-5)",
+        reason="Add register method to AgentRegistry (#719)",
+    )
+    assert snap.version_hash == "abc1234"
+
+
+def test_archaeology_result_to_markdown():
+    c = Citation(source_type="git", reference="commit abc", content_preview="test commit")
+    result = ArchaeologyResult(
+        query="Why does AgentRegistry exist?",
+        timeline=[
+            TimelineEvent(
+                timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+                source_type="git",
+                summary="Created AgentRegistry",
+                citations=[c],
+            ),
+        ],
+        causes=[
+            CausalClaim(
+                cause="Need for dynamic agent dispatch",
+                effect="AgentRegistry was created",
+                confidence=0.9,
+                citations=[c],
+                verified=True,
+            ),
+        ],
+        evolution=[
+            EvolutionSnapshot(
+                version_hash="abc1234",
+                date=datetime(2024, 1, 1, tzinfo=UTC),
+                diff_summary="added agent_registry.py",
+                reason="Initial creation",
+                citations=[c],
+            ),
+        ],
+        narrative="AgentRegistry was created to enable dynamic agent dispatch.",
+    )
+    md = result.to_markdown()
+    assert "AgentRegistry" in md
+    assert "## Timeline" in md
+    assert "## Causal Chain" in md
+    assert "## Evolution History" in md
+    assert "## Citations" in md
+
+
+def test_archaeology_result_all_citations_deduplication():
+    c1 = Citation(source_type="git", reference="commit abc", content_preview="test")
+    c2 = Citation(source_type="slack", reference="slack://C1/123", content_preview="msg")
+    result = ArchaeologyResult(
+        query="test",
+        timeline=[
+            TimelineEvent(
+                timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+                source_type="git",
+                summary="test",
+                citations=[c1, c2],
+            ),
+        ],
+        causes=[
+            CausalClaim(cause="a", effect="b", confidence=0.5, citations=[c1]),
+        ],
+    )
+    all_cites = result.all_citations
+    assert len(all_cites) == 2  # c1 deduplicated
+
+
+def test_source_config_defaults():
+    cfg = SourceConfig()
+    assert cfg.repo_path == "."
+    assert cfg.include_git is True
+    assert cfg.min_citations_per_claim == 2
+    assert cfg.slack_bot_token is None

--- a/tests/archaeology/test_archaeology.py
+++ b/tests/archaeology/test_archaeology.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -264,3 +264,109 @@ async def test_timeline_email_events(tmp_path: Path):
         assert len(events) == 1
         assert events[0].source_type == "email"
         assert "Proposal: AgentRegistry" in events[0].summary
+
+
+from collections.abc import AsyncGenerator
+from synapsekit.llm.base import BaseLLM, LLMConfig
+from synapsekit.archaeology.causal_linker import CausalLinker
+
+
+class FakeLLM(BaseLLM):
+    def __init__(self, response: str = "") -> None:
+        super().__init__(LLMConfig(model="fake", api_key="", provider="fake"))
+        self.response = response
+
+    async def stream(self, prompt: str, **kw) -> AsyncGenerator[str]:
+        yield self.response
+
+
+async def test_causal_linker_parses_claims():
+    llm_response = (
+        "CAUSE: PR #718 introduced AgentRegistry\n"
+        "EFFECT: Agents could be dynamically dispatched\n"
+        "CONFIDENCE: 0.9\n"
+        "REASONING: Commit message explicitly states purpose\n"
+        "---\n"
+        "CAUSE: Feature request for multi-agent systems\n"
+        "EFFECT: AgentRegistry added register method\n"
+        "CONFIDENCE: 0.7\n"
+        "REASONING: Follow-up PR extended the class\n"
+        "---"
+    )
+    llm = FakeLLM(response=llm_response)
+    linker = CausalLinker(llm, min_citations=0)
+
+    c = Citation(source_type="git", reference="commit abc", content_preview="AgentRegistry")
+    events = [
+        TimelineEvent(
+            timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+            source_type="git",
+            summary="Created AgentRegistry (#718)",
+            citations=[c],
+        ),
+    ]
+    claims = await linker.link(events, "AgentRegistry")
+    assert len(claims) == 2
+    assert claims[0].cause == "PR #718 introduced AgentRegistry"
+    assert claims[0].confidence == 0.9
+
+
+async def test_causal_linker_min_citations_filter():
+    llm_response = (
+        "CAUSE: Unknown cause\n"
+        "EFFECT: Unknown effect\n"
+        "CONFIDENCE: 0.3\n"
+        "REASONING: Weak evidence\n"
+        "---"
+    )
+    llm = FakeLLM(response=llm_response)
+    linker = CausalLinker(llm, min_citations=2)
+
+    events = [
+        TimelineEvent(
+            timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+            source_type="git",
+            summary="Some event",
+            citations=[],
+        ),
+    ]
+    claims = await linker.link(events, "test")
+    assert len(claims) == 0  # Filtered out due to insufficient citations
+
+
+async def test_causal_linker_empty_events():
+    llm = FakeLLM()
+    linker = CausalLinker(llm)
+    claims = await linker.link([], "test")
+    assert claims == []
+
+
+async def test_causal_linker_with_verifier():
+    llm_response = (
+        "CAUSE: Issue #718 required dynamic agents\n"
+        "EFFECT: AgentRegistry was created\n"
+        "CONFIDENCE: 0.95\n"
+        "REASONING: Strong evidence from issue discussion\n"
+        "---"
+    )
+    llm = FakeLLM(response=llm_response)
+    
+    mock_verifier = MagicMock()
+    mock_result = MagicMock()
+    mock_result.verified = True
+    mock_verifier.solve = AsyncMock(return_value=mock_result)
+
+    linker = CausalLinker(llm, verifier=mock_verifier, min_citations=0)
+    c = Citation(source_type="git", reference="commit abc", content_preview="Issue #718 required dynamic agents")
+    events = [
+        TimelineEvent(
+            timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+            source_type="git",
+            summary="AgentRegistry created for #718",
+            citations=[c],
+        ),
+    ]
+    claims = await linker.link(events, "AgentRegistry")
+    assert len(claims) == 1
+    assert claims[0].verified is True
+

--- a/tests/archaeology/test_archaeology.py
+++ b/tests/archaeology/test_archaeology.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import subprocess
 from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from synapsekit.archaeology.timeline_reconstructor import TimelineReconstructor
 from synapsekit.archaeology.types import (
     ArchaeologyResult,
     CausalClaim,
@@ -14,6 +18,7 @@ from synapsekit.archaeology.types import (
     SourceConfig,
     TimelineEvent,
 )
+from synapsekit.loaders.base import Document
 
 
 def test_citation_construction():
@@ -129,3 +134,133 @@ def test_source_config_defaults():
     assert cfg.include_git is True
     assert cfg.min_citations_per_claim == 2
     assert cfg.slack_bot_token is None
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """Create a temporary git repository with multi-commit history."""
+    subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    (tmp_path / "agent.py").write_text(
+        "class AgentRegistry:\n    def __init__(self):\n        pass\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Initial AgentRegistry (#718)"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    (tmp_path / "agent.py").write_text(
+        "class AgentRegistry:\n    def __init__(self):\n        pass\n\n    def register(self):\n        pass\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add register method (#719)"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    return tmp_path
+
+
+async def test_timeline_git_events(git_repo: Path):
+    tr = TimelineReconstructor(repo_path=git_repo)
+    events = await tr.reconstruct("AgentRegistry", include_git=True)
+    assert len(events) >= 1
+    assert all(e.source_type == "git" for e in events)
+    assert any("AgentRegistry" in e.summary for e in events)
+
+
+async def test_timeline_events_sorted_chronologically(git_repo: Path):
+    tr = TimelineReconstructor(repo_path=git_repo)
+    events = await tr.reconstruct("AgentRegistry", include_git=True)
+    timestamps = [e.timestamp for e in events]
+    assert timestamps == sorted(timestamps)
+
+
+async def test_timeline_markdown_events(tmp_path: Path):
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    (notes_dir / "design.md").write_text(
+        "AgentRegistry was designed for dynamic dispatch",
+        encoding="utf-8",
+    )
+    tr = TimelineReconstructor(repo_path=tmp_path)
+    events = await tr.reconstruct(
+        "AgentRegistry",
+        include_git=False,
+        markdown_roots=[notes_dir],
+    )
+    assert len(events) >= 1
+    assert events[0].source_type == "markdown"
+
+
+async def test_timeline_empty_query(git_repo: Path):
+    tr = TimelineReconstructor(repo_path=git_repo)
+    events = await tr.reconstruct("xyznonexistent", include_git=True)
+    assert isinstance(events, list)
+
+
+async def test_timeline_slack_events(tmp_path: Path):
+    tr = TimelineReconstructor(repo_path=tmp_path)
+    mock_slack_doc = Document(
+        text="Discussing why AgentRegistry was introduced in architecture review",
+        metadata={"timestamp": "1700000000.0", "channel": "C123", "user": "U456"},
+    )
+    with patch(
+        "synapsekit.loaders.slack.SlackLoader.aload",
+        new=AsyncMock(return_value=[mock_slack_doc]),
+    ):
+        events = await tr.reconstruct(
+            "AgentRegistry",
+            include_git=False,
+            slack_bot_token="xoxb-fake",
+            slack_channel_ids=["C123"],
+        )
+        assert len(events) == 1
+        assert events[0].source_type == "slack"
+        assert "architecture review" in events[0].summary
+
+
+async def test_timeline_email_events(tmp_path: Path):
+    tr = TimelineReconstructor(repo_path=tmp_path)
+    mock_email_doc = Document(
+        text="AgentRegistry proposal thread body text",
+        metadata={
+            "subject": "Proposal: AgentRegistry",
+            "from": "alice@synapsekit.dev",
+            "date": "2024-01-15T10:00:00+00:00",
+            "email_id": "101",
+        },
+    )
+    with patch(
+        "synapsekit.loaders.email.EmailLoader.aload",
+        new=AsyncMock(return_value=[mock_email_doc]),
+    ):
+        events = await tr.reconstruct(
+            "AgentRegistry",
+            include_git=False,
+            email_imap_server="imap.fake.com",
+            email_address="me@fake.com",
+            email_password="fake",
+        )
+        assert len(events) == 1
+        assert events[0].source_type == "email"
+        assert "Proposal: AgentRegistry" in events[0].summary

--- a/tests/sandbox/test_audit.py
+++ b/tests/sandbox/test_audit.py
@@ -1,0 +1,32 @@
+"""Audit integration for sandbox lifecycle traces."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from synapsekit.audit import SigningPolicy
+from synapsekit.sandbox import PCSandbox
+
+
+def test_sandbox_exports_a_signed_audit_bundle(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        host = tmp_path / "host"
+        host.mkdir()
+        sandbox = PCSandbox(
+            base=host,
+            backend="fake",
+            state_dir=tmp_path / "sessions",
+        )
+        environment = await sandbox.start()
+        try:
+            output = environment.export_audit_bundle(
+                tmp_path / "sandbox.audit.zip",
+                SigningPolicy.ed25519(),
+            )
+            assert output.is_file()
+            assert output.stat().st_size > 0
+        finally:
+            await sandbox.discard()
+
+    asyncio.run(scenario())

--- a/tests/sandbox/test_backends.py
+++ b/tests/sandbox/test_backends.py
@@ -1,0 +1,132 @@
+"""Backend contracts and agent/environment integration tests."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from synapsekit.computer_use.agent import ComputerUseAgent
+from synapsekit.computer_use.types import ComputerAction, ComputerActionType, ComputerObservation
+from synapsekit.sandbox.backends.docker import DockerBackend
+from synapsekit.sandbox.backends.fake import FakeBackend
+from synapsekit.sandbox.backends.firecracker import FirecrackerBackend
+from synapsekit.sandbox.backends.lima import LimaBackend
+from synapsekit.sandbox.diff import DiffBundle
+from synapsekit.sandbox.types import FileChange, FileChangeKind, SandboxConfig
+
+
+def test_fake_backend_executes_in_the_worktree(tmp_path) -> None:
+    async def scenario() -> None:
+        work = tmp_path / "work"
+        work.mkdir()
+        backend = FakeBackend()
+        handle = await backend.start(session_id="test", work_root=str(work), config=SandboxConfig())
+        result = await backend.exec(
+            handle,
+            ["python", "-c", "from pathlib import Path; Path('created.txt').write_text('ok')"],
+            timeout=10,
+        )
+        assert result.ok
+        assert (work / "created.txt").read_text() == "ok"
+
+    asyncio.run(scenario())
+
+
+def test_docker_start_has_restrictive_defaults(monkeypatch, tmp_path) -> None:
+    calls: list[list[str]] = []
+
+    async def fake_run(command, **kwargs):
+        calls.append(list(command))
+        from synapsekit.sandbox.types import CommandResult
+
+        if command[:2] == ["docker", "version"]:
+            return CommandResult(0, "27.0\n", "")
+        return CommandResult(0, "container-id\n", "")
+
+    monkeypatch.setattr("synapsekit.sandbox.backends.docker.run_process", fake_run)
+
+    async def scenario() -> None:
+        backend = DockerBackend()
+        handle = await backend.start(
+            session_id="abcdef1234567890",
+            work_root=str(tmp_path),
+            config=SandboxConfig(network="none"),
+        )
+        assert handle.identifier == "container-id"
+
+    asyncio.run(scenario())
+    command = calls[1]
+    assert "--read-only" in command
+    assert "--cap-drop" in command
+    assert "ALL" in command
+    assert "--security-opt" in command
+    assert "no-new-privileges" in command
+    assert command[command.index("--network") + 1] == "none"
+    assert "--privileged" not in command
+
+
+def test_vm_backends_fail_closed_on_unsupported_configuration(monkeypatch) -> None:
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+
+    async def scenario() -> None:
+        lima = await LimaBackend().probe()
+        firecracker = await FirecrackerBackend().probe()
+        assert not lima.available
+        assert not firecracker.available
+
+    asyncio.run(scenario())
+
+
+def test_computer_use_agent_uses_environment_screen_without_closing_it() -> None:
+    class Screen:
+        closed = False
+
+        async def observe(self):
+            return ComputerObservation(text="ready")
+
+        async def execute(self, action):
+            return "ok"
+
+        async def close(self):
+            self.closed = True
+
+    class Provider:
+        async def next_action(self, task, observation, history):
+            return ComputerAction(type=ComputerActionType.DONE, reason="done")
+
+    screen = Screen()
+    environment = SimpleNamespace(screen=screen)
+
+    async def scenario() -> None:
+        agent = ComputerUseAgent(provider=Provider(), screen=Screen())
+        result = await agent.run("check", env=environment)
+        assert result.completed
+
+    asyncio.run(scenario())
+    assert screen.closed is False
+
+
+def test_apply_rolls_back_when_a_later_operation_is_invalid(tmp_path) -> None:
+    root = tmp_path / "host"
+    root.mkdir()
+    bundle = DiffBundle(
+        host_root=str(root),
+        base_fingerprint="base",
+        sandbox_id="sandbox",
+        changes=(
+            FileChange(FileChangeKind.ADD, "one.txt", payload=b"one"),
+            FileChange(FileChangeKind.ADD, "two.txt", payload=None),
+        ),
+    )
+    receipt = SimpleNamespace(passed=True, diff_sha256=bundle.digest)
+
+    async def scenario() -> None:
+        try:
+            await bundle.apply(receipt)
+        except Exception as exc:
+            assert "missing payload" in str(exc)
+        else:
+            raise AssertionError("invalid operation unexpectedly applied")
+
+    asyncio.run(scenario())
+    assert not (root / "one.txt").exists()

--- a/tests/sandbox/test_core.py
+++ b/tests/sandbox/test_core.py
@@ -1,0 +1,179 @@
+"""Core PC Twin tests that do not require Docker or a VM runtime."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from synapsekit.sandbox import (
+    ApplyConflictError,
+    CallableEvalGate,
+    DiffBundle,
+    PCSandbox,
+    SandboxSecurityError,
+    SandboxState,
+)
+from synapsekit.sandbox.overlay import capture_manifest
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _open_fake(tmp_path: Path) -> tuple[PCSandbox, object]:
+    base = tmp_path / "host"
+    base.mkdir()
+    (base / "project").mkdir()
+    (base / "project" / "input.txt").write_text("before\n", encoding="utf-8")
+    (base / ".env").write_text("SECRET=do-not-copy\n", encoding="utf-8")
+    sandbox = PCSandbox(
+        base=base,
+        backend="fake",
+        state_dir=tmp_path / "sessions",
+        exclude=(".env",),
+    )
+    environment = await sandbox.start()
+    return sandbox, environment
+
+
+def test_snapshot_diff_eval_and_apply(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        sandbox, environment = await _open_fake(tmp_path)
+        try:
+            assert not (environment.work_root / ".env").exists()
+            (environment.work_root / "project" / "input.txt").write_text(
+                "after\n", encoding="utf-8"
+            )
+            (environment.work_root / "project" / "new.txt").write_text("new\n", encoding="utf-8")
+
+            diff = await environment.diff_against_host()
+            assert diff.preview().modifications == 1
+            assert diff.preview().additions == 1
+
+            gate = CallableEvalGate(lambda current_diff, env: {"passed": True, "score": 1.0})
+            receipt = await environment.evaluate(gate, diff)
+            await environment.apply(diff, receipt)
+
+            assert environment.state == SandboxState.APPLIED
+            assert (environment.host_root / "project" / "input.txt").read_text() == "after\n"
+            assert (environment.host_root / "project" / "new.txt").read_text() == "new\n"
+        finally:
+            await sandbox.discard()
+
+    _run(scenario())
+
+
+def test_file_deletion_is_diffed_and_applied(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        sandbox, environment = await _open_fake(tmp_path)
+        try:
+            target = environment.work_root / "project" / "input.txt"
+            target.unlink()
+            diff = await environment.diff_against_host()
+            assert diff.preview().deletions == 1
+            receipt = await environment.evaluate(CallableEvalGate(lambda *_: True), diff)
+            await environment.apply(diff, receipt)
+            assert not (environment.host_root / "project" / "input.txt").exists()
+        finally:
+            await sandbox.discard()
+
+    _run(scenario())
+
+
+def test_apply_requires_matching_passing_receipt(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        sandbox, environment = await _open_fake(tmp_path)
+        try:
+            (environment.work_root / "project" / "input.txt").write_text("after\n")
+            diff = await environment.diff_against_host()
+            rejected = await environment.evaluate(
+                CallableEvalGate(lambda current_diff, env: False), diff
+            )
+            with pytest.raises(ApplyConflictError):
+                await diff.apply(rejected)
+        finally:
+            await sandbox.discard()
+
+    _run(scenario())
+
+
+def test_host_conflict_is_detected_before_mutation(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        sandbox, environment = await _open_fake(tmp_path)
+        try:
+            (environment.work_root / "project" / "input.txt").write_text("sandbox\n")
+            diff = await environment.diff_against_host()
+            receipt = await environment.evaluate(
+                CallableEvalGate(lambda current_diff, env: True), diff
+            )
+            (environment.host_root / "project" / "input.txt").write_text("host changed\n")
+            with pytest.raises(ApplyConflictError):
+                await diff.apply(receipt)
+            assert (environment.host_root / "project" / "input.txt").read_text() == "host changed\n"
+        finally:
+            await sandbox.discard()
+
+    _run(scenario())
+
+
+def test_diff_bundle_round_trip_and_digest(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        sandbox, environment = await _open_fake(tmp_path)
+        try:
+            (environment.work_root / "project" / "new.txt").write_text("payload")
+            diff = await environment.diff_against_host()
+            path = tmp_path / "change.diff.zip"
+            diff.write(path)
+            loaded = DiffBundle.read(path)
+            assert loaded.digest == diff.digest
+            assert loaded.to_dict() == diff.to_dict()
+        finally:
+            await sandbox.discard()
+
+    _run(scenario())
+
+
+def test_snapshot_rejects_escape_symlink(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside")
+    link = root / "escape"
+    try:
+        link.symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable on this Windows runner")
+    with pytest.raises(SandboxSecurityError):
+        capture_manifest(root)
+
+
+def test_cli_spawn_and_diff_use_persisted_session(tmp_path: Path, capsys) -> None:
+    from synapsekit.cli.main import main
+
+    base = tmp_path / "host"
+    base.mkdir()
+    (base / "file.txt").write_text("before")
+    state_dir = tmp_path / "sessions"
+    main(
+        [
+            "sandbox",
+            "spawn",
+            "--backend",
+            "fake",
+            "--base",
+            str(base),
+            "--state-dir",
+            str(state_dir),
+            "--format",
+            "json",
+        ]
+    )
+    session = json.loads(capsys.readouterr().out)["session_id"]
+    metadata = json.loads((state_dir / session / "metadata.json").read_text())
+    Path(metadata["work_root"], "file.txt").write_text("changed")
+    main(["sandbox", "diff", session, "--state-dir", str(state_dir), "--format", "json"])
+    result = json.loads(capsys.readouterr().out)
+    assert result["preview"]["modifications"] == 1

--- a/tests/sandbox/test_marketplace.py
+++ b/tests/sandbox/test_marketplace.py
@@ -1,0 +1,43 @@
+"""Marketplace agent execution through the PC sandbox boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from synapsekit.sandbox import PCSandbox
+
+
+def test_installed_agent_runs_from_private_sandbox_runtime(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        host = tmp_path / "host"
+        host.mkdir()
+        agent = tmp_path / "installed-agent"
+        agent.mkdir()
+        (agent / "entry.py").write_text(
+            "import sys\nprint(sys.argv[sys.argv.index('--prompt') + 1])\n",
+            encoding="utf-8",
+        )
+        sandbox = PCSandbox(
+            base=host,
+            backend="fake",
+            state_dir=tmp_path / "sessions",
+        )
+        try:
+            result = await sandbox.run(
+                agent,
+                SimpleNamespace(name="example", entrypoint="entry.py"),
+                "inspect safely",
+                python_executable=sys.executable,
+            )
+            assert result.ok
+            assert result.stdout.strip() == "inspect safely"
+
+            diff = await sandbox.diff()
+            assert diff.preview().changes == 0
+        finally:
+            await sandbox.discard()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary

- Add a sandboxed PC Twin lifecycle with secure materialized overlays, deterministic manifests, hash-guarded diff bundles, evaluation receipts, and transactional apply/rollback.
- Add Docker/OrbStack/Fake backends plus fail-closed Lima and Firecracker capability boundaries, network/resource policies, and `synapse sandbox spawn|diff|apply|discard` commands.
- Integrate marketplace agent execution, computer-use audit events, signed audit export, package-root APIs, documentation, and focused coverage.
- Keep agent execution shell-free and preserve Windows compatibility for direct shell built-ins and the multiprocessing REPL path.

## Safety notes

- Default network policy is `none`.
- Host credential paths and the private agent runtime area are excluded from snapshots and diffs.
- Apply requires a passing receipt matching the exact diff digest and performs preflight conflict checks plus rollback on failure.
- Lima/Firecracker intentionally fail closed until runtime-specific VM/kernel/rootfs/device policy is supplied; they never fall back to an unisolated host process.
- The portable overlay is materialized and reports `native_cow=False`; native CoW benchmarking remains backend-specific.

## Validation

- `610 passed, 4 skipped` — `tests/agents`
- `76 passed, 1 skipped` — sandbox/computer-use/audit/marketplace/CLI matrix
- Ruff check and format check passed
- Targeted mypy passed for the sandbox package
- Async-blocking gate passed: 578 files scanned
- `compileall` passed
- Docker daemon integration was unavailable locally because Docker Desktop's Linux engine was not running.

Closes #747
